### PR TITLE
Compilation.md: Does not compile with VS2015 anymore

### DIFF
--- a/docs/Compilation.md
+++ b/docs/Compilation.md
@@ -9,7 +9,7 @@ Choose `Use Git from the Windows command prompt`. This isn't mandatory, so if yo
 
 ## Part A: Preparing the Visual Studio environment
 
-### Visual Studio 2017 or 2015
+### Visual Studio 2017
 
 1. Install Visual C++, part of Visual Studio (any edition will work fine).
    Make sure to select **Windows 8.1 SDK** and **MFC and ATL support** during installation.


### PR DESCRIPTION
Save others some time and frustration:
MPC-HC does not compile with Visual Studio 2015 anymore, probably because of bd7ab544e727bd1256ecd2f8953674ea405f1b28.