### PR TITLE
Fix wrong and inconsistent default value

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -1822,7 +1822,7 @@ void CAppSettings::LoadSettings()
     nDefaultToolbarSize = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_DEFAULTTOOLBARSIZE, 24);
 
     bSaveImagePosition = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_SAVEIMAGE_POSITION, TRUE);
-    bSaveImageCurrentTime = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_SAVEIMAGE_CURRENTTIME, FALSE);
+    bSaveImageCurrentTime = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_SAVEIMAGE_CURRENTTIME, TRUE);
 
     if (fLaunchfullscreen) {
         nCLSwitches |= CLSW_FULLSCREEN;


### PR DESCRIPTION
Refs https://github.com/clsid2/mpc-hc/commit/eaa105ba00a15b62b60c3a5e8b47bc34f7cb98dd.

Noticed this because after updating to 1.7.18, this advanced setting was set to false (bolded).

Note 1.7.18 has a similar issue with "youtube-dl max height" advanced setting, that you already have fixed in later commits.