### PR TITLE
Fix memory leak of CWnd

### DIFF
--- a/src/thirdparty/TreePropSheet/TreePropSheet.cpp
+++ b/src/thirdparty/TreePropSheet/TreePropSheet.cpp
@@ -865,6 +865,8 @@ void CTreePropSheet::OnDestroy()
     delete m_pwndPageTree;
     m_pwndPageTree = NULL;
 
+    CWnd* frameWnd = m_pFrame->GetWnd();
+    if (nullptr != frameWnd && IsWindow(frameWnd->m_hWnd)) frameWnd->DestroyWindow(); //fix memory leak of CWnd
     delete m_pFrame;
     m_pFrame = NULL;
 }


### PR DESCRIPTION
m_pFrame can point to object partially inherited from CWnd (default impl in PropPageFrameDefault, for example).  This CWnd can be retrieved but is never destroyed, leading to memory leak.  I've fixed it in my branch but posting here to fix as an isolated issue.