### PR TITLE
Fix black screen when using Floating Point Processing under EVR-CP

### DIFF
--- a/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.cpp
@@ -638,10 +638,16 @@ HRESULT CDX9AllocatorPresenter::CreateDevice(CString& _Error)
 
     // set color formats
     if (m_bFullFloatingPointProcessing) {
-        m_SurfaceType = D3DFMT_A32B32G32R32F;
+        m_TemporarySurfaceType = D3DFMT_A32B32G32R32F;
     } else if (m_bHalfFloatingPointProcessing) {
-        m_SurfaceType = D3DFMT_A16B16G16R16F;
+        m_TemporarySurfaceType = D3DFMT_A16B16G16R16F;
     } else if (m_bForceInputHighColorResolution || m_bHighColorResolution) {
+        m_TemporarySurfaceType = D3DFMT_A2R10G10B10;
+    } else {
+        m_TemporarySurfaceType = D3DFMT_X8R8G8B8;
+    }
+
+    if (m_bForceInputHighColorResolution || m_bHighColorResolution) {
         m_SurfaceType = D3DFMT_A2R10G10B10;
     } else {
         m_SurfaceType = D3DFMT_X8R8G8B8;

--- a/src/filters/renderer/VideoRenderers/DX9RenderingEngine.cpp
+++ b/src/filters/renderer/VideoRenderers/DX9RenderingEngine.cpp
@@ -153,6 +153,7 @@ CDX9RenderingEngine::CDX9RenderingEngine(HWND hWnd, HRESULT& hr, CString* _pErro
     , m_bForceInputHighColorResolution(false)
     , m_RenderingPath(RENDERING_PATH_DRAW)
     , m_SurfaceType(D3DFMT_UNKNOWN)
+    , m_TemporarySurfaceType(D3DFMT_UNKNOWN)
     , m_bFullFloatingPointProcessing(false)
     , m_bHalfFloatingPointProcessing(false)
     , m_bColorManagement(false)
@@ -542,7 +543,7 @@ HRESULT CDX9RenderingEngine::InitTemporaryVideoTextures(int count)
                      m_nativeVideoSize.cy,
                      1,
                      D3DUSAGE_RENDERTARGET,
-                     m_SurfaceType,
+                     m_TemporarySurfaceType,
                      D3DPOOL_DEFAULT,
                      &m_pTemporaryVideoTextures[i],
                      nullptr);
@@ -596,7 +597,7 @@ HRESULT CDX9RenderingEngine::InitTemporaryScreenSpaceTextures(int count)
                      m_TemporaryScreenSpaceTextureSize.cy,
                      1,
                      D3DUSAGE_RENDERTARGET,
-                     m_SurfaceType,
+                     m_TemporarySurfaceType,
                      D3DPOOL_DEFAULT,
                      &m_pTemporaryScreenSpaceTextures[i],
                      nullptr);

--- a/src/filters/renderer/VideoRenderers/DX9RenderingEngine.h
+++ b/src/filters/renderer/VideoRenderers/DX9RenderingEngine.h
@@ -61,6 +61,7 @@ namespace DSObjects
         bool                        m_bD3DX;
         RenderingPath               m_RenderingPath;
         D3DFORMAT                   m_SurfaceType;
+        D3DFORMAT                   m_TemporarySurfaceType;
         CComPtr<IDirect3DTexture9>  m_pVideoTexture[MAX_VIDEO_SURFACES];
         CComPtr<IDirect3DSurface9>  m_pVideoSurface[MAX_VIDEO_SURFACES];
 


### PR DESCRIPTION
Apparently IMFSample doesn't like it when the surface is using floating point. Could be a driver issue on my laptop though this works.