### PR TITLE
fix memory leaks with mp3 coverart (CMPCPngImage)

### DIFF
--- a/src/mpc-hc/CoverArt.cpp
+++ b/src/mpc-hc/CoverArt.cpp
@@ -84,7 +84,10 @@ bool CoverArt::FindEmbedded(CComPtr<IFilterGraph> pFilterGraph, std::vector<BYTE
                         if (score > best_score || internalCover.empty()) {
                             internalCover.assign(pData, pData + len);
                             best_score = score;
-                            if (best_score == 2) break;
+                            if (best_score == 2) {
+                                CoTaskMemFree(pData);
+                                break;
+                            }
                         }
                     } else if (!best_score && CString(mime).MakeLower().Find(_T("image")) != -1) {
                         CString nameLower = CString(name).MakeLower();

--- a/src/mpc-hc/MPCPngImage.cpp
+++ b/src/mpc-hc/MPCPngImage.cpp
@@ -82,9 +82,11 @@ BOOL CMPCPngImage::LoadFromBuffer(const LPBYTE lpBuffer, UINT uiSize)
 
     memcpy(lpResBuffer, lpBuffer, uiSize);
 
-    HRESULT hResult = ::CreateStreamOnHGlobal(hRes, FALSE, &pStream);
+    HRESULT hResult = ::CreateStreamOnHGlobal(hRes, TRUE, &pStream);
 
     if (hResult != S_OK) {
+        ::GlobalUnlock(hRes);
+        ::GlobalFree(hRes);
         return FALSE;
     }
 
@@ -94,7 +96,7 @@ BOOL CMPCPngImage::LoadFromBuffer(const LPBYTE lpBuffer, UINT uiSize)
     }
 
     m_pImage->Load(pStream);
-    pStream->Release();
+    pStream->Release(); //should free hRes due to fDeleteOnRelease=TRUE above
 
     BOOL bRes = Attach(m_pImage->Detach());
 


### PR DESCRIPTION
I found 3 possible memory leaks in the mp3 coverart code. All fixed, here.

After fixing them, I recalled wondering in the past why CMPCPngImage was used instead of MFC's CPngImage.  After review, I can conclude it is nothing but a shameless code copy (perhaps to avoid using afxtoolbarimages in its entirety).

But one of the memory bugs I fixed is already fixed, there.  Perhaps fixed since the CMPCPngImage code was cloned.  But another, less likely, memory leak is still there, which would only occur if CreateStreamOnHGlobal failed.

![image](https://user-images.githubusercontent.com/3324395/71562947-c6352f00-2a3c-11ea-9c1b-91569c443ba7.png)
