### PR TITLE
Ability to parse EXTM3U format (title only)

### DIFF
--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -336,6 +336,10 @@ void CPlayerPlaylistBar::ParsePlayList(CAtlList<CString>& fns, CAtlList<CString>
     if (ct == "application/x-mpc-playlist") {
         ParseMPCPlayList(fns.GetHead());
         return;
+    } else if (ct == "audio/x-mpegurl") {
+        if (ParseM3UPlayList(fns.GetHead())) {
+            return; //we have handled this one. if parse fails it should fall through to AddItem below
+        }
     } else {
 #if INTERNAL_SOURCEFILTER_MPEG
         const CAppSettings& s = AfxGetAppSettings();
@@ -375,6 +379,64 @@ bool CPlayerPlaylistBar::ParseBDMVPlayList(CString fn)
     }
 
     return !m_pl.IsEmpty();
+}
+
+bool CPlayerPlaylistBar::ParseM3UPlayList(CString fn) {
+    CString str;
+    CPlaylistItem pli;
+    std::vector<int> idx;
+
+    CWebTextFile f(CTextFile::UTF8);
+    if (!f.Open(fn) || !f.ReadString(str) || str != _T("#EXTM3U")) {
+        return false;
+    }
+
+    if (f.GetEncoding() == CTextFile::DEFAULT_ENCODING) {
+        f.SetEncoding(CTextFile::ANSI);
+    }
+
+    CPath base(fn);
+    base.RemoveFileSpec();
+
+    bool success = false;
+
+    CString lastTitle = _T("");
+    while (f.ReadString(str)) {
+        CAtlList<CString> sl;
+        Explode(str, sl, ':', 2);
+        if (sl.GetCount() == 2) {
+            CString key = sl.RemoveHead();
+            CString value = sl.RemoveHead();
+            if (key == _T("#EXTINF")) {
+                int findDelim;
+                if (-1 == (findDelim = value.Find(_T(",")) )) {
+                    continue; //discard invalid EXTINF line
+                }
+                if (f.ReadString(str)) {
+                    pli.m_label = value.Mid(findDelim + 1);
+                    pli.m_fns.RemoveAll();
+                    pli.m_fns.AddTail(str);
+                    m_pl.AddTail(pli);
+                    success = true;
+                    continue;
+                } else {
+                    break; //we could not read any more from the file, so the loop should break (and we have to discard this last EXTINF that has no valid filename)
+                }
+            }
+        }
+
+        //we can process this line as a single unlabeled file, since it didn't validate as an EXTINF line
+        if (str.Find(_T("#EXT")) != 0) { //discard all ^#EXT.* indiscriminately
+            pli.m_label = _T("");
+            pli.m_fns.RemoveAll();
+            pli.m_fns.AddTail(str);
+            m_pl.AddTail(pli);
+            success = true;
+        }
+
+    }
+
+    return success;
 }
 
 bool CPlayerPlaylistBar::ParseMPCPlayList(CString fn)

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -69,6 +69,7 @@ private:
 
     bool ParseMPCPlayList(CString fn);
     bool SaveMPCPlayList(CString fn, CTextFile::enc e, bool fRemovePath);
+    bool ParseM3UPlayList(CString fn);
 
     void SetupList();
     void UpdateList();


### PR DESCRIPTION
I added the ability to pull the title from the M3Us.

Also, by parsing regular M3Us as well, they work again.  I think not reading the body in GetContentType broke its ability to redirect to the M3U urls.

I did not support recursion, but it would be fairly easy.  I think previously M3Us may have supported recursion.