### PR TITLE
Refactor DVB to BDA in DVBChannel.  Support ATSC tuner (minimal)

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -2409,9 +2409,9 @@ void CAppSettings::AddFav(favtype ft, CString s)
     SetFav(ft, sl);
 }
 
-CDVBChannel* CAppSettings::FindChannelByPref(int nPrefNumber)
+CBDAChannel* CAppSettings::FindChannelByPref(int nPrefNumber)
 {
-    auto it = find_if(m_DVBChannels.begin(), m_DVBChannels.end(), [&](CDVBChannel const & channel) {
+    auto it = find_if(m_DVBChannels.begin(), m_DVBChannels.end(), [&](CBDAChannel const & channel) {
         return channel.GetPrefNumber() == nPrefNumber;
     });
 

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -583,7 +583,7 @@ public:
     int             iBDAOffset;
     bool            fBDAIgnoreEncryptedChannels;
     int             nDVBLastChannel;
-    std::vector<CDVBChannel> m_DVBChannels;
+    std::vector<CBDAChannel> m_DVBChannels;
     DVB_RebuildFilterGraph nDVBRebuildFilterGraph;
     DVB_StopFilterGraph nDVBStopFilterGraph;
 
@@ -835,7 +835,7 @@ public:
     void            SetFav(favtype ft, CAtlList<CString>& sl);
     void            AddFav(favtype ft, CString s);
 
-    CDVBChannel*    FindChannelByPref(int nPrefNumber);
+    CBDAChannel*    FindChannelByPref(int nPrefNumber);
 
     bool            GetAllowMultiInst() const;
 

--- a/src/mpc-hc/DVBChannel.cpp
+++ b/src/mpc-hc/DVBChannel.cpp
@@ -25,17 +25,17 @@
 #include "mplayerc.h"
 
 
-LCID DVBStreamInfo::GetLCID() const
+LCID BDAStreamInfo::GetLCID() const
 {
     return ISOLang::ISO6392ToLcid(CStringA(sLanguage));
 };
 
-CDVBChannel::CDVBChannel(CString strChannel)
+CBDAChannel::CBDAChannel(CString strChannel)
 {
     FromString(strChannel);
 }
 
-void CDVBChannel::FromString(CString strValue)
+void CBDAChannel::FromString(CString strValue)
 {
     int i = 0;
 
@@ -63,7 +63,7 @@ void CDVBChannel::FromString(CString strValue)
     m_ulPMT       = _tstol(strValue.Tokenize(_T("|"), i));
     m_ulPCR       = _tstol(strValue.Tokenize(_T("|"), i));
     m_ulVideoPID  = _tstol(strValue.Tokenize(_T("|"), i));
-    m_nVideoType  = (DVB_STREAM_TYPE) _tstol(strValue.Tokenize(_T("|"), i));
+    m_nVideoType  = (BDA_STREAM_TYPE) _tstol(strValue.Tokenize(_T("|"), i));
     m_nAudioCount = _tstol(strValue.Tokenize(_T("|"), i));
     if (nVersion > FORMAT_VERSION_1) {
         m_nDefaultAudio = _tstol(strValue.Tokenize(_T("|"), i));
@@ -75,28 +75,28 @@ void CDVBChannel::FromString(CString strValue)
 
     for (int j = 0; j < m_nAudioCount; j++) {
         m_Audios[j].ulPID     = _tstol(strValue.Tokenize(_T("|"), i));
-        m_Audios[j].nType     = (DVB_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+        m_Audios[j].nType     = (BDA_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
         m_Audios[j].nPesType  = (PES_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
         m_Audios[j].sLanguage = strValue.Tokenize(_T("|"), i);
     }
 
     for (int j = 0; j < m_nSubtitleCount; j++) {
         m_Subtitles[j].ulPID     = _tstol(strValue.Tokenize(_T("|"), i));
-        m_Subtitles[j].nType     = (DVB_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+        m_Subtitles[j].nType     = (BDA_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
         m_Subtitles[j].nPesType  = (PES_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
         m_Subtitles[j].sLanguage = strValue.Tokenize(_T("|"), i);
     }
 
     if (nVersion > FORMAT_VERSION_3) {
-        m_nVideoFps    = (DVB_FPS_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
-        m_nVideoChroma = (DVB_CHROMA_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+        m_nVideoFps    = (BDA_FPS_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+        m_nVideoChroma = (BDA_CHROMA_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
         m_nVideoWidth  = _tstol(strValue.Tokenize(_T("|"), i));
         m_nVideoHeight = _tstol(strValue.Tokenize(_T("|"), i));
-        m_nVideoAR     = (DVB_AspectRatio_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+        m_nVideoAR     = (BDA_AspectRatio_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
     }
 }
 
-CString CDVBChannel::ToString() const
+CString CBDAChannel::ToString() const
 {
     auto substituteEmpty = [](const CString & lang) -> CString {
         if (lang.IsEmpty())
@@ -146,7 +146,7 @@ CString CDVBChannel::ToString() const
     return strValue;
 }
 
-CStringA CDVBChannel::ToJSON() const
+CStringA CBDAChannel::ToJSON() const
 {
     CStringA jsonChannel;
     jsonChannel.Format("{ \"index\" : %d, \"name\" : \"%s\" }",
@@ -155,20 +155,20 @@ CStringA CDVBChannel::ToJSON() const
     return jsonChannel;
 }
 
-void CDVBChannel::AddStreamInfo(ULONG ulPID, DVB_STREAM_TYPE nType, PES_STREAM_TYPE nPesType, LPCTSTR strLanguage)
+void CBDAChannel::AddStreamInfo(ULONG ulPID, BDA_STREAM_TYPE nType, PES_STREAM_TYPE nPesType, LPCTSTR strLanguage)
 {
     switch (nType) {
-        case DVB_MPV:
-        case DVB_H264:
-        case DVB_HEVC:
+        case BDA_MPV:
+        case BDA_H264:
+        case BDA_HEVC:
             m_ulVideoPID = ulPID;
             m_nVideoType = nType;
             break;
-        case DVB_MPA:
-        case DVB_AC3:
-        case DVB_EAC3:
-        case DVB_LATM:
-            if (m_nAudioCount < DVB_MAX_AUDIO) {
+        case BDA_MPA:
+        case BDA_AC3:
+        case BDA_EAC3:
+        case BDA_LATM:
+            if (m_nAudioCount < BDA_MAX_AUDIO) {
                 m_Audios[m_nAudioCount].ulPID     = ulPID;
                 m_Audios[m_nAudioCount].nType     = nType;
                 m_Audios[m_nAudioCount].nPesType  = nPesType;
@@ -176,8 +176,8 @@ void CDVBChannel::AddStreamInfo(ULONG ulPID, DVB_STREAM_TYPE nType, PES_STREAM_T
                 m_nAudioCount++;
             }
             break;
-        case DVB_SUBTITLE:
-            if (m_nSubtitleCount < DVB_MAX_SUBTITLE) {
+        case BDA_SUBTITLE:
+            if (m_nSubtitleCount < BDA_MAX_SUBTITLE) {
                 m_Subtitles[m_nSubtitleCount].ulPID     = ulPID;
                 m_Subtitles[m_nSubtitleCount].nType     = nType;
                 m_Subtitles[m_nSubtitleCount].nPesType  = nPesType;
@@ -188,32 +188,32 @@ void CDVBChannel::AddStreamInfo(ULONG ulPID, DVB_STREAM_TYPE nType, PES_STREAM_T
     }
 }
 
-REFERENCE_TIME CDVBChannel::GetAvgTimePerFrame()
+REFERENCE_TIME CBDAChannel::GetAvgTimePerFrame()
 {
     REFERENCE_TIME Value;
     switch (m_nVideoFps) {
-        case DVB_FPS_23_976:
+        case BDA_FPS_23_976:
             Value = 417084;
             break;
-        case DVB_FPS_24_0:
+        case BDA_FPS_24_0:
             Value = 416667;
             break;
-        case DVB_FPS_25_0:
+        case BDA_FPS_25_0:
             Value = 400000;
             break;
-        case DVB_FPS_29_97:
+        case BDA_FPS_29_97:
             Value = 333667;
             break;
-        case DVB_FPS_30_0:
+        case BDA_FPS_30_0:
             Value = 333333;
             break;
-        case DVB_FPS_50_0:
+        case BDA_FPS_50_0:
             Value = 200000;
             break;
-        case DVB_FPS_59_94:
+        case BDA_FPS_59_94:
             Value = 166834;
             break;
-        case DVB_FPS_60_0:
+        case BDA_FPS_60_0:
             Value = 166667;
             break;
         default:
@@ -223,32 +223,32 @@ REFERENCE_TIME CDVBChannel::GetAvgTimePerFrame()
     return Value;
 }
 
-CString CDVBChannel::GetVideoFpsDesc()
+CString CBDAChannel::GetVideoFpsDesc()
 {
     CString strValue;
     switch (m_nVideoFps) {
-        case DVB_FPS_23_976:
+        case BDA_FPS_23_976:
             strValue = _T("23.976");
             break;
-        case DVB_FPS_24_0:
+        case BDA_FPS_24_0:
             strValue = _T("24.000");
             break;
-        case DVB_FPS_25_0:
+        case BDA_FPS_25_0:
             strValue = _T("25.000");
             break;
-        case DVB_FPS_29_97:
+        case BDA_FPS_29_97:
             strValue = _T("29.970");
             break;
-        case DVB_FPS_30_0:
+        case BDA_FPS_30_0:
             strValue = _T("30.000");
             break;
-        case DVB_FPS_50_0:
+        case BDA_FPS_50_0:
             strValue = _T("50.000");
             break;
-        case DVB_FPS_59_94:
+        case BDA_FPS_59_94:
             strValue = _T("59.940");
             break;
-        case DVB_FPS_60_0:
+        case BDA_FPS_60_0:
             strValue = _T("60.000");
             break;
         default:
@@ -259,20 +259,20 @@ CString CDVBChannel::GetVideoFpsDesc()
 
 }
 
-DWORD CDVBChannel::GetVideoARx()
+DWORD CBDAChannel::GetVideoARx()
 {
     DWORD Value;
     switch (GetVideoAR()) {
-        case DVB_AR_1:
+        case BDA_AR_1:
             Value = 1;
             break;
-        case DVB_AR_3_4:
+        case BDA_AR_3_4:
             Value = 4;
             break;
-        case DVB_AR_9_16:
+        case BDA_AR_9_16:
             Value = 16;
             break;
-        case DVB_AR_1_2_21:
+        case BDA_AR_1_2_21:
             Value = 221;
             break;
         default:
@@ -282,20 +282,20 @@ DWORD CDVBChannel::GetVideoARx()
     return Value;
 }
 
-DWORD CDVBChannel::GetVideoARy()
+DWORD CBDAChannel::GetVideoARy()
 {
     DWORD Value;
     switch (GetVideoAR()) {
-        case DVB_AR_1:
+        case BDA_AR_1:
             Value = 1;
             break;
-        case DVB_AR_3_4:
+        case BDA_AR_3_4:
             Value = 3;
             break;
-        case DVB_AR_9_16:
+        case BDA_AR_9_16:
             Value = 9;
             break;
-        case DVB_AR_1_2_21:
+        case BDA_AR_1_2_21:
             Value = 100;
             break;
         default:

--- a/src/mpc-hc/DVBChannel.h
+++ b/src/mpc-hc/DVBChannel.h
@@ -30,8 +30,8 @@
 #define FORMAT_VERSION_4       4
 #define FORMAT_VERSION_CURRENT 5
 
-#define DVB_MAX_AUDIO    10
-#define DVB_MAX_SUBTITLE 10
+#define BDA_MAX_AUDIO    10
+#define BDA_MAX_SUBTITLE 10
 
 struct EventDescriptor {
     CString eventName;
@@ -46,69 +46,68 @@ struct EventDescriptor {
     CString content;
 };
 
-enum DVB_STREAM_TYPE {
-    DVB_MPV      = 0x00,
-    DVB_H264     = 0x01,
-    DVB_MPA      = 0x02,
-    DVB_AC3      = 0x03,
-    DVB_EAC3     = 0x04,
-    DVB_HEVC     = 0x05,
-    DVB_LATM     = 0x11,
-    DVB_PSI      = 0x80,
-    DVB_TIF      = 0x81,
-    DVB_EPG      = 0x82,
-    //DVB_PMT    = 0x83,
-    DVB_SUB      = 0x83,
-    DVB_SUBTITLE = 0xFE,
-    DVB_UNKNOWN  = 0xFF
+enum BDA_STREAM_TYPE {
+    BDA_MPV      = 0x00,
+    BDA_H264     = 0x01,
+    BDA_MPA      = 0x02,
+    BDA_AC3      = 0x03,
+    BDA_EAC3     = 0x04,
+    BDA_HEVC     = 0x05,
+    BDA_LATM     = 0x11,
+    BDA_PSI      = 0x80,
+    BDA_TIF      = 0x81,
+    BDA_EPG      = 0x82,
+    BDA_SUB      = 0x83,
+    BDA_SUBTITLE = 0xFE,
+    BDA_UNKNOWN  = 0xFF
 };
 
-enum DVB_CHROMA_TYPE {
-    DVB_Chroma_NONE  = 0x00,
-    DVB_Chroma_4_2_0 = 0x01,
-    DVB_Chroma_4_2_2 = 0x02,
-    DVB_Chroma_4_4_4 = 0x03
+enum BDA_CHROMA_TYPE {
+    BDA_Chroma_NONE  = 0x00,
+    BDA_Chroma_4_2_0 = 0x01,
+    BDA_Chroma_4_2_2 = 0x02,
+    BDA_Chroma_4_4_4 = 0x03
 };
 
-enum DVB_FPS_TYPE {
-    DVB_FPS_NONE   = 0x00,
-    DVB_FPS_23_976 = 0x01,
-    DVB_FPS_24_0   = 0x02,
-    DVB_FPS_25_0   = 0x03,
-    DVB_FPS_29_97  = 0x04,
-    DVB_FPS_30_0   = 0x05,
-    DVB_FPS_50_0   = 0x06,
-    DVB_FPS_59_94  = 0x07,
-    DVB_FPS_60_0   = 0x08
+enum BDA_FPS_TYPE {
+    BDA_FPS_NONE   = 0x00,
+    BDA_FPS_23_976 = 0x01,
+    BDA_FPS_24_0   = 0x02,
+    BDA_FPS_25_0   = 0x03,
+    BDA_FPS_29_97  = 0x04,
+    BDA_FPS_30_0   = 0x05,
+    BDA_FPS_50_0   = 0x06,
+    BDA_FPS_59_94  = 0x07,
+    BDA_FPS_60_0   = 0x08
 };
 
-enum DVB_AspectRatio_TYPE {
-    DVB_AR_NULL   = 0x00,
-    DVB_AR_1      = 0x01,
-    DVB_AR_3_4    = 0x02,
-    DVB_AR_9_16   = 0x03,
-    DVB_AR_1_2_21 = 0x04
+enum BDA_AspectRatio_TYPE {
+    BDA_AR_NULL   = 0x00,
+    BDA_AR_1      = 0x01,
+    BDA_AR_3_4    = 0x02,
+    BDA_AR_9_16   = 0x03,
+    BDA_AR_1_2_21 = 0x04
 };
 
-struct DVBStreamInfo {
+struct BDAStreamInfo {
     ULONG           ulPID    = 0;
-    DVB_STREAM_TYPE nType    = DVB_UNKNOWN;
+    BDA_STREAM_TYPE nType    = BDA_UNKNOWN;
     PES_STREAM_TYPE nPesType = INVALID;
     CString         sLanguage;
 
     LCID GetLCID() const;
 };
 
-class CDVBChannel
+class CBDAChannel
 {
 public:
-    CDVBChannel() = default;
-    CDVBChannel(CString strChannel);
-    ~CDVBChannel() = default;
+    CBDAChannel() = default;
+    CBDAChannel(CString strChannel);
+    ~CBDAChannel() = default;
 
     CString ToString() const;
     /**
-     * @brief Output a JSON representation of a DVB channel.
+     * @brief Output a JSON representation of a BDA channel.
      * @note The object contains two elements : "index", which corresponds to
      * @c m_nPrefNumber, and "name", which contains @c m_strName.
      * @returns A string representing a JSON object containing the
@@ -127,26 +126,26 @@ public:
     ULONG GetPMT() const { return m_ulPMT; };
     ULONG GetPCR() const { return m_ulPCR; };
     ULONG GetVideoPID() const { return m_ulVideoPID; };
-    DVB_FPS_TYPE GetVideoFps() const { return m_nVideoFps; }
+    BDA_FPS_TYPE GetVideoFps() const { return m_nVideoFps; }
     CString GetVideoFpsDesc();
-    DVB_CHROMA_TYPE GetVideoChroma() const { return m_nVideoChroma; }
+    BDA_CHROMA_TYPE GetVideoChroma() const { return m_nVideoChroma; }
     ULONG GetVideoWidth() const {return m_nVideoWidth; }
     ULONG GetVideoHeight() const {return m_nVideoHeight; }
-    DVB_AspectRatio_TYPE GetVideoAR() {return m_nVideoAR; }
+    BDA_AspectRatio_TYPE GetVideoAR() {return m_nVideoAR; }
     DWORD GetVideoARx();
     DWORD GetVideoARy();
-    DVB_STREAM_TYPE GetVideoType() const { return m_nVideoType; }
+    BDA_STREAM_TYPE GetVideoType() const { return m_nVideoType; }
     ULONG GetDefaultAudioPID() const { return m_Audios[GetDefaultAudio()].ulPID; };
-    DVB_STREAM_TYPE GetDefaultAudioType() const { return m_Audios[GetDefaultAudio()].nType; }
+    BDA_STREAM_TYPE GetDefaultAudioType() const { return m_Audios[GetDefaultAudio()].nType; }
     ULONG GetDefaultSubtitlePID() const { return m_Subtitles[GetDefaultSubtitle()].ulPID; };
     int GetAudioCount() const { return m_nAudioCount; };
     int GetDefaultAudio() const { return m_nDefaultAudio; };
     int GetSubtitleCount() const { return m_nSubtitleCount; };
     int GetDefaultSubtitle() const { return m_nDefaultSubtitle; };
-    DVBStreamInfo* GetAudio(int nIndex) { return &m_Audios[nIndex]; };
-    const DVBStreamInfo* GetAudio(int nIndex) const { return &m_Audios[nIndex]; };
-    DVBStreamInfo* GetSubtitle(int nIndex) { return &m_Subtitles[nIndex]; };
-    const DVBStreamInfo* GetSubtitle(int nIndex) const { return &m_Subtitles[nIndex]; };
+    BDAStreamInfo* GetAudio(int nIndex) { return &m_Audios[nIndex]; };
+    const BDAStreamInfo* GetAudio(int nIndex) const { return &m_Audios[nIndex]; };
+    BDAStreamInfo* GetSubtitle(int nIndex) { return &m_Subtitles[nIndex]; };
+    const BDAStreamInfo* GetSubtitle(int nIndex) const { return &m_Subtitles[nIndex]; };
     bool HasName() const { return !m_strName.IsEmpty(); };
     bool IsEncrypted() const { return m_bEncrypted; };
     bool GetNowNextFlag() const { return m_bNowNextFlag; };
@@ -165,24 +164,24 @@ public:
     void SetPMT(ULONG Value) { m_ulPMT = Value; };
     void SetPCR(ULONG Value) { m_ulPCR = Value; };
     void SetVideoPID(ULONG Value) { m_ulVideoPID = Value; };
-    void SetVideoFps(DVB_FPS_TYPE Value) { m_nVideoFps = Value; };
-    void SetVideoChroma(DVB_CHROMA_TYPE Value) { m_nVideoChroma = Value; };
+    void SetVideoFps(BDA_FPS_TYPE Value) { m_nVideoFps = Value; };
+    void SetVideoChroma(BDA_CHROMA_TYPE Value) { m_nVideoChroma = Value; };
     void SetVideoWidth(ULONG Value) { m_nVideoWidth = Value; };
     void SetVideoHeight(ULONG Value) { m_nVideoHeight = Value; };
-    void SetVideoAR(DVB_AspectRatio_TYPE Value) { m_nVideoAR = Value; };
+    void SetVideoAR(BDA_AspectRatio_TYPE Value) { m_nVideoAR = Value; };
     void SetDefaultAudio(int Value) { m_nDefaultAudio = Value; }
     void SetDefaultSubtitle(int Value) { m_nDefaultSubtitle = Value; }
 
-    void AddStreamInfo(ULONG ulPID, DVB_STREAM_TYPE nType, PES_STREAM_TYPE nPesType, LPCTSTR strLanguage);
+    void AddStreamInfo(ULONG ulPID, BDA_STREAM_TYPE nType, PES_STREAM_TYPE nPesType, LPCTSTR strLanguage);
 
-    bool operator < (CDVBChannel const& channel) const {
+    bool operator < (CBDAChannel const& channel) const {
         int aOriginNumber = GetOriginNumber();
         int bOriginNumber = channel.GetOriginNumber();
         return (aOriginNumber == 0 && bOriginNumber == 0) ? GetPrefNumber() < channel.GetPrefNumber() : (aOriginNumber == 0 || bOriginNumber == 0) ? bOriginNumber == 0 : aOriginNumber < bOriginNumber;
     }
 
     // Returns true for channels with the same place, doesn't necessarily need to be equal (i.e if internal streams were updated)
-    bool operator==(CDVBChannel const& channel) const {
+    bool operator==(CBDAChannel const& channel) const {
         return GetPMT() == channel.GetPMT() && GetFrequency() == channel.GetFrequency();
     }
 
@@ -200,18 +199,18 @@ private:
     ULONG m_ulPMT                   = 0;
     ULONG m_ulPCR                   = 0;
     ULONG m_ulVideoPID              = 0;
-    DVB_STREAM_TYPE m_nVideoType    = DVB_MPV;
-    DVB_FPS_TYPE m_nVideoFps        = DVB_FPS_25_0;
-    DVB_CHROMA_TYPE m_nVideoChroma  = DVB_Chroma_4_2_0;
+    BDA_STREAM_TYPE m_nVideoType    = BDA_MPV;
+    BDA_FPS_TYPE m_nVideoFps        = BDA_FPS_25_0;
+    BDA_CHROMA_TYPE m_nVideoChroma  = BDA_Chroma_4_2_0;
     ULONG m_nVideoWidth             = 0;
     ULONG m_nVideoHeight            = 0;
-    DVB_AspectRatio_TYPE m_nVideoAR = DVB_AR_NULL;
+    BDA_AspectRatio_TYPE m_nVideoAR = BDA_AR_NULL;
     int m_nAudioCount               = 0;
     int m_nDefaultAudio             = 0;
     int m_nSubtitleCount            = 0;
     int m_nDefaultSubtitle          = -1;
-    std::array<DVBStreamInfo, DVB_MAX_AUDIO> m_Audios;
-    std::array<DVBStreamInfo, DVB_MAX_SUBTITLE> m_Subtitles;
+    std::array<BDAStreamInfo, BDA_MAX_AUDIO> m_Audios;
+    std::array<BDAStreamInfo, BDA_MAX_SUBTITLE> m_Subtitles;
 
     void FromString(CString strValue);
 };

--- a/src/mpc-hc/FGManagerBDA.h
+++ b/src/mpc-hc/FGManagerBDA.h
@@ -132,7 +132,7 @@ public:
 
     DECLARE_IUNKNOWN;
     STDMETHODIMP NonDelegatingQueryInterface(REFIID riid, void** ppv);
-    STDMETHODIMP UpdatePSI(const CDVBChannel* pChannel, EventDescriptor& NowNext);
+    STDMETHODIMP UpdatePSI(const CBDAChannel* pChannel, EventDescriptor& NowNext);
 
 private:
 
@@ -143,23 +143,23 @@ private:
     CComQIPtr<IBDA_SignalStatistics>     m_pBDADemodStats;
     CComPtr<IBDA_AutoDemodulate>         m_pBDAAutoDemulate;
     DVB_RebuildFilterGraph m_nDVBRebuildFilterGraph;
-    CAtlMap<DVB_STREAM_TYPE, CDVBStream> m_DVBStreams;
+    CAtlMap<BDA_STREAM_TYPE, CDVBStream> m_DVBStreams;
 
-    DVB_STREAM_TYPE m_nCurVideoType;
-    DVB_STREAM_TYPE m_nCurAudioType;
+    BDA_STREAM_TYPE m_nCurVideoType;
+    BDA_STREAM_TYPE m_nCurAudioType;
     bool            m_fHideWindow;
     CComPtr<IBaseFilter> m_pDemux;
 
     HRESULT         CreateKSFilter(IBaseFilter** ppBF, CLSID KSCategory, const CStringW& DisplayName);
     HRESULT         ConnectFilters(IBaseFilter* pOutFiter, IBaseFilter* pInFilter);
     HRESULT         CreateMicrosoftDemux(CComPtr<IBaseFilter>& pMpeg2Demux);
-    HRESULT         SetChannelInternal(CDVBChannel* pChannel);
-    HRESULT         SwitchStream(DVB_STREAM_TYPE nOldType, DVB_STREAM_TYPE nNewType);
+    HRESULT         SetChannelInternal(CBDAChannel* pChannel);
+    HRESULT         SwitchStream(BDA_STREAM_TYPE nOldType, BDA_STREAM_TYPE nNewType);
     HRESULT         ChangeState(FILTER_STATE nRequested);
     HRESULT         ClearMaps();
     FILTER_STATE    GetState();
-    void UpdateMediaType(VIDEOINFOHEADER2* NewVideoHeader, CDVBChannel* pChannel);
-    HRESULT Flush(DVB_STREAM_TYPE nVideoType, DVB_STREAM_TYPE nAudioType);
+    void UpdateMediaType(VIDEOINFOHEADER2* NewVideoHeader, CBDAChannel* pChannel);
+    HRESULT Flush(BDA_STREAM_TYPE nVideoType, BDA_STREAM_TYPE nAudioType);
 
     template <class ITF>
     HRESULT SearchIBDATopology(const CComPtr<IBaseFilter>& pTuner, CComPtr<ITF>& pItf) {

--- a/src/mpc-hc/IGraphBuilder2.h
+++ b/src/mpc-hc/IGraphBuilder2.h
@@ -57,5 +57,5 @@ interface __declspec(uuid("546E72B3-66A1-4A58-A99B-56530B3E2FFF"))
     STDMETHOD(SetFrequency)(ULONG ulFrequency, ULONG ulBandwidth) PURE;
     STDMETHOD(Scan)(ULONG ulFrequency, ULONG ulBandwidth, HWND hWnd) PURE;
     STDMETHOD(GetStats)(BOOLEAN& bPresent, BOOLEAN& bLocked, LONG& lDbStrength, LONG& lPercentQuality) PURE;
-    STDMETHOD(UpdatePSI)(const class CDVBChannel* pChannel, struct EventDescriptor& NowNext) PURE;
+    STDMETHOD(UpdatePSI)(const class CBDAChannel* pChannel, struct EventDescriptor& NowNext) PURE;
 };

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -8089,7 +8089,7 @@ void CMainFrame::OnPlayAudio(UINT nID)
     } else if (GetPlaybackMode() == PM_FILE) {
         OnNavStreamSelectSubMenu(i, 1);
     } else if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
-        if (CDVBChannel* pChannel = m_pDVBState->pChannel) {
+        if (CBDAChannel* pChannel = m_pDVBState->pChannel) {
             OnNavStreamSelectSubMenu(i, 1);
             pChannel->SetDefaultAudio(i);
         }
@@ -8126,7 +8126,7 @@ void CMainFrame::OnPlaySubtitles(UINT nID)
     }
 
     if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
-        if (CDVBChannel* pChannel = m_pDVBState->pChannel) {
+        if (CBDAChannel* pChannel = m_pDVBState->pChannel) {
             OnNavStreamSelectSubMenu(i, 2);
             pChannel->SetDefaultSubtitle(i);
         }
@@ -15338,7 +15338,7 @@ HRESULT CMainFrame::SetChannel(int nChannel)
     CAppSettings& s = AfxGetAppSettings();
     HRESULT hr = S_OK;
     CComQIPtr<IBDATuner> pTun = m_pGB;
-    CDVBChannel* pChannel = s.FindChannelByPref(nChannel);
+    CBDAChannel* pChannel = s.FindChannelByPref(nChannel);
 
     if (s.m_DVBChannels.empty() && nChannel == INT_ERROR) {
         hr = S_FALSE; // All channels have been cleared or it is the first start
@@ -15403,7 +15403,7 @@ HRESULT CMainFrame::SetChannel(int nChannel)
 
 void CMainFrame::UpdateCurrentChannelInfo(bool bShowOSD /*= true*/, bool bShowInfoBar /*= false*/)
 {
-    const CDVBChannel* pChannel = m_pDVBState->pChannel;
+    const CBDAChannel* pChannel = m_pDVBState->pChannel;
     CComQIPtr<IBDATuner> pTun = m_pGB;
 
     if (!m_pDVBState->bInfoActive && pChannel && pTun) {

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -599,7 +599,7 @@ public:
         };
 
         CString         sChannelName;                // Current channel name
-        CDVBChannel*    pChannel          = nullptr; // Pointer to current channel object
+        CBDAChannel*    pChannel          = nullptr; // Pointer to current channel object
         EventDescriptor NowNext;                     // Current channel EIT
         bool            bActive           = false;   // True when channel is active
         bool            bSetChannelActive = false;   // True when channel change is in progress

--- a/src/mpc-hc/Mpeg2SectionData.h
+++ b/src/mpc-hc/Mpeg2SectionData.h
@@ -74,18 +74,18 @@ public:
     HRESULT     ParsePAT();
     HRESULT     ParseNIT();
     HRESULT     ParseEIT(ULONG ulSID, EventDescriptor& NowNext);
-    HRESULT     ParsePMT(CDVBChannel& Channel);
+    HRESULT     ParsePMT(CBDAChannel& Channel);
 
     static CStringW ConvertString(BYTE* pBuffer, size_t uLength);
 
-    CAtlMap<int, CDVBChannel>   Channels;
+    CAtlMap<int, CBDAChannel>   Channels;
 
 private:
     CComQIPtr<IMpeg2Data>       m_pData;
     MPEG2_FILTER                m_Filter;
 
 
-    DVB_STREAM_TYPE ConvertToDVBType(PES_STREAM_TYPE nType);
+    BDA_STREAM_TYPE ConvertToDVBType(PES_STREAM_TYPE nType);
     HRESULT         ParseSIHeader(CGolombBuffer& gb, DVB_SI SIType, WORD& wSectionLength, WORD& wTSID);
     HRESULT         SetTime(CGolombBuffer& gb, EventDescriptor& NowNext);
 };

--- a/src/mpc-hc/PlayerNavigationDialog.cpp
+++ b/src/mpc-hc/PlayerNavigationDialog.cpp
@@ -216,9 +216,9 @@ void CPlayerNavigationDialog::OnContextMenu(CWnd* pWnd, CPoint point)
         M_REMOVE_ALL
     };
 
-    auto findChannelByItemNumber = [this](std::vector<CDVBChannel>& c, int nItem) {
+    auto findChannelByItemNumber = [this](std::vector<CBDAChannel>& c, int nItem) {
         int nPrefNumber = (int)m_channelList.GetItemData(nItem);
-        return find_if(c.begin(), c.end(), [&](CDVBChannel const & channel) {
+        return find_if(c.begin(), c.end(), [&](CBDAChannel const & channel) {
             return channel.GetPrefNumber() == nPrefNumber;
         });
     };
@@ -291,7 +291,7 @@ void CPlayerNavigationDialog::OnContextMenu(CWnd* pWnd, CPoint point)
                 const int nRemovedPrefNumber = it->GetPrefNumber();
                 s.m_DVBChannels.erase(it);
                 // Update channels pref number
-                for (CDVBChannel& channel : s.m_DVBChannels) {
+                for (CBDAChannel& channel : s.m_DVBChannels) {
                     const int nPrefNumber = channel.GetPrefNumber();
                     ASSERT(nPrefNumber != nRemovedPrefNumber);
                     if (nPrefNumber > nRemovedPrefNumber) {

--- a/src/mpc-hc/TunerScanDlg.cpp
+++ b/src/mpc-hc/TunerScanDlg.cpp
@@ -133,7 +133,7 @@ void CTunerScanDlg::OnBnClickedSave()
 
     for (int i = 0; i < m_ChannelList.GetItemCount(); i++) {
         try {
-            CDVBChannel channel(m_ChannelList.GetItemText(i, TSCC_CHANNEL));
+            CBDAChannel channel(m_ChannelList.GetItemText(i, TSCC_CHANNEL));
             auto it = std::find(std::begin(DVBChannels), std::end(DVBChannels), channel);
             if (it != DVBChannels.end()) {
                 // replace existing channel
@@ -223,7 +223,7 @@ LRESULT CTunerScanDlg::OnStats(WPARAM wParam, LPARAM lParam)
 LRESULT CTunerScanDlg::OnNewChannel(WPARAM wParam, LPARAM lParam)
 {
     try {
-        CDVBChannel channel((LPCTSTR)lParam);
+        CBDAChannel channel((LPCTSTR)lParam);
         if (!m_bIgnoreEncryptedChannels || !channel.IsEncrypted()) {
             CString strTemp;
             int nItem, nChannelNumber;
@@ -252,9 +252,9 @@ LRESULT CTunerScanDlg::OnNewChannel(WPARAM wParam, LPARAM lParam)
             m_ChannelList.SetItemText(nItem, TSCC_FREQUENCY, strTemp);
 
             m_ChannelList.SetItemText(nItem, TSCC_ENCRYPTED, ResStr(channel.IsEncrypted() ? IDS_YES : IDS_NO));
-            if (channel.GetVideoType() == DVB_H264) {
+            if (channel.GetVideoType() == BDA_H264) {
                 strTemp = _T("H.264");
-            } else if (channel.GetVideoType() == DVB_HEVC) {
+            } else if (channel.GetVideoType() == BDA_HEVC) {
                 strTemp = _T("HEVC");
             } else if (channel.GetVideoPID()) {
                 strTemp = _T("MPEG-2");

--- a/src/mpc-hc/WebClientSocket.cpp
+++ b/src/mpc-hc/WebClientSocket.cpp
@@ -908,7 +908,7 @@ bool CWebClientSocket::OnViewRes(CStringA& hdr, CStringA& body, CStringA& mime)
     return true;
 }
 
-static CStringA GetChannelsJSON(const std::vector<CDVBChannel>& channels)
+static CStringA GetChannelsJSON(const std::vector<CBDAChannel>& channels)
 {
     // begin the JSON object with the "channels" array inside
     CStringA jsonChannels = "{ \"channels\" : [";


### PR DESCRIPTION
This patch basically renames a lot of DVB elements to BDA, since they are not unique to DVB.  Some DVB references remain in the code, but DVBChannel and FGManagerBDA have been refactored.

The only functional change is adding support for ATSC tuners.  The scanning does not work (it doesn't find any channels), but maybe in the future someone can support it.  I manually added the frequencies to the registry and they worked for me.

Mostly, it will just be nice to have ATSC support in the main branch for testing any BDA issues in the future.