### PR TITLE
Add Per-monitor V2 dpi awareness to manifest

### DIFF
--- a/src/mpc-hc/res/mpc-hc.exe.manifest.conf
+++ b/src/mpc-hc/res/mpc-hc.exe.manifest.conf
@@ -38,6 +38,7 @@
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
       <dpiAware>True/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>


### PR DESCRIPTION
MPC-HC already has per-monitor DPI awareness set in it's manifest file.
However, the settings menu doesn't seem to scale at all.

Adding this line to the manifest file fixes this. It tells Windows to perform scaling on more components than the original algorithm did. With this fix, the scaling issues seem to be fully resolved for me.

You can find more documentation here: https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows