### PR TITLE
More fixes for snapshots

### DIFF
--- a/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.cpp
@@ -37,7 +37,6 @@ using namespace DSObjects;
 
 CMPCVRAllocatorPresenter::CMPCVRAllocatorPresenter(HWND hWnd, HRESULT& hr, CString& _Error)
     : CSubPicAllocatorPresenterImpl(hWnd, hr, &_Error)
-    , m_ScreenSize(0, 0)
 {
     if (FAILED(hr)) {
         _Error += L"ISubPicAllocatorPresenterImpl failed\n";
@@ -49,11 +48,6 @@ CMPCVRAllocatorPresenter::CMPCVRAllocatorPresenter(HWND hWnd, HRESULT& hr, CStri
 
 CMPCVRAllocatorPresenter::~CMPCVRAllocatorPresenter()
 {
-    if (m_pSRCB) {
-        // nasty, but we have to let it know about our death somehow
-        ((CSubRenderCallback*)(ISubRenderCallback*)m_pSRCB)->SetMPCVRAP(nullptr);
-    }
-
     // the order is important here
     m_pSubPicQueue = nullptr;
     m_pAllocator = nullptr;
@@ -68,7 +62,11 @@ STDMETHODIMP CMPCVRAllocatorPresenter::NonDelegatingQueryInterface(REFIID riid, 
         }
     }
 
-    return __super::NonDelegatingQueryInterface(riid, ppv);
+	return QI(ISubRenderCallback)
+		   QI(ISubRenderCallback2)
+		   QI(ISubRenderCallback3)
+		   QI(ISubRenderCallback4)
+		   __super::NonDelegatingQueryInterface(riid, ppv);
 }
 
 HRESULT CMPCVRAllocatorPresenter::SetDevice(IDirect3DDevice9* pD3DDev)
@@ -77,18 +75,17 @@ HRESULT CMPCVRAllocatorPresenter::SetDevice(IDirect3DDevice9* pD3DDev)
         // release all resources
         m_pSubPicQueue = nullptr;
         m_pAllocator = nullptr;
-        __super::SetPosition(CRect(), CRect());
         return S_OK;
     }
 
     const CRenderersSettings& r = GetRenderersSettings();
 
-    MONITORINFO mi;
-    mi.cbSize = sizeof(MONITORINFO);
-    if (GetMonitorInfo(MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST), &mi)) {
-        m_ScreenSize.SetSize(mi.rcMonitor.right - mi.rcMonitor.left, mi.rcMonitor.bottom - mi.rcMonitor.top);
-    }
-    InitMaxSubtitleTextureSize(r.subPicQueueSettings.nMaxRes, m_ScreenSize);
+	CSize screenSize;
+	MONITORINFO mi = { sizeof(MONITORINFO) };
+	if (GetMonitorInfoW(MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST), &mi)) {
+		screenSize.SetSize(mi.rcMonitor.right - mi.rcMonitor.left, mi.rcMonitor.bottom - mi.rcMonitor.top);
+	}
+	InitMaxSubtitleTextureSize(r.subPicQueueSettings.nMaxRes, screenSize);
 
     if (m_pAllocator) {
         m_pAllocator->ChangeDevice(pD3DDev);
@@ -118,25 +115,34 @@ HRESULT CMPCVRAllocatorPresenter::SetDevice(IDirect3DDevice9* pD3DDev)
     return hr;
 }
 
-HRESULT CMPCVRAllocatorPresenter::Render(
-    REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, REFERENCE_TIME atpf,
-    int left, int top, int right, int bottom, int width, int height)
+
+// ISubRenderCallback4 (called through CSubRenderCallback)
+
+HRESULT CMPCVRAllocatorPresenter::RenderEx3(REFERENCE_TIME rtStart,
+											REFERENCE_TIME rtStop,
+											REFERENCE_TIME atpf,
+											RECT croppedVideoRect,
+											RECT originalVideoRect,
+											RECT viewportRect,
+											const double videoStretchFactor,
+											int xOffsetInPixels, DWORD flags)
 {
-    CRect wndRect(0, 0, width, height);
-    CRect videoRect(left, top, right, bottom);
-    __super::SetPosition(wndRect, videoRect); // needed? should be already set by the player
-    if (!g_bExternalSubtitleTime) {
-        if (g_bExternalSubtitle && g_dRate != 0.0) {
-            const REFERENCE_TIME sampleTime = rtStart - g_tSegmentStart;
-            SetTime(g_tSegmentStart + sampleTime * g_dRate);
-        } else {
-            SetTime(rtStart);
-        }
-    }
-    if (atpf > 0 && m_pSubPicQueue) {
-        m_pSubPicQueue->SetFPS(10000000.0 / atpf);
-    }
-    return AlphaBltSubPic(wndRect, videoRect);
+	CheckPointer(m_pSubPicQueue, E_UNEXPECTED);
+
+	if (!g_bExternalSubtitleTime) {
+		if (g_bExternalSubtitle && g_dRate != 0.0) {
+			const REFERENCE_TIME sampleTime = rtStart - g_tSegmentStart;
+			SetTime(g_tSegmentStart + sampleTime * g_dRate);
+		} else {
+			SetTime(rtStart);
+		}
+	}
+	if (atpf > 0) {
+		m_fps = 10000000.0 / atpf;
+		m_pSubPicQueue->SetFPS(m_fps);
+	}
+
+	return AlphaBltSubPic(viewportRect, croppedVideoRect, nullptr, videoStretchFactor, xOffsetInPixels);
 }
 
 // ISubPicAllocatorPresenter
@@ -159,13 +165,16 @@ STDMETHODIMP CMPCVRAllocatorPresenter::CreateRenderer(IUnknown** ppRenderer)
         return E_FAIL;
     }
 
-    m_pSRCB = DEBUG_NEW CSubRenderCallback(this);
-    if (FAILED(pSR->SetCallback(m_pSRCB))) {
+    if (FAILED(pSR->SetCallback(this))) {
         m_pMPCVR = nullptr;
         return E_FAIL;
     }
 
     (*ppRenderer = (IUnknown*)(INonDelegatingUnknown*)(this))->AddRef();
+
+	if (CComQIPtr<IExFilterConfig> pIExFilterConfig = m_pMPCVR) {
+		pIExFilterConfig->SetBool("lessRedraws", true);
+	}
 
     CComQIPtr<IBaseFilter> pBF = m_pMPCVR;
     CComPtr<IPin> pPin = GetFirstPin(pBF);
@@ -186,7 +195,7 @@ STDMETHODIMP_(void) CMPCVRAllocatorPresenter::SetPosition(RECT w, RECT v)
         pVW->SetWindowPosition(w.left, w.top, w.right - w.left, w.bottom - w.top);
     }
 
-    SetVideoSize(GetVideoSize(), GetVideoSize(true));
+	__super::SetPosition(w, v);
 }
 
 STDMETHODIMP CMPCVRAllocatorPresenter::SetRotation(int rotation)
@@ -248,8 +257,14 @@ STDMETHODIMP_(bool) CMPCVRAllocatorPresenter::Paint(bool bAll)
 STDMETHODIMP CMPCVRAllocatorPresenter::GetDIB(BYTE* lpDib, DWORD* size)
 {
     HRESULT hr = E_NOTIMPL;
+    if (CComQIPtr<IExFilterConfig> pIExFilterConfig = m_pMPCVR) {
+        hr = pIExFilterConfig->GetBin("currentImageAR", (LPVOID*)lpDib, (unsigned int*)size); //PR submitted to MPCVR tree.  if accepted this will work.
+        if (S_OK == hr) { //if failed, defaults to old code which currently doesn't use DAR (2020-05-16)
+            return hr;
+        }
+    }
     if (CComQIPtr<IBasicVideo> pBV = m_pMPCVR) {
-        hr = pBV->GetCurrentImage((long*)size, (long*)lpDib);
+        hr = pBV->GetCurrentImage((long*)size, (long*)lpDib); //SAR, not DAR
     }
     return hr;
 }

--- a/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.cpp
@@ -257,14 +257,8 @@ STDMETHODIMP_(bool) CMPCVRAllocatorPresenter::Paint(bool bAll)
 STDMETHODIMP CMPCVRAllocatorPresenter::GetDIB(BYTE* lpDib, DWORD* size)
 {
     HRESULT hr = E_NOTIMPL;
-    if (CComQIPtr<IExFilterConfig> pIExFilterConfig = m_pMPCVR) {
-        hr = pIExFilterConfig->GetBin("currentImageAR", (LPVOID*)lpDib, (unsigned int*)size); //PR submitted to MPCVR tree.  if accepted this will work.
-        if (S_OK == hr) { //if failed, defaults to old code which currently doesn't use DAR (2020-05-16)
-            return hr;
-        }
-    }
     if (CComQIPtr<IBasicVideo> pBV = m_pMPCVR) {
-        hr = pBV->GetCurrentImage((long*)size, (long*)lpDib); //SAR, not DAR
+        hr = pBV->GetCurrentImage((long*)size, (long*)lpDib);
     }
     return hr;
 }

--- a/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.h
@@ -26,69 +26,49 @@
 
 namespace DSObjects
 {
-    class CMPCVRAllocatorPresenter
-        : public CSubPicAllocatorPresenterImpl
-    {
-        class CSubRenderCallback : public CUnknown, public ISubRenderCallback, public CCritSec
-        {
-            CMPCVRAllocatorPresenter* m_pMPCVRAP;
+	class CMPCVRAllocatorPresenter : public CSubPicAllocatorPresenterImpl, ISubRenderCallback4
+	{
+		CComPtr<IUnknown> m_pMPCVR;
 
-        public:
-            CSubRenderCallback(CMPCVRAllocatorPresenter* pMPCVRAP)
-                : CUnknown(_T("CSubRender"), nullptr)
-                , m_pMPCVRAP(pMPCVRAP) {
-            }
+	public:
+		CMPCVRAllocatorPresenter(HWND hWnd, HRESULT& hr, CString& _Error);
+		virtual ~CMPCVRAllocatorPresenter();
 
-            DECLARE_IUNKNOWN
-            STDMETHODIMP NonDelegatingQueryInterface(REFIID riid, void** ppv) {
-                return
-                    QI(ISubRenderCallback)
-                    __super::NonDelegatingQueryInterface(riid, ppv);
-            }
+		DECLARE_IUNKNOWN
+		STDMETHODIMP NonDelegatingQueryInterface(REFIID riid, void** ppv) override;
 
-            void SetMPCVRAP(CMPCVRAllocatorPresenter* pMPCVRAP) {
-                CAutoLock cAutoLock(this);
-                m_pMPCVRAP = pMPCVRAP;
-            }
+		// ISubRenderCallback
+		STDMETHODIMP SetDevice(IDirect3DDevice9* pD3DDev) override;
+		STDMETHODIMP Render(REFERENCE_TIME rtStart, int left, int top, int right,
+							int bottom, int width, int height) override {
+			return RenderEx(rtStart, 0, 0, left, top, right, bottom, width, height);
+		};
 
-            // ISubRenderCallback
+		// ISubRenderCallback2
+		STDMETHODIMP RenderEx(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, REFERENCE_TIME atpf,
+							  int left, int top, int right, int bottom, int width, int height) override {
+			return RenderEx2(rtStart, rtStop, atpf, { left, top, right, bottom },
+			{ left, top, right, bottom }, { 0, 0, width, height });
+		};
+			
+		// ISubRenderCallback3
+		STDMETHODIMP RenderEx2(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop,
+								REFERENCE_TIME atpf, RECT croppedVideoRect,
+								RECT originalVideoRect, RECT viewportRect,
+								const double videoStretchFactor = 1.0) override {
+			return RenderEx3(rtStart, rtStop, atpf, croppedVideoRect, originalVideoRect, viewportRect, videoStretchFactor);
+		}
 
-            STDMETHODIMP SetDevice(IDirect3DDevice9* pD3DDev) {
-                CAutoLock cAutoLock(this);
-                return m_pMPCVRAP ? m_pMPCVRAP->SetDevice(pD3DDev) : E_UNEXPECTED;
-            }
+		// ISubRenderCallback4
+		STDMETHODIMP RenderEx3(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop,
+							   REFERENCE_TIME atpf, RECT croppedVideoRect,
+							   RECT originalVideoRect, RECT viewportRect,
+							   const double videoStretchFactor = 1.0,
+							   int xOffsetInPixels = 0, DWORD flags = 0) override;
 
-            STDMETHODIMP Render(REFERENCE_TIME rtStart, int left, int top, int right, int bottom, int width, int height) {
-                CAutoLock cAutoLock(this);
-                return m_pMPCVRAP ? m_pMPCVRAP->Render(rtStart, 0, 0, left, top, right, bottom, width, height) : E_UNEXPECTED;
-            }
-
-            // ISubRendererCallback2
-
-            STDMETHODIMP RenderEx(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, REFERENCE_TIME AvgTimePerFrame, int left, int top, int right, int bottom, int width, int height) {
-                CAutoLock cAutoLock(this);
-                return m_pMPCVRAP ? m_pMPCVRAP->Render(rtStart, rtStop, AvgTimePerFrame, left, top, right, bottom, width, height) : E_UNEXPECTED;
-            }
-        };
-
-        CComPtr<IUnknown> m_pMPCVR;
-        CComPtr<ISubRenderCallback> m_pSRCB;
-        CSize   m_ScreenSize;
-
-    public:
-        CMPCVRAllocatorPresenter(HWND hWnd, HRESULT& hr, CString& _Error);
-        virtual ~CMPCVRAllocatorPresenter();
-
-        DECLARE_IUNKNOWN
-        STDMETHODIMP NonDelegatingQueryInterface(REFIID riid, void** ppv);
-
-        HRESULT SetDevice(IDirect3DDevice9* pD3DDev);
-        HRESULT Render(
-            REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, REFERENCE_TIME atpf,
-            int left, int top, int bottom, int right, int width, int height);
 
         // ISubPicAllocatorPresenter
-        STDMETHODIMP CreateRenderer(IUnknown** ppRenderer);
+		STDMETHODIMP CreateRenderer(IUnknown** ppRenderer) override;
         STDMETHODIMP_(void) SetPosition(RECT w, RECT v);
         STDMETHODIMP SetRotation(int rotation);
         STDMETHODIMP_(int) GetRotation();

--- a/src/filters/renderer/VideoRenderers/SyncRenderer.h
+++ b/src/filters/renderer/VideoRenderers/SyncRenderer.h
@@ -190,6 +190,7 @@ namespace GothSync
         HRESULT TextureResizeBilinear(IDirect3DTexture9* pTexture, const Vector dst[4], const CRect& SrcRect);
         HRESULT TextureResizeBicubic1pass(IDirect3DTexture9* pTexture, const Vector dst[4], const CRect& SrcRect);
         HRESULT TextureResizeBicubic2pass(IDirect3DTexture9* pTexture, const Vector dst[4], const CRect& SrcRect);
+        HRESULT Resize(IDirect3DTexture9* pTexture, const CRect& srcRect, const CRect& destRect);
 
         typedef HRESULT(WINAPI* D3DXLoadSurfaceFromMemoryPtr)(
             LPDIRECT3DSURFACE9 pDestSurface,
@@ -202,6 +203,16 @@ namespace GothSync
             CONST RECT* pSrcRect,
             DWORD Filter,
             D3DCOLOR ColorKey);
+
+        typedef HRESULT(WINAPI* D3DXLoadSurfaceFromSurfacePtr)(
+            LPDIRECT3DSURFACE9        pDestSurface,
+            CONST PALETTEENTRY* pDestPalette,
+            CONST RECT* pDestRect,
+            LPDIRECT3DSURFACE9        pSrcSurface,
+            CONST PALETTEENTRY* pSrcPalette,
+            CONST RECT* pSrcRect,
+            DWORD                     Filter,
+            D3DCOLOR                  ColorKey);
 
         typedef HRESULT(WINAPI* D3DXCreateLinePtr)
         (LPDIRECT3DDEVICE9 pDevice,
@@ -232,6 +243,7 @@ namespace GothSync
         int m_VMR9AlphaBitmapWidthBytes;
 
         D3DXLoadSurfaceFromMemoryPtr m_pD3DXLoadSurfaceFromMemory;
+        D3DXLoadSurfaceFromSurfacePtr m_pD3DXLoadSurfaceFromSurface;
         D3DXCreateLinePtr m_pD3DXCreateLine;
         D3DXCreateFontPtr m_pD3DXCreateFont;
         HRESULT(__stdcall* m_pD3DXCreateSprite)(LPDIRECT3DDEVICE9 pDevice, LPD3DXSPRITE* ppSprite);


### PR DESCRIPTION
It seems that SyncRenderer wasn't actually working, so this fixes that.

Secondly, MPCVR is now supported if a patch is accepted by me to MPCVR source.  In the meantime it will failback to the "bad" code.  If the GetCurrentImage() call is fixed with my code instead, that will solve mpc-hc w/o requiring my patch (but the patch is harmless in that case).