### PR TITLE
force explicit use of GetVideoSize()

### DIFF
--- a/src/SubPic/SubPicAllocatorPresenterImpl.h
+++ b/src/SubPic/SubPicAllocatorPresenterImpl.h
@@ -92,7 +92,7 @@ public:
     STDMETHODIMP CreateRenderer(IUnknown** ppRenderer) PURE;
 
     STDMETHODIMP_(void) SetVideoSize(CSize szVideo, CSize szAspectRatio = CSize(0, 0));
-    STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR = true) const;
+    STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR) const;
     STDMETHODIMP_(SIZE) GetVisibleVideoSize() const {
         return m_nativeVideoSize;
     };

--- a/src/filters/renderer/VideoRenderers/DXRAllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/DXRAllocatorPresenter.cpp
@@ -185,7 +185,7 @@ STDMETHODIMP_(void) CDXRAllocatorPresenter::SetPosition(RECT w, RECT v)
         pVW->SetWindowPosition(w.left, w.top, w.right - w.left, w.bottom - w.top);
     }
 
-    SetVideoSize(GetVideoSize(), GetVideoSize(true));
+    SetVideoSize(GetVideoSize(false), GetVideoSize(true));
 }
 
 STDMETHODIMP_(SIZE) CDXRAllocatorPresenter::GetVideoSize(bool bCorrectAR) const

--- a/src/filters/renderer/VideoRenderers/DXRAllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/DXRAllocatorPresenter.h
@@ -90,7 +90,7 @@ namespace DSObjects
         // ISubPicAllocatorPresenter
         STDMETHODIMP CreateRenderer(IUnknown** ppRenderer);
         STDMETHODIMP_(void) SetPosition(RECT w, RECT v);
-        STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR = true) const;
+        STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR) const;
         STDMETHODIMP_(bool) Paint(bool bAll);
         STDMETHODIMP GetDIB(BYTE* lpDib, DWORD* size);
         STDMETHODIMP SetPixelShader(LPCSTR pSrcData, LPCSTR pTarget);

--- a/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.h
@@ -72,7 +72,7 @@ namespace DSObjects
         STDMETHODIMP_(void) SetPosition(RECT w, RECT v);
         STDMETHODIMP SetRotation(int rotation);
         STDMETHODIMP_(int) GetRotation();
-        STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR = true) const;
+        STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR) const;
         STDMETHODIMP_(bool) Paint(bool bAll);
         STDMETHODIMP GetDIB(BYTE* lpDib, DWORD* size);
 		STDMETHODIMP GetDisplayedImage(LPVOID* dibImage);

--- a/src/filters/renderer/VideoRenderers/madVRAllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/madVRAllocatorPresenter.cpp
@@ -174,7 +174,7 @@ STDMETHODIMP_(void) CmadVRAllocatorPresenter::SetPosition(RECT w, RECT v)
         pVW->SetWindowPosition(w.left, w.top, w.right - w.left, w.bottom - w.top);
     }
 
-    SetVideoSize(GetVideoSize(), GetVideoSize(true));
+    SetVideoSize(GetVideoSize(false), GetVideoSize(true));
 }
 
 STDMETHODIMP_(SIZE) CmadVRAllocatorPresenter::GetVideoSize(bool bCorrectAR) const

--- a/src/filters/renderer/VideoRenderers/madVRAllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/madVRAllocatorPresenter.h
@@ -69,7 +69,7 @@ namespace DSObjects
         // ISubPicAllocatorPresenter
         STDMETHODIMP CreateRenderer(IUnknown** ppRenderer) override;
         STDMETHODIMP_(void) SetPosition(RECT w, RECT v) override;
-        STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR = true) const override;
+        STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR) const override;
         STDMETHODIMP_(bool) Paint(bool bAll) override;
         STDMETHODIMP GetDIB(BYTE* lpDib, DWORD* size) override;
         STDMETHODIMP SetPixelShader(LPCSTR pSrcData, LPCSTR pTarget) override {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -11864,7 +11864,7 @@ void CMainFrame::OpenSetupVideo()
     if (m_pMFVDC) { // EVR
         m_fAudioOnly = false;
     } else if (m_pCAP) {
-        CSize vs = m_pCAP->GetVideoSize();
+        CSize vs = m_pCAP->GetVideoSize(false);
         m_fAudioOnly = (vs.cx <= 0 || vs.cy <= 0);
     } else {
         {


### PR DESCRIPTION
To remove confusion, I changed the very few uses of default bCorrectAR to use it explicitly, and remove the default parameter.  Also fixed two instances where I think the default caused the wrong behavior.