### PR TITLE
Fixes for VS2019 Build Tools v142 

### DIFF
--- a/src/Subtitles/stdafx.h
+++ b/src/Subtitles/stdafx.h
@@ -40,3 +40,4 @@
 #include <list>
 #include <memory>
 #include <thread>
+#include <functional>

--- a/src/thirdparty/sanear/src/AudioDevice.h
+++ b/src/thirdparty/sanear/src/AudioDevice.h
@@ -2,6 +2,7 @@
 
 #include "DspChunk.h"
 #include "DspFormat.h"
+#include <memory>
 
 namespace SaneAudioRenderer
 {
@@ -90,7 +91,7 @@ namespace SaneAudioRenderer
 
         bool CheckLastInstances()
         {
-            if (!m_backend.unique())
+            if (m_backend.use_count() != 1)
                 return false;
 
             if (m_backend->audioClock && !IsLastInstance(m_backend->audioClock))

--- a/src/thirdparty/sanear/src/AudioDevice.h
+++ b/src/thirdparty/sanear/src/AudioDevice.h
@@ -2,7 +2,6 @@
 
 #include "DspChunk.h"
 #include "DspFormat.h"
-#include <memory>
 
 namespace SaneAudioRenderer
 {


### PR DESCRIPTION
Couple things broke when I upgraded visual studio, which I think is caused by newer version of c++.  

See here for one of them: https://github.com/microsoft/terminal/pull/449/files

The other is due to https://en.cppreference.com/w/cpp/memory/shared_ptr/unique

This is removed in c++20 and was deprecated as of c++17.  It seems equivalent to use_count()==1, and although the idea is not to do that check at all, this at least seems to work the same as before.