### PR TITLE
add features for MPCVR and madVR

### DIFF
--- a/src/SubPic/ISubPic.h
+++ b/src/SubPic/ISubPic.h
@@ -173,6 +173,8 @@ public IUnknown {
 //
 // ISubPicAllocatorPresenter
 //
+#define TARGET_FRAME 0
+#define TARGET_SCREEN 1
 
 interface __declspec(uuid("CF75B1F0-535C-4074-8869-B15F177F944E"))
 ISubPicAllocatorPresenter :
@@ -211,6 +213,22 @@ public ISubPicAllocatorPresenter {
     STDMETHOD(SetIsRendering)(bool bIsRendering) PURE;
 
     STDMETHOD(SetDefaultVideoAngle)(Vector v) PURE;
+};
+
+
+interface __declspec(uuid("AD863F43-83F9-4B8E-962C-426F2BDBEAEF"))
+ISubPicAllocatorPresenter3 :
+public ISubPicAllocatorPresenter2 {
+	STDMETHOD (SetRotation) (int rotation) PURE;
+	STDMETHOD_(int, GetRotation) () PURE;
+	STDMETHOD (SetFlip) (bool flip) PURE;
+	STDMETHOD_(bool, GetFlip) () PURE;
+	STDMETHOD (GetVideoFrame) (BYTE* lpDib, DWORD* size) PURE;
+	STDMETHOD_(int, GetPixelShaderMode) () PURE;
+	STDMETHOD (ClearPixelShaders) (int target) PURE;
+	STDMETHOD (AddPixelShader) (int target, LPCWSTR name, LPCSTR profile, LPCSTR sourceCode) PURE;
+	STDMETHOD_(bool, ResizeDevice) () PURE;
+    STDMETHOD_(bool, ToggleStats) () PURE;
 };
 
 //

--- a/src/SubPic/SubPicAllocatorPresenterImpl.h
+++ b/src/SubPic/SubPicAllocatorPresenterImpl.h
@@ -31,7 +31,7 @@
 class CSubPicAllocatorPresenterImpl
     : public CUnknown
     , public CCritSec
-    , public ISubPicAllocatorPresenter2
+	, public ISubPicAllocatorPresenter3
     , public ISubRenderConsumer2
 {
 private:
@@ -47,9 +47,9 @@ protected:
     CRect m_videoRect, m_windowRect;
 	bool  m_bOtherTransform = false;
 
-    REFERENCE_TIME m_rtNow;
-    double m_fps;
-    UINT m_refreshRate;
+	REFERENCE_TIME m_rtNow = 0;
+	double m_fps           = 25.0;
+	UINT m_refreshRate     = 0;
 
     CMediaType m_inputMediaType;
 
@@ -88,34 +88,26 @@ public:
 
     DECLARE_IUNKNOWN;
     STDMETHODIMP NonDelegatingQueryInterface(REFIID riid, void** ppv);
+    STDMETHODIMP_(void) SetVideoSize(CSize szVideo, CSize szAspectRatio = CSize(0, 0));
+
+    // ISubPicAllocatorPresenter
 
     STDMETHODIMP CreateRenderer(IUnknown** ppRenderer) PURE;
-
-    STDMETHODIMP_(void) SetVideoSize(CSize szVideo, CSize szAspectRatio = CSize(0, 0));
     STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR) const;
-    STDMETHODIMP_(SIZE) GetVisibleVideoSize() const {
-        return m_nativeVideoSize;
-    };
     STDMETHODIMP_(void) SetPosition(RECT w, RECT v);
     STDMETHODIMP_(bool) Paint(bool bAll) PURE;
-
     STDMETHODIMP_(void) SetTime(REFERENCE_TIME rtNow);
     STDMETHODIMP_(void) SetSubtitleDelay(int delayMs);
     STDMETHODIMP_(int) GetSubtitleDelay() const;
     STDMETHODIMP_(double) GetFPS() const;
-
     STDMETHODIMP_(void) SetSubPicProvider(ISubPicProvider* pSubPicProvider);
     STDMETHODIMP_(void) Invalidate(REFERENCE_TIME rtInvalidate = -1);
-
     STDMETHODIMP GetDIB(BYTE* lpDib, DWORD* size) { return E_NOTIMPL; }
-
-	STDMETHODIMP GetDisplayedImage(LPVOID* dibImage) { return E_NOTIMPL; }
-    STDMETHODIMP_(bool) ResetDevice() { return false; }
-
-    STDMETHODIMP_(bool) DisplayChange() { return false; }
-
+    STDMETHODIMP GetDisplayedImage(LPVOID* dibImage) { return E_NOTIMPL; }
     STDMETHODIMP SetVideoAngle(Vector v);
     STDMETHODIMP SetPixelShader(LPCSTR pSrcData, LPCSTR pTarget) { return E_NOTIMPL; }
+    STDMETHODIMP_(bool) ResetDevice() { return false; }
+    STDMETHODIMP_(bool) DisplayChange() { return false; }
 
     // ISubPicAllocatorPresenter2
 
@@ -126,9 +118,26 @@ public:
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP SetIsRendering(bool bIsRendering) { return E_NOTIMPL; }
+    STDMETHODIMP_(SIZE) GetVisibleVideoSize() const {
+        return m_nativeVideoSize;
+    }
 
+    STDMETHODIMP SetIsRendering(bool bIsRendering) { return E_NOTIMPL; }
+    STDMETHODIMP_(bool) IsRendering() { return true; }
     STDMETHODIMP SetDefaultVideoAngle(Vector v);
+
+    // ISubPicAllocatorPresenter3
+
+	STDMETHODIMP SetRotation(int rotation) { return E_NOTIMPL; }
+	STDMETHODIMP_(int) GetRotation() { return 0; }
+	STDMETHODIMP SetFlip(bool flip) { return E_NOTIMPL; }
+	STDMETHODIMP_(bool) GetFlip() { return false; }
+    STDMETHODIMP GetVideoFrame(BYTE* lpDib, DWORD* size) { return E_NOTIMPL; }
+    STDMETHODIMP_(int) GetPixelShaderMode() { return 0; }
+    STDMETHODIMP ClearPixelShaders(int target) { return E_NOTIMPL; }
+    STDMETHODIMP AddPixelShader(int target, LPCWSTR name, LPCSTR profile, LPCSTR sourceCode) { return E_NOTIMPL; }
+    STDMETHODIMP_(bool) ResizeDevice() { return false; }
+    STDMETHODIMP_(bool) ToggleStats() { return false; }
 
     // ISubRenderOptions
 

--- a/src/Subtitles/stdafx.h
+++ b/src/Subtitles/stdafx.h
@@ -40,3 +40,4 @@
 #include <list>
 #include <memory>
 #include <thread>
+#include <functional>

--- a/src/filters/renderer/VideoRenderers/DX9RenderingEngine.cpp
+++ b/src/filters/renderer/VideoRenderers/DX9RenderingEngine.cpp
@@ -20,6 +20,7 @@
 
 #include "stdafx.h"
 #include <algorithm>
+#pragma warning(disable: 5033) // warning C5033: 'register' is no longer a supported storage class
 #include "lcms2/library/include/lcms2.h"
 #include "../../../mpc-hc/resource.h"
 #include "Dither.h"

--- a/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.h
@@ -69,15 +69,20 @@ namespace DSObjects
 
         // ISubPicAllocatorPresenter
 		STDMETHODIMP CreateRenderer(IUnknown** ppRenderer) override;
-        STDMETHODIMP_(void) SetPosition(RECT w, RECT v);
-        STDMETHODIMP SetRotation(int rotation);
-        STDMETHODIMP_(int) GetRotation();
         STDMETHODIMP_(SIZE) GetVideoSize(bool bCorrectAR) const;
-        STDMETHODIMP_(bool) Paint(bool bAll);
-        STDMETHODIMP GetDIB(BYTE* lpDib, DWORD* size);
-		STDMETHODIMP GetDisplayedImage(LPVOID* dibImage);
+		STDMETHODIMP_(void) SetPosition(RECT w, RECT v) override;
+		STDMETHODIMP_(bool) Paint(bool bAll) override;
+		STDMETHODIMP GetDIB(BYTE* lpDib, DWORD* size) override;
+		STDMETHODIMP GetDisplayedImage(LPVOID* dibImage) override;
         STDMETHODIMP SetPixelShader(LPCSTR pSrcData, LPCSTR pTarget);
-		STDMETHODIMP_(bool) DisplayChange() override;
-        STDMETHODIMP_(bool) IsRendering();
+        STDMETHODIMP_(bool) DisplayChange() override;
+		STDMETHODIMP_(bool) IsRendering() override;
+        // ISubPicAllocatorPresenter3
+		STDMETHODIMP SetRotation(int rotation) override;
+		STDMETHODIMP_(int) GetRotation() override;
+		STDMETHODIMP_(int) GetPixelShaderMode() override;
+		STDMETHODIMP ClearPixelShaders(int target) override;
+		STDMETHODIMP AddPixelShader(int target, LPCWSTR name, LPCSTR profile, LPCSTR sourceCode) override;
+        STDMETHODIMP_(bool) ToggleStats() override;
     };
 }

--- a/src/filters/renderer/VideoRenderers/madVRAllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/madVRAllocatorPresenter.h
@@ -28,7 +28,8 @@ namespace DSObjects
     class CmadVRAllocatorPresenter : public CSubPicAllocatorPresenterImpl, ISubRenderCallback4
     {
         CComPtr<IUnknown> m_pMVR;
-
+        wchar_t debugShortcut[1024];
+        bool debugShortcutDisabled;
     public:
         CmadVRAllocatorPresenter(HWND hWnd, HRESULT& hr, CString& _Error);
         virtual ~CmadVRAllocatorPresenter();
@@ -79,5 +80,12 @@ namespace DSObjects
 
         // ISubPicAllocatorPresenter2
         STDMETHODIMP_(bool) IsRendering() override;
+        // ISubPicAllocatorPresenter3
+		STDMETHODIMP SetRotation(int rotation) override;
+		STDMETHODIMP_(int) GetRotation() override;
+		STDMETHODIMP_(int) GetPixelShaderMode() override { return 9; }
+		STDMETHODIMP ClearPixelShaders(int target) override;
+		STDMETHODIMP AddPixelShader(int target, LPCWSTR name, LPCSTR profile, LPCSTR sourceCode) override;
+        STDMETHODIMP_(bool) ToggleStats() override;
     };
 }

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -189,6 +189,18 @@ enum DVB_StopFilterGraph {
     DVB_STOP_FG_ALWAYS
 };
 
+struct ShaderC {
+	CString   label;
+	CString   profile;
+	CString   srcdata;
+	ULONGLONG length = 0;
+	FILETIME  ftwrite = {0,0};
+
+	bool Match(LPCWSTR _label, const bool _bD3D11) const {
+		return (label.CompareNoCase(_label) == 0 && (_bD3D11 == (profile == "ps_4_0")));
+	}
+};
+
 struct DisplayMode {
     bool  bValid = false;
     CSize size;

--- a/src/mpc-hc/CMPCThemeHeaderCtrl.cpp
+++ b/src/mpc-hc/CMPCThemeHeaderCtrl.cpp
@@ -2,7 +2,6 @@
 #include "CMPCThemeHeaderCtrl.h"
 #include "CMPCTheme.h"
 #include "CMPCThemeUtil.h"
-#include <lcms2\library\include\lcms2.h>
 
 CMPCThemeHeaderCtrl::CMPCThemeHeaderCtrl()
 {

--- a/src/mpc-hc/ColorProfileUtil.cpp
+++ b/src/mpc-hc/ColorProfileUtil.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "ColorProfileUtil.h"
+#pragma warning(disable: 5033) // warning C5033: 'register' is no longer a supported storage class
 #include "lcms2/library/include/lcms2.h"
 #include "MainFrm.h"
 #include "Icm.h"

--- a/src/mpc-hc/FGFilter.cpp
+++ b/src/mpc-hc/FGFilter.cpp
@@ -518,6 +518,9 @@ HRESULT CFGFilterVideoRenderer::Create(IBaseFilter** ppBF, CInterfaceList<IUnkno
         if (CComQIPtr<ISubPicAllocatorPresenter2> pCAP2 = pCAP) {
             pUnks.AddTail(pCAP2);
         }
+        if (CComQIPtr<ISubPicAllocatorPresenter3> pCAP3 = pCAP) {
+            pUnks.AddTail(pCAP3);
+        }
     }
 
     CheckPointer(*ppBF, E_FAIL);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1601,8 +1601,6 @@ void CMainFrame::OnDisplayChange() // untested, not sure if it's working...
 {
     TRACE(_T("*** CMainFrame::OnDisplayChange()\n"));
 
-    const CAppSettings& s = AfxGetAppSettings();
-
     if (GetLoadState() == MLS::LOADED) {
         if (m_pGraphThread) {
             CAMMsgEvent e;
@@ -5817,7 +5815,9 @@ void CMainFrame::OnUpdateViewDisplayRendererStats(CCmdUI* pCmdUI)
     const CAppSettings& s = AfxGetAppSettings();
     bool supported = (s.iDSVideoRendererType == VIDRNDT_DS_VMR9RENDERLESS
                       || s.iDSVideoRendererType == VIDRNDT_DS_EVR_CUSTOM
-                      || s.iDSVideoRendererType == VIDRNDT_DS_SYNC);
+                      || s.iDSVideoRendererType == VIDRNDT_DS_SYNC
+                      || s.iDSVideoRendererType == VIDRNDT_DS_MADVR
+                      || s.iDSVideoRendererType == VIDRNDT_DS_MPCVR);
 
     pCmdUI->Enable(supported && GetLoadState() == MLS::LOADED && !m_fAudioOnly);
     pCmdUI->SetCheck(supported && AfxGetMyApp()->m_Renderers.m_iDisplayStats);
@@ -5833,9 +5833,16 @@ void CMainFrame::OnViewDisplayRendererStats()
     const CAppSettings& s = AfxGetAppSettings();
     bool supported = (s.iDSVideoRendererType == VIDRNDT_DS_VMR9RENDERLESS
                       || s.iDSVideoRendererType == VIDRNDT_DS_EVR_CUSTOM
-                      || s.iDSVideoRendererType == VIDRNDT_DS_SYNC);
+                      || s.iDSVideoRendererType == VIDRNDT_DS_SYNC
+                      || s.iDSVideoRendererType == VIDRNDT_DS_MADVR
+                      || s.iDSVideoRendererType == VIDRNDT_DS_MPCVR);
 
     if (supported) {
+        if (m_pCAP3) {
+            m_pCAP3->ToggleStats();
+            return;
+        }
+
         if (!AfxGetMyApp()->m_Renderers.m_iDisplayStats) {
             AfxGetMyApp()->m_Renderers.m_bResetStats = true; // to reset statistics on first call ...
         }
@@ -7247,11 +7254,8 @@ void CMainFrame::OnViewRotate(UINT nID)
 {
     HRESULT hr = E_NOTIMPL;
 
-    if (m_pMVRC && m_pMVRI) {
-        int rotation;
-        if (FAILED(m_pMVRI->GetInt("rotation", &rotation))) {
-            return;
-        }
+    if (m_pCAP3) {
+        int rotation = m_pCAP3->GetRotation();
 
         switch (nID) {
             case ID_PANSCAN_ROTATEZP:
@@ -7267,7 +7271,11 @@ void CMainFrame::OnViewRotate(UINT nID)
         rotation %= 360;
         ASSERT(rotation >= 0);
 
-        if (SUCCEEDED(hr = m_pMVRC->SendCommandInt("rotate", rotation))) {
+        hr = m_pCAP3->SetRotation(rotation);
+        if (!m_pMVRC) {
+            MoveVideoWindow(); // need for EVRcp and Sync renderer, also mpcvr
+        }
+        if (S_OK == hr) {
             m_AngleZ = (360 - rotation) % 360;
         }
     } else if (m_pCAP) {
@@ -7345,7 +7353,7 @@ void CMainFrame::OnViewRotate(UINT nID)
 
 void CMainFrame::OnUpdateViewRotate(CCmdUI* pCmdUI)
 {
-    pCmdUI->Enable(GetLoadState() == MLS::LOADED && !m_fAudioOnly && (m_pCAP || (m_pMVRC && m_pMVRI)));
+    pCmdUI->Enable(GetLoadState() == MLS::LOADED && !m_fAudioOnly && (m_pCAP || m_pCAP3));
 }
 
 // FIXME
@@ -10927,6 +10935,144 @@ void CMainFrame::RepaintVideo()
     }
 }
 
+ShaderC* CMainFrame::GetShader(CString path)
+{
+	ShaderC* pShader = nullptr;
+
+	for (auto& shader : m_ShaderCache) {
+		if (shader.Match(path, false)) {
+			pShader = &shader;
+			break;
+		}
+	}
+
+	if (!pShader) {
+		if (::PathFileExistsW(path)) {
+			CStdioFile file;
+			if (file.Open(path, CFile::modeRead | CFile::shareDenyWrite | CFile::typeText)) {
+				ShaderC shader;
+				shader.label = path;
+
+				CString str;
+				file.ReadString(str); // read first string
+				if (str.Left(25) == L"// $MinimumShaderProfile:") {
+					shader.profile = str.Mid(25).Trim(); // shader version property
+				} else {
+					file.SeekToBegin();
+				}
+
+				if (shader.profile == L"ps_3_sw") {
+					shader.profile = L"ps_3_0";
+				} else if (shader.profile != L"ps_2_0"
+						&& shader.profile != L"ps_2_a"
+						&& shader.profile != L"ps_2_b"
+						&& shader.profile != L"ps_3_0") {
+					shader.profile = L"ps_2_0";
+				}
+
+				while (file.ReadString(str)) {
+					shader.srcdata += str + L"\n";
+				}
+
+				shader.length = file.GetLength();
+
+				FILETIME ftCreate, ftAccess, ftWrite;
+				if (GetFileTime(file.m_hFile, &ftCreate, &ftAccess, &ftWrite)) {
+					shader.ftwrite = ftWrite;
+				}
+
+				file.Close();
+
+				m_ShaderCache.push_back(shader);
+				pShader = &m_ShaderCache.back();
+			}
+		}
+	}
+
+	return pShader;
+}
+
+bool CMainFrame::SaveShaderFile(ShaderC* shader)
+{
+	CString path;
+	if (AfxGetMyApp()->GetAppSavePath(path)) {
+		path.AppendFormat(L"Shaders\\%s.hlsl", shader->label);
+
+		CStdioFile file;
+		if (file.Open(path, CFile::modeWrite  | CFile::shareExclusive | CFile::typeText)) {
+			file.SetLength(0);
+
+			CString str;
+			str.Format(L"// $MinimumShaderProfile: %s\n", shader->profile);
+			file.WriteString(str);
+
+			file.WriteString(shader->srcdata);
+			file.Close();
+
+			// delete out-of-date data from the cache
+			for (auto it = m_ShaderCache.begin(), end = m_ShaderCache.end(); it != end; ++it) {
+				if (it->Match(shader->label, false)) {
+					m_ShaderCache.erase(it);
+					break;
+				}
+			}
+
+			return true;
+		}
+	}
+	return false;
+}
+
+bool CMainFrame::DeleteShaderFile(LPCWSTR label)
+{
+	CString path;
+	if (AfxGetMyApp()->GetAppSavePath(path)) {
+		path.AppendFormat(L"Shaders\\%s.hlsl", label);
+
+		if (!::PathFileExistsW(path) || ::DeleteFileW(path)) {
+			// if the file is missing or deleted successfully, then remove it from the cache
+			for (auto it = m_ShaderCache.begin(), end = m_ShaderCache.end(); it != end; ++it) {
+				if (it->Match(label, false)) {
+					m_ShaderCache.erase(it);
+					return true;
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
+void CMainFrame::TidyShaderCashe()
+{
+	CString appsavepath;
+	if (!AfxGetMyApp()->GetAppSavePath(appsavepath)) {
+		return;
+	}
+
+	for (auto it = m_ShaderCache.cbegin(); it != m_ShaderCache.cend(); ) {
+		CString path(appsavepath);
+		path += L"Shaders\\";
+		path += (*it).label + L".hlsl";
+
+		CFile file;
+		if (file.Open(path, CFile::modeRead | CFile::modeCreate | CFile::shareDenyNone)) {
+			ULONGLONG length = file.GetLength();
+			FILETIME ftCreate = {}, ftAccess = {}, ftWrite = {};
+			GetFileTime(file.m_hFile, &ftCreate, &ftAccess, &ftWrite);
+
+			file.Close();
+
+			if ((*it).length == length && CompareFileTime(&(*it).ftwrite, &ftWrite) == 0) {
+				it++;
+				continue; // actual shader
+			}
+		}
+
+		m_ShaderCache.erase(it++); // outdated shader
+	}
+}
+
 void CMainFrame::SetShaders(bool bSetPreResize/* = true*/, bool bSetPostResize/* = true*/)
 {
     if (GetLoadState() != MLS::LOADED) {
@@ -10936,10 +11082,48 @@ void CMainFrame::SetShaders(bool bSetPreResize/* = true*/, bool bSetPostResize/*
     const auto& s = AfxGetAppSettings();
     bool preFailed = false, postFailed = false;
 
-    // When pTarget parameter of ISubPicAllocatorPresenter2::SetPixelShader2() is nullptr,
-    // internal video renderers select maximum available profile and madVR (the only external renderer that
-    // supports shader part of ISubPicAllocatorPresenter2 interface) seems to ignore it altogether.
-    if (m_pCAP2) {
+    if (m_pCAP3) { //interfaces for madVR and MPC-VR
+        const int PShaderMode = m_pCAP3->GetPixelShaderMode();
+        if (PShaderMode != 9) {
+            return;
+        }
+
+        if (bSetPreResize) {
+            m_pCAP3->ClearPixelShaders(TARGET_FRAME);
+            for (const auto& shader : s.m_Shaders.GetCurrentPreset().GetPreResize()) {
+                ShaderC* pShader = GetShader(shader.filePath);
+                if (pShader) {
+                    CStringW label = pShader->label;
+                    CStringA profile = pShader->profile;
+                    CStringA srcdata = pShader->srcdata;
+                    if (FAILED(m_pCAP3->AddPixelShader(TARGET_FRAME, label, profile, srcdata))) {
+                        preFailed=true;
+                        m_pCAP3->ClearPixelShaders(TARGET_FRAME);
+                        break;
+                    }
+                }
+            }
+        }
+        if (bSetPostResize) {
+            m_pCAP3->ClearPixelShaders(TARGET_SCREEN);
+            for (const auto& shader : s.m_Shaders.GetCurrentPreset().GetPostResize()) {
+                ShaderC* pShader = GetShader(shader.filePath);
+                if (pShader) {
+                    CStringW label = pShader->label;
+                    CStringA profile = pShader->profile;
+                    CStringA srcdata = pShader->srcdata;
+                    if (FAILED(m_pCAP3->AddPixelShader(TARGET_SCREEN, label, profile, srcdata))) {
+                        postFailed = true;
+                        m_pCAP3->ClearPixelShaders(TARGET_SCREEN);
+                        break;
+                    }
+                }
+            }
+        }
+    } else if (m_pCAP2) {
+        // When pTarget parameter of ISubPicAllocatorPresenter2::SetPixelShader2() is nullptr,
+        // internal video renderers select maximum available profile and madVR (the only external renderer that
+        // supports shader part of ISubPicAllocatorPresenter2 interface) seems to ignore it altogether.
         if (bSetPreResize) {
             m_pCAP2->SetPixelShader2(nullptr, nullptr, false);
             for (const auto& shader : s.m_Shaders.GetCurrentPreset().GetPreResize()) {
@@ -12571,6 +12755,7 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
             throw (UINT)IDS_INVALID_PARAMS_ERROR;
         }
 
+        m_pCAP3 = nullptr;
         m_pCAP2 = nullptr;
         m_pCAP = nullptr;
 
@@ -12580,6 +12765,7 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
 
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP), TRUE);
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP2), TRUE);
+        m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP3), TRUE);
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRWC), FALSE); // might have IVMRMixerBitmap9, but not IVMRWindowlessControl9
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRMC), TRUE);
         m_pGB->FindInterface(IID_PPV_ARGS(&pVMB), TRUE);
@@ -12775,6 +12961,7 @@ void CMainFrame::CloseMediaPrivate()
     m_pMVRS.Release();
     m_pMVRC.Release();
     m_pMVRI.Release();
+    m_pCAP3.Release();
     m_pCAP2.Release();
     m_pCAP.Release();
     m_pVMRWC.Release();
@@ -15110,6 +15297,7 @@ bool CMainFrame::BuildGraphVideoAudio(int fVPreview, bool fVCapture, int fAPrevi
             m_pMVRSR.Release();
 
             m_OSD.Stop();
+            m_pCAP3.Release();
             m_pCAP2.Release();
             m_pCAP.Release();
             m_pVMRWC.Release();
@@ -15122,6 +15310,7 @@ bool CMainFrame::BuildGraphVideoAudio(int fVPreview, bool fVCapture, int fAPrevi
 
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP), TRUE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP2), TRUE);
+            m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP3), TRUE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRWC), FALSE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRMC), TRUE);
             m_pGB->FindInterface(IID_PPV_ARGS(&pVMB), TRUE);

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -225,6 +225,7 @@ private:
 
     CComPtr<ISubPicAllocatorPresenter> m_pCAP;
     CComPtr<ISubPicAllocatorPresenter2> m_pCAP2;
+    CComPtr<ISubPicAllocatorPresenter3> m_pCAP3; //ported from mpc-be. in use for mpcvr and madvr
 
     CComPtr<IMadVRSettings> m_pMVRS;
     CComPtr<IMadVRSubclassReplacement> m_pMVRSR;
@@ -578,6 +579,12 @@ public:
 
     // shaders
     void SetShaders(bool bSetPreResize = true, bool bSetPostResize = true);
+	
+	std::list<ShaderC> m_ShaderCache;
+	ShaderC* GetShader(CString path);
+	bool SaveShaderFile(ShaderC* shader);
+	bool DeleteShaderFile(LPCWSTR label);
+	void TidyShaderCashe();
 
     // capturing
     bool m_fCapturing;

--- a/src/thirdparty/sanear/src/AudioDevice.h
+++ b/src/thirdparty/sanear/src/AudioDevice.h
@@ -2,6 +2,7 @@
 
 #include "DspChunk.h"
 #include "DspFormat.h"
+#include <memory>
 
 namespace SaneAudioRenderer
 {
@@ -90,7 +91,7 @@ namespace SaneAudioRenderer
 
         bool CheckLastInstances()
         {
-            if (!m_backend.unique())
+            if (m_backend.use_count() != 1)
                 return false;
 
             if (m_backend->audioClock && !IsLastInstance(m_backend->audioClock))

--- a/src/thirdparty/sanear/src/AudioDevice.h
+++ b/src/thirdparty/sanear/src/AudioDevice.h
@@ -2,7 +2,6 @@
 
 #include "DspChunk.h"
 #include "DspFormat.h"
-#include <memory>
 
 namespace SaneAudioRenderer
 {


### PR DESCRIPTION
1. Shaders (post-size only works)
2. OSD
3. Stats
4. Rotate

I implemented some of ISubPicAllocatorPresenter3 from mpc-be, but instead of replacing ISubPicAllocatorPresenter, I extended ISubPicAllocatorPresenter2 and added some of the new features there for madVR and MPC-VR.

One thing in here is support for the CTRL+J shortcut for madVR.  It works by temporarily disabling the madVR shortcut and reenabling it after.  I could not get the madVR shortcut to work in mpc-hc.  I'm not sure why, as it works in mpc-be.  But the stats are supported via that shortcut with this code.

Many people have reported issues with the madVR shortcut but it seems to affect different people differently.  At least CTRL+J (or whatever mpc-hc shortcut is set to) now works reliably.