### PR TITLE
support dx11 shaders in mpcvr

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -10963,7 +10963,7 @@ void CMainFrame::RepaintVideo()
     }
 }
 
-ShaderC* CMainFrame::GetShader(CString path)
+ShaderC* CMainFrame::GetShader(CString path, bool bD3D11)
 {
 	ShaderC* pShader = nullptr;
 
@@ -10989,7 +10989,9 @@ ShaderC* CMainFrame::GetShader(CString path)
 					file.SeekToBegin();
 				}
 
-				if (shader.profile == L"ps_3_sw") {
+                if (bD3D11) {
+                    shader.profile = L"ps_4_0";
+                } else if (shader.profile == L"ps_3_sw") {
 					shader.profile = L"ps_3_0";
 				} else if (shader.profile != L"ps_2_0"
 						&& shader.profile != L"ps_2_a"
@@ -11112,14 +11114,14 @@ void CMainFrame::SetShaders(bool bSetPreResize/* = true*/, bool bSetPostResize/*
 
     if (m_pCAP3) { //interfaces for madVR and MPC-VR
         const int PShaderMode = m_pCAP3->GetPixelShaderMode();
-        if (PShaderMode != 9) {
+        if (PShaderMode != 9 && PShaderMode != 11) {
             return;
         }
 
         if (bSetPreResize) {
             m_pCAP3->ClearPixelShaders(TARGET_FRAME);
             for (const auto& shader : s.m_Shaders.GetCurrentPreset().GetPreResize()) {
-                ShaderC* pShader = GetShader(shader.filePath);
+                ShaderC* pShader = GetShader(shader.filePath, PShaderMode == 11);
                 if (pShader) {
                     CStringW label = pShader->label;
                     CStringA profile = pShader->profile;
@@ -11135,7 +11137,7 @@ void CMainFrame::SetShaders(bool bSetPreResize/* = true*/, bool bSetPostResize/*
         if (bSetPostResize) {
             m_pCAP3->ClearPixelShaders(TARGET_SCREEN);
             for (const auto& shader : s.m_Shaders.GetCurrentPreset().GetPostResize()) {
-                ShaderC* pShader = GetShader(shader.filePath);
+                ShaderC* pShader = GetShader(shader.filePath, PShaderMode == 11);
                 if (pShader) {
                     CStringW label = pShader->label;
                     CStringA profile = pShader->profile;

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -580,7 +580,7 @@ public:
     void SetShaders(bool bSetPreResize = true, bool bSetPostResize = true);
 	
 	std::list<ShaderC> m_ShaderCache;
-	ShaderC* GetShader(CString path);
+	ShaderC* GetShader(CString path, bool bD3D11);
 	bool SaveShaderFile(ShaderC* shader);
 	bool DeleteShaderFile(LPCWSTR label);
 	void TidyShaderCashe();


### PR DESCRIPTION
@clsid2 , see if this works for dx11 shaders in windows 7.  It works for me in Windows 10 (didn't previously).

mpc-be stores default shaders in the appdata folder, with one folder for dx11.  But the shader editor only works on dx9.  If you switch to dx11 it will use the appropriate shader, but for custom ones it would be missing.

If the renderer is in dx11 mode, it would be good to have the stock shaders available in dx11 mode.  But currently there's no good interface for dealing with custom shaders between versions.  So right now, the shader will just fail unless it is the right type.