### PR TITLE
avoid error with c++17 deprecation warning (treated as error)

### DIFF
--- a/src/mpc-hc/Translations.cpp
+++ b/src/mpc-hc/Translations.cpp
@@ -26,7 +26,7 @@
 
 namespace
 {
-    static_assert(std::is_pod<Translations::LanguageResource>::value, "POD type is expected.");
+    static_assert(std::is_standard_layout<Translations::LanguageResource>::value, "POD type is expected.");
 
     constexpr Translations::LanguageResource languageResources[] = {
         { 1025,   _T("Arabic"),                   _T("Lang\\mpcresources.ar.dll")    },


### PR DESCRIPTION
is_pod is deprecated as of c++20.  However, with current build settings, this is now a warning treated as error on VS2019.  I believe is_standard_layout is the intended use, here.