### PR TITLE
restore lost code when fixing indent

### DIFF
--- a/src/SubPic/SubPicQueueImpl.cpp
+++ b/src/SubPic/SubPicQueueImpl.cpp
@@ -551,7 +551,7 @@ DWORD CSubPicQueue::ThreadProc()
                 }
 
                 REFERENCE_TIME rtCurrent = std::max(rtStart, rtStartRendering);
-                if (rtCurrent - m_rtNow > rtStop - rtStart) {
+                if (rtCurrent > m_rtNow && rtTimePerFrame <= rtStop - rtStart) {
                     // Round current time to the next estimated video frame timing
                     REFERENCE_TIME rtCurrentRounded = (rtCurrent / rtTimePerFrame) * rtTimePerFrame;
                     if (rtCurrentRounded < rtCurrent) {


### PR DESCRIPTION
I just noticed when I fixed the indent, a bad copy of that line was used instead of the working code--fixed here.