### PR TITLE
unsorted chapters

### DIFF
--- a/src/DSUtil/DSMPropertyBag.cpp
+++ b/src/DSUtil/DSMPropertyBag.cpp
@@ -419,8 +419,7 @@ STDMETHODIMP IDSMChapterBagImpl::ChapRemoveAll()
     return S_OK;
 }
 
-STDMETHODIMP_(long) IDSMChapterBagImpl::ChapLookup(REFERENCE_TIME* prt, BSTR* ppName)
-{
+STDMETHODIMP_(long) IDSMChapterBagImpl::ChapLookup(REFERENCE_TIME* prt, BSTR* ppName) {
     CheckPointer(prt, -1);
 
     ChapSort();
@@ -433,6 +432,29 @@ STDMETHODIMP_(long) IDSMChapterBagImpl::ChapLookup(REFERENCE_TIME* prt, BSTR* pp
         }
     }
     return (long)i;
+}
+
+STDMETHODIMP_(long) IDSMChapterBagImpl::ChapLookupUnsorted(REFERENCE_TIME* prt, BSTR* ppName) {
+    CheckPointer(prt, -1);
+
+    CAtlArray<CDSMChapter> mm;
+    mm.Copy(m_chapters);
+    std::sort(mm.GetData(), mm.GetData() + mm.GetCount());
+
+    size_t mmI = range_bsearch(mm, *prt);
+    if (mmI != MAXSIZE_T) {
+        size_t i;
+        for (i = 0; i < m_chapters.GetCount(); i++) {
+            if (m_chapters[i].rt == mm[mmI].rt && m_chapters[i].name.Compare(mm[mmI].name)==0) {
+                *prt = m_chapters[i].rt;
+                if (ppName) {
+                    *ppName = m_chapters[i].name.AllocSysString();
+                }
+                return i;
+            }
+        }
+    }
+    return (long)MAXSIZE_T;
 }
 
 STDMETHODIMP IDSMChapterBagImpl::ChapSort()

--- a/src/DSUtil/DSMPropertyBag.h
+++ b/src/DSUtil/DSMPropertyBag.h
@@ -139,6 +139,7 @@ interface __declspec(uuid("2D0EBE73-BA82-4E90-859B-C7C48ED3650F"))
     STDMETHOD(ChapRemoveAt)(DWORD iIndex) PURE;
     STDMETHOD(ChapRemoveAll)() PURE;
     STDMETHOD_(long, ChapLookup)(REFERENCE_TIME* prt, BSTR* ppName) PURE;
+    STDMETHOD_(long, ChapLookupUnsorted)(REFERENCE_TIME* prt, BSTR* ppName) PURE;
     STDMETHOD(ChapSort)() PURE;
 };
 
@@ -179,6 +180,7 @@ public:
     STDMETHODIMP ChapRemoveAt(DWORD iIndex);
     STDMETHODIMP ChapRemoveAll();
     STDMETHODIMP_(long) ChapLookup(REFERENCE_TIME* prt, BSTR* ppName = nullptr);
+    STDMETHODIMP_(long) ChapLookupUnsorted(REFERENCE_TIME* prt, BSTR* ppName = nullptr);
     STDMETHODIMP ChapSort();
 };
 

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -11851,7 +11851,7 @@ void CMainFrame::SetupChapters()
         EndEnumPins;
     }
 
-    m_pCB->ChapSort();
+    //m_pCB->ChapSort();
 
     UpdateSeekbarChapterBag();
 }
@@ -14128,7 +14128,7 @@ void CMainFrame::SetupJumpToSubMenus(CMenu* parentMenu /*= nullptr*/, int iInser
 
         SetupChapters();
         REFERENCE_TIME rt = GetPos();
-        DWORD j = m_pCB->ChapLookup(&rt, nullptr);
+        DWORD j = m_pCB->ChapLookupUnsorted(&rt, nullptr);
 
         if (m_pCB->ChapGetCount() > 1) {
             menuStartRadioSection();


### PR DESCRIPTION
This is probably not complete.  However, I created some basic implementation code that allows for unsorted chapters and finding elements.  For DVD, I did not use this implementation, assuming it would work fine sorted.

Maybe you can identify some areas where it breaks and I can try to fix it.  It's possible all we need to do is call the "unsorted" finder everywhere, and stop sorting entirely.

I kept the "sorting" logic by sorting a copy of the array and finding the same element that would have been found, and then doing my best to match by timestamp and title within the unsorted array.  It's possible this is inadequate for identical titles and timestamps ("Chapter 1" @ 1:01), so adding in the chapter ID might be a better test.