### PR TITLE
show decoded urls in recent files

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -14479,7 +14479,13 @@ void CMainFrame::SetupRecentFilesSubMenu()
         for (int i = 0; i < MRU.GetSize(); i++) {
             UINT flags = MF_BYCOMMAND | MF_STRING | MF_ENABLED;
             if (!MRU[i].IsEmpty()) {
-                VERIFY(subMenu.AppendMenu(flags, id, MRU[i]));
+                CString p = MRU[i];
+                bool isURL = (-1 != p.Find(_T("://")));
+                if (isURL) {
+                    VERIFY(subMenu.AppendMenu(flags, id, UrlDecodeWithUTF8(p)));
+                } else {
+                    VERIFY(subMenu.AppendMenu(flags, id, p));
+                }
             }
             id++;
         }


### PR DESCRIPTION
I had some concern that it might re-use the decoded string when clicking on it, rather than the MRU data.  It does seem to work that way, actually, but the URLs still seem to be ok.  Hopefully it is url encoding before sending, which should avoid any issue.

