### PR TITLE
do not auto fullscreen for audio files

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -10078,9 +10078,9 @@ void CMainFrame::SetDefaultFullscreenState()
 {
     CAppSettings& s = AfxGetAppSettings();
 
-    // Waffs : fullscreen command line
+    bool clGoFullscreen = !(s.nCLSwitches & CLSW_ADD) && (s.nCLSwitches & CLSW_FULLSCREEN);
     bool foundVideoFiles = false;
-    if (!s.slFiles.IsEmpty()) {
+    if (clGoFullscreen && !s.slFiles.IsEmpty()) {
         const CMediaFormats& mf = AfxGetAppSettings().m_Formats;
         POSITION pos = s.slFiles.GetHeadPosition();
         while (pos) {
@@ -10092,7 +10092,7 @@ void CMainFrame::SetDefaultFullscreenState()
         }
     }
 
-    if (!(s.nCLSwitches & CLSW_ADD) && (s.nCLSwitches & CLSW_FULLSCREEN) && foundVideoFiles) {
+    if (clGoFullscreen && foundVideoFiles) {
         if (s.IsD3DFullscreen()) {
             m_fStartInD3DFullscreen = true;
         } else {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -10086,7 +10086,7 @@ void CMainFrame::SetDefaultFullscreenState()
         while (pos) {
             CString fpath = s.slFiles.GetNext(pos);
             CString ext = fpath.Mid(fpath.ReverseFind('.'));
-            if (!mf.FindExt(ext, true)) {
+            if (!mf.FindExt(ext, true) && mf.FindExt(ext)) {
                 foundVideoFiles = true;
             }
         }

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -10079,7 +10079,20 @@ void CMainFrame::SetDefaultFullscreenState()
     CAppSettings& s = AfxGetAppSettings();
 
     // Waffs : fullscreen command line
-    if (!(s.nCLSwitches & CLSW_ADD) && (s.nCLSwitches & CLSW_FULLSCREEN) && !s.slFiles.IsEmpty()) {
+    bool foundVideoFiles = false;
+    if (!s.slFiles.IsEmpty()) {
+        const CMediaFormats& mf = AfxGetAppSettings().m_Formats;
+        POSITION pos = s.slFiles.GetHeadPosition();
+        while (pos) {
+            CString fpath = s.slFiles.GetNext(pos);
+            CString ext = fpath.Mid(fpath.ReverseFind('.'));
+            if (!mf.FindExt(ext, true)) {
+                foundVideoFiles = true;
+            }
+        }
+    }
+
+    if (!(s.nCLSwitches & CLSW_ADD) && (s.nCLSwitches & CLSW_FULLSCREEN) && foundVideoFiles) {
         if (s.IsD3DFullscreen()) {
             m_fStartInD3DFullscreen = true;
         } else {


### PR DESCRIPTION
It still could fullscreen if the player was previously full-screen.  That could be stopped, too, but maybe we should honor last position.