### PR TITLE
Patch150

### DIFF
--- a/src/mpc-hc/PlayerInfoBar.cpp
+++ b/src/mpc-hc/PlayerInfoBar.cpp
@@ -68,10 +68,12 @@ bool CPlayerInfoBar::SetLine(CString label, CString info)
 
     CAutoPtr<CStatusLabel> l(DEBUG_NEW CStatusLabel(m_pMainFrame->m_dpi, true, false));
     l->Create(label, WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | SS_OWNERDRAW, CRect(0, 0, 0, 0), this);
+    l->ScaleFont(GetFont(), m_pMainFrame->m_dpi);
     m_label.Add(l);
 
     CAutoPtr<CStatusLabel> i(DEBUG_NEW CStatusLabel(m_pMainFrame->m_dpi, false, true));
     i->Create(info, WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | SS_OWNERDRAW | SS_NOTIFY, CRect(0, 0, 0, 0), this);
+    i->ScaleFont(GetFont(), m_pMainFrame->m_dpi);
     if (usetheme) {
         themedToolTip.AddTool(i, info);
     } else {
@@ -175,10 +177,10 @@ void CPlayerInfoBar::EventCallback(MpcEvent ev)
     switch (ev) {
         case MpcEvent::DPI_CHANGED:
             for (size_t i = 0; i < m_label.GetCount(); i++) {
-                m_label[i]->ScaleFont(m_pMainFrame->m_dpi);
+                m_label[i]->ScaleFont(GetFont(), m_pMainFrame->m_dpi);
             }
             for (size_t i = 0; i < m_info.GetCount(); i++) {
-                m_info[i]->ScaleFont(m_pMainFrame->m_dpi);
+                m_info[i]->ScaleFont(GetFont(), m_pMainFrame->m_dpi);
             }
             break;
 

--- a/src/mpc-hc/PlayerStatusBar.cpp
+++ b/src/mpc-hc/PlayerStatusBar.cpp
@@ -55,6 +55,9 @@ CPlayerStatusBar::~CPlayerStatusBar()
 BOOL CPlayerStatusBar::Create(CWnd* pParentWnd)
 {
     BOOL ret = CDialogBar::Create(pParentWnd, IDD_PLAYERSTATUSBAR, WS_CHILD | WS_VISIBLE | CBRS_ALIGN_BOTTOM, IDD_PLAYERSTATUSBAR);
+    m_type.SetFont(GetFont());
+    m_status.ScaleFont(GetFont(), m_pMainFrame->m_dpi);
+    m_time.ScaleFont(GetFont(), m_pMainFrame->m_dpi);
 
     // Should never be RTLed
     ModifyStyleEx(WS_EX_LAYOUTRTL, WS_EX_NOINHERITLAYOUT);
@@ -128,8 +131,8 @@ void CPlayerStatusBar::EventCallback(MpcEvent ev)
 {
     switch (ev) {
         case MpcEvent::DPI_CHANGED:
-            m_status.ScaleFont(m_pMainFrame->m_dpi);
-            m_time.ScaleFont(m_pMainFrame->m_dpi);
+            m_status.ScaleFont(GetFont(), m_pMainFrame->m_dpi);
+            m_time.ScaleFont(GetFont(), m_pMainFrame->m_dpi);
             SetMediaTypeIcon();
             break;
 
@@ -162,7 +165,7 @@ void CPlayerStatusBar::Relayout()
 #endif
 
     if (CDC* pDC = m_time.GetDC()) {
-        CFont* pOld = pDC->SelectObject(&m_time.GetFont());
+        CFont* pOld = pDC->SelectObject(m_time.GetFont());
         m_time.GetWindowText(str);
         r2 = r;
         r2.left = r2.right - pDC->GetTextExtent(str).cx;
@@ -175,17 +178,16 @@ void CPlayerStatusBar::Relayout()
     }
 
     if (CDC* pDC = m_status.GetDC()) {
-        CFont* pOld = pDC->SelectObject(&m_status.GetFont());
         m_status.GetWindowText(str);
+        CSize cs = CMPCThemeUtil::GetTextSize(str, pDC, &m_status.GetScaledFont()); //GetTextExtent not accurate with extended characters
         r2 = r;
-        r2.right = r2.left + pDC->GetTextExtent(str).cx;
+        r2.right = r2.left + cs.cx;
         // If the text is too long, ensure it won't overlap
         // with the timer. Ellipses will be added if needed.
         if (r2.right >= m_time_rect.left) {
             r2.right = m_time_rect.left - 1;
         }
         m_status.MoveWindow(&r2, FALSE);
-        pDC->SelectObject(pOld);
         m_status.ReleaseDC(pDC);
     } else {
         ASSERT(FALSE);

--- a/src/mpc-hc/PlayerStatusBar.cpp
+++ b/src/mpc-hc/PlayerStatusBar.cpp
@@ -165,7 +165,7 @@ void CPlayerStatusBar::Relayout()
 #endif
 
     if (CDC* pDC = m_time.GetDC()) {
-        CFont* pOld = pDC->SelectObject(m_time.GetFont());
+        CFont* pOld = pDC->SelectObject(&m_time.GetScaledFont());
         m_time.GetWindowText(str);
         r2 = r;
         r2.left = r2.right - pDC->GetTextExtent(str).cx;

--- a/src/mpc-hc/StatusLabel.cpp
+++ b/src/mpc-hc/StatusLabel.cpp
@@ -43,10 +43,8 @@ void CStatusLabel::ScaleFont(CFont* f, const DpiHelper& dpiHelper)
 {
     m_font.DeleteObject();
     LOGFONT lf;
-    if (f && f->GetSafeHandle()) {
-        f->GetLogFont(&lf);
-    } else {
-        GetStatusFont(&lf);
+    if (!f || !f->GetSafeHandle() || !f->GetLogFont(&lf)) {
+        GetStatusFont(&lf); //fall back if we couldn't use passed font successfully
     }
 
     lf.lfHeight = dpiHelper.ScaleSystemToOverrideY(lf.lfHeight);

--- a/src/mpc-hc/StatusLabel.cpp
+++ b/src/mpc-hc/StatusLabel.cpp
@@ -32,18 +32,23 @@ CStatusLabel::CStatusLabel(const DpiHelper& dpiHelper, bool fRightAlign, bool fA
     : m_fRightAlign(fRightAlign)
     , m_fAddEllipses(fAddEllipses)
 {
-    ScaleFont(dpiHelper);
+    ScaleFont(nullptr, dpiHelper);
 }
 
 CStatusLabel::~CStatusLabel()
 {
 }
 
-void CStatusLabel::ScaleFont(const DpiHelper& dpiHelper)
+void CStatusLabel::ScaleFont(CFont* f, const DpiHelper& dpiHelper)
 {
     m_font.DeleteObject();
     LOGFONT lf;
-    GetStatusFont(&lf);
+    if (f && f->GetSafeHandle()) {
+        f->GetLogFont(&lf);
+    } else {
+        GetStatusFont(&lf);
+    }
+
     lf.lfHeight = dpiHelper.ScaleSystemToOverrideY(lf.lfHeight);
     VERIFY(m_font.CreateFontIndirect(&lf));
 }

--- a/src/mpc-hc/StatusLabel.h
+++ b/src/mpc-hc/StatusLabel.h
@@ -37,8 +37,8 @@ public:
     CStatusLabel(const DpiHelper& dpiHelper, bool fRightAlign, bool fAddEllipses);
     virtual ~CStatusLabel();
 
-    void ScaleFont(const DpiHelper& dpiHelper);
-    CFont& GetFont() { return m_font; }
+    void ScaleFont(CFont* f, const DpiHelper& dpiHelper);
+    CFont& GetScaledFont() { return m_font; }
 
     void DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct);
 


### PR DESCRIPTION
GetStatusFont only allows use of the system defined statusfont size.  This allows the class to follow the font size of its parent statusbar, instead.  By default, it should behave the same, but if you wanted to change or increase the font size, this would let you.