### PR TITLE
fallback to 639-1 lang tags when finding LCID

### DIFF
--- a/src/Subtitles/SubtitleInputPin.cpp
+++ b/src/Subtitles/SubtitleInputPin.cpp
@@ -103,8 +103,13 @@ HRESULT CSubtitleInputPin::CompleteConnect(IPin* pReceivePin)
         if (psi != nullptr) {
             dwOffset = psi->dwOffset;
 
-            name = ISOLang::ISO6392ToLanguage(psi->IsoLang);
             lcid = ISOLang::ISO6392ToLcid(psi->IsoLang);
+            if (0 == lcid) { //try 639-1 in case it comes from BCP-47 (contains mix of 639-1 and 639-2)
+                lcid = ISOLang::ISO6391ToLcid(psi->IsoLang);
+                name = ISOLang::ISO6391ToLanguage(psi->IsoLang);
+            } else {
+                name = ISOLang::ISO6392ToLanguage(psi->IsoLang);
+            }
 
             CString trackName(psi->TrackName);
             trackName.Trim();


### PR DESCRIPTION
See https://github.com/clsid2/mpc-hc/pull/627

I tracked the problem down to the zh-hans not successfully matching a 639-2 lang tag. It's a valid lang tag, actually, but (as it happens), not a valid Language tag in matroska.  Even so, it seems better to match something than nothing, and other containers may return 639-1 or BCP-47.  And with another patch I will submit, even LAVFilters can pull the supported BCP-47 tag from LanguageIETF.

We don't parse bcp-47 yet, but if it does get returned, it should *usually* match either 639-1 or 639-2.