### PR TITLE
Change Simplified Chinese font to default font on Simplified Chinese Windows: Microsoft YaHei

### DIFF
--- a/src/mpc-hc/mpcresources/cfg/mpc-hc.zh_CN.cfg
+++ b/src/mpc-hc/mpcresources/cfg/mpc-hc.zh_CN.cfg
@@ -5,4 +5,4 @@ langDefine: LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 langDefineMFC: AFX_TARG_CHS
 langID: 2052
 fileDesc: MPC-HC 简体中文资源
-font: FONT 8, "Microsoft YaHei UI", 400, 0, 0x0
+font: FONT 8, "Microsoft YaHei", 400, 0, 0x0

--- a/src/mpc-hc/mpcresources/cfg/mpc-hc.zh_CN.cfg
+++ b/src/mpc-hc/mpcresources/cfg/mpc-hc.zh_CN.cfg
@@ -5,4 +5,4 @@ langDefine: LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 langDefineMFC: AFX_TARG_CHS
 langID: 2052
 fileDesc: MPC-HC 简体中文资源
-font: FONT 8, "Tahoma", 400, 0, 0x0
+font: FONT 8, "Microsoft YaHei UI", 400, 0, 0x0


### PR DESCRIPTION
This will fix a bug on status bar.
♡ is display wrong in Tahoma, but works fine with Microsoft YaHei.
![image](https://user-images.githubusercontent.com/41434272/95571735-7c618680-0a5b-11eb-9c5f-998f9038e8b6.png)
Before fix
![image](https://user-images.githubusercontent.com/41434272/95573245-bdf33100-0a5d-11eb-96c8-9930386ed717.png)
After fix