### PR TITLE
UpdateChecker can use backup update URL

### DIFF
--- a/include/mpc-hc_config.h
+++ b/include/mpc-hc_config.h
@@ -34,6 +34,7 @@
 #define WEBSITE_URL  _T("https://github.com/clsid2/mpc-hc/releases")
 #define DOWNLOAD_URL _T("https://github.com/clsid2/mpc-hc/releases")
 #define UPDATE_URL   _T("https://github.com/clsid2/mpc-hc/raw/develop/version.txt")
+#define BACKUP_UPDATE_URL   _T("https://cdn.jsdelivr.net/gh/clsid2/mpc-hc@develop/version.txt")
 #define TRAC_URL     _T("https://github.com/clsid2/mpc-hc/issues")
 #define BUGS_URL     _T("https://github.com/clsid2/mpc-hc/issues")
 

--- a/src/mpc-hc/UpdateChecker.cpp
+++ b/src/mpc-hc/UpdateChecker.cpp
@@ -53,6 +53,13 @@ UpdateChecker::~UpdateChecker()
 
 Update_Status UpdateChecker::IsUpdateAvailable(const Version& currentVersion)
 {
+    Update_Status update_status = IsUpdateAvailable(currentVersion, false);
+    if (update_status == UPDATER_ERROR) update_status = IsUpdateAvailable(currentVersion, true);
+    return update_status;
+}
+
+Update_Status UpdateChecker::IsUpdateAvailable(const Version& currentVersion, bool useBackupURL)
+{
     Update_Status updateAvailable = UPDATER_LATEST_STABLE;
 
     try {
@@ -90,7 +97,11 @@ Update_Status UpdateChecker::IsUpdateAvailable(const Version& currentVersion)
         CString headers;
         headers.Format(headersFmt, osVersionStr.GetString());
 
-        CHttpFile* versionFile = (CHttpFile*) internet.OpenURL(versionFileURL,
+        CString fileURL;
+        if (useBackupURL) fileURL = BACKUP_UPDATE_URL;
+        else fileURL = versionFileURL;
+
+        CHttpFile* versionFile = (CHttpFile*) internet.OpenURL(fileURL,
                                                                1,
                                                                INTERNET_FLAG_TRANSFER_ASCII | INTERNET_FLAG_DONT_CACHE | INTERNET_FLAG_RELOAD,
                                                                headers,

--- a/src/mpc-hc/UpdateChecker.h
+++ b/src/mpc-hc/UpdateChecker.h
@@ -63,6 +63,7 @@ public:
     UpdateChecker(CString versionFileURL);
     ~UpdateChecker();
 
+    Update_Status IsUpdateAvailable(const Version& currentVersion, bool useBackupURL);
     Update_Status IsUpdateAvailable(const Version& currentVersion);
     Update_Status IsUpdateAvailable();
     const Version& GetLatestVersion() const { return latestVersion; };


### PR DESCRIPTION
In China mainland, raw.githubusercontent.com was blocked by [GFW](https://en.wikipedia.org/wiki/Great_Firewall), so the update check will be failed. This patch will add a backup update URL which is not blocked by GFW in China.