### PR TITLE
Update remove tags regex when opening WEBVTT file

### DIFF
--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -517,7 +517,7 @@ static bool OpenVTT(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet) {
                 std::string stdTmp(pszConvertedAnsiString);
                 //remove tags we don't support
                 stdTmp = std::regex_replace(stdTmp, std::regex("<c[.\\w\\d]*>"), "");
-                stdTmp = std::regex_replace(stdTmp, std::regex("</c>"), "");
+                stdTmp = std::regex_replace(stdTmp, std::regex("</c[.\\w\\d]*>"), "");
                 stdTmp = std::regex_replace(stdTmp, std::regex("<\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d>"), "");
                 stdTmp = std::regex_replace(stdTmp, std::regex("<v[ .][^>]*>"), "");
                 stdTmp = std::regex_replace(stdTmp, std::regex("</v>"), "");


### PR DESCRIPTION
The subtitles file. (Download from netflix.com)
[ReLIFE.zip](https://github.com/clsid2/mpc-hc/files/5384976/ReLIFE.zip)
Before fix:
![image](https://user-images.githubusercontent.com/41434272/96129062-b681cb00-0f28-11eb-8b31-f37ea706d652.png)
After fix:
![image](https://user-images.githubusercontent.com/41434272/96129080-beda0600-0f28-11eb-8439-99de2996f98f.png)
