### PR TITLE
fix theme issues for MPC-BE AR

### DIFF
--- a/src/mpc-hc/CMPCThemeInternalPropertyPageWnd.cpp
+++ b/src/mpc-hc/CMPCThemeInternalPropertyPageWnd.cpp
@@ -1,0 +1,29 @@
+#include "stdafx.h"
+#include "CMPCThemeInternalPropertyPageWnd.h"
+
+CMPCThemeInternalPropertyPageWnd::~CMPCThemeInternalPropertyPageWnd() {
+}
+BEGIN_MESSAGE_MAP(CMPCThemeInternalPropertyPageWnd, CInternalPropertyPageWnd)
+    ON_WM_CTLCOLOR()
+    ON_WM_ERASEBKGND()
+END_MESSAGE_MAP()
+
+
+HBRUSH CMPCThemeInternalPropertyPageWnd::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor) {
+    HBRUSH ret;
+    ret = getCtlColor(pDC, pWnd, nCtlColor);
+    if (nullptr != ret) {
+        return ret;
+    } else {
+        return __super::OnCtlColor(pDC, pWnd, nCtlColor);
+    }
+}
+
+BOOL CMPCThemeInternalPropertyPageWnd::OnEraseBkgnd(CDC* pDC) {
+    bool ret = MPCThemeEraseBkgnd(pDC, this, CTLCOLOR_DLG);
+    if (ret) {
+        return ret;
+    } else {
+        return __super::OnEraseBkgnd(pDC);
+    }
+}

--- a/src/mpc-hc/CMPCThemeInternalPropertyPageWnd.h
+++ b/src/mpc-hc/CMPCThemeInternalPropertyPageWnd.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "..\src\filters\InternalPropertyPage.h"
+#include "CMPCThemeUtil.h"
+
+class CMPCThemeInternalPropertyPageWnd :
+    public CInternalPropertyPageWnd
+    , public CMPCThemeUtil {
+
+    virtual ~CMPCThemeInternalPropertyPageWnd();
+public:
+    DECLARE_MESSAGE_MAP()
+    afx_msg HBRUSH OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor);
+    afx_msg BOOL OnEraseBkgnd(CDC* pDC);
+};
+

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -9,6 +9,7 @@
 #include "CMPCThemeTabCtrl.h"
 #include "VersionHelpersInternal.h"
 #include "CMPCThemeTitleBarControlButton.h"
+#include "CMPCThemeInternalPropertyPageWnd.h"
 #include "CMPCThemeWin10Api.h"
 #undef SubclassWindow
 
@@ -114,6 +115,9 @@ void CMPCThemeUtil::fulfillThemeReqs(CWnd* wnd)
                     makeThemed(pObject, tChild);
                 } else if (0 == _tcsicmp(windowClass, WC_TABCONTROL)) {
                     CMPCThemeTabCtrl* pObject = DEBUG_NEW CMPCThemeTabCtrl();
+                    makeThemed(pObject, tChild);
+                } else if (windowTitle == _T("CInternalPropertyPageWnd")) { //only seems to be needed for windows from external filters?
+                    CMPCThemeInternalPropertyPageWnd* pObject = DEBUG_NEW CMPCThemeInternalPropertyPageWnd();
                     makeThemed(pObject, tChild);
                 }
             }

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="CMPCThemeButton.cpp" />
     <ClCompile Include="CMPCThemeFrameUtil.cpp" />
     <ClCompile Include="CMPCThemeFrameWnd.cpp" />
+    <ClCompile Include="CMPCThemeInternalPropertyPageWnd.cpp" />
     <ClCompile Include="CMPCThemeMiniDockFrameWnd.cpp" />
     <ClCompile Include="CMPCThemeTitleBarControlButton.cpp" />
     <ClCompile Include="CMPCThemeUtil.cpp" />
@@ -328,6 +329,7 @@
     <ClInclude Include="CMPCThemeButton.h" />
     <ClInclude Include="CMPCThemeFrameUtil.h" />
     <ClInclude Include="CMPCThemeFrameWnd.h" />
+    <ClInclude Include="CMPCThemeInternalPropertyPageWnd.h" />
     <ClInclude Include="CMPCThemeMiniDockFrameWnd.h" />
     <ClInclude Include="CMPCThemeTitleBarControlButton.h" />
     <ClInclude Include="CMPCThemeUtil.h" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -602,6 +602,9 @@
       <Filter>MPCTheme</Filter>
     </ClCompile>
     <ClCompile Include="ColorProfileUtil.cpp" />
+    <ClCompile Include="CMPCThemeInternalPropertyPageWnd.cpp">
+      <Filter>MPCTheme</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AppSettings.h">
@@ -1137,6 +1140,9 @@
       <Filter>MPCTheme</Filter>
     </ClInclude>
     <ClInclude Include="ColorProfileUtil.h" />
+    <ClInclude Include="CMPCThemeInternalPropertyPageWnd.h">
+      <Filter>MPCTheme</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="res\ani.avi">


### PR DESCRIPTION
New themed class for internal prop sheets. 

Fix bugs with menu creation.  Some strange stuff in there:

1. MF_POPUP is not a valid fType, but fType is ignored without MIIM_FTYPE anyway, so it was a nop. (removed)
2. Using AppendMenu with idf=0 is bad because it's used as an id, but I'm not sure id=0 is valid.  Started at 1. Only bothers the themed menus.
3. Even though (2) worked, the menus did not get measured correctly when created as a non-submenu and then changed via setmenuiteminfo.  So code rearranged a bit to create initially as a popup.  This may be a theme-only problem.