### PR TITLE
Try to reprocess YDLSourceURL by youtube-dl if failed first time.

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -837,7 +837,6 @@ CMainFrame::CMainFrame()
     , m_bToggleShaderScreenSpace(false)
     , m_MPLSPlaylist()
     , m_sydlLastProcessURL()
-    , m_bydlReprocess(true)
 {
     // Don't let CFrameWnd handle automatically the state of the menu items.
     // This means that menu items without handlers won't be automatically
@@ -3774,8 +3773,7 @@ LRESULT CMainFrame::OnOpenMediaFailed(WPARAM wParam, LPARAM lParam)
 
     if (wParam == PM_FILE) {
         auto* pli = m_wndPlaylistBar.GetCur();
-        if (pli != nullptr && pli->m_bYoutubeDL && (m_sydlLastProcessURL != pli->m_ydlSourceURL || m_bydlReprocess)) {
-            m_bydlReprocess = false;
+        if (pli != nullptr && pli->m_bYoutubeDL && m_sydlLastProcessURL != pli->m_ydlSourceURL) {
             OpenCurPlaylistItem(0, true);  // Try to reprocess if failed first time.
             return 0;
         }
@@ -13454,7 +13452,6 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
         return std::make_pair(wp, lp);
     };
     if (err.IsEmpty()) {
-        m_bydlReprocess = true;
         auto args = getMessageArgs();
         if (!m_bOpenedThroughThread) {
             ASSERT(GetCurrentThreadId() == AfxGetApp()->m_nThreadID);
@@ -18759,7 +18756,6 @@ bool CMainFrame::ProcessYoutubeDLURL(CString url, bool append, bool replace)
     }
 
     m_sydlLastProcessURL = url;
-    m_bydlReprocess = false;
 
     if (!append && !replace) {
         m_wndPlaylistBar.Empty();

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1153,7 +1153,6 @@ protected:
 
     bool m_bExtOnTop; // 'true' if the "on top" flag was set by an external tool
 
-    bool m_bydlReprocess;
     CString m_sydlLastProcessURL;
 
 public:

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1153,6 +1153,9 @@ protected:
 
     bool m_bExtOnTop; // 'true' if the "on top" flag was set by an external tool
 
+    bool m_bydlReprocess;
+    CString m_sydlLastProcessURL;
+
 public:
     afx_msg UINT OnPowerBroadcast(UINT nPowerEvent, LPARAM nEventData);
     afx_msg void OnSessionChange(UINT nSessionState, UINT nId);


### PR DESCRIPTION
In most situation, the file link can not open because it already expired. If it failed to open first time, reprocess source url with youtube-dl automatically is better than automatically open next file in playlist.