### PR TITLE
Do some check when parsing MPCPLAYLIST

### DIFF
--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -738,7 +738,7 @@ bool CPlayerPlaylistBar::ParseMPCPlayList(CString fn)
 
     std::sort(idx.begin(), idx.end());
     for (int i : idx) {
-        m_pl.AddTail(pli[i]);
+        if (pli[i].m_fns.GetCount() > 0) m_pl.AddTail(pli[i]);
     }
 
     return !pli.IsEmpty();


### PR DESCRIPTION
If a playlist Item do not cotain any filename, it should be removed.