### PR TITLE
add NULL check

### DIFF
--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1510,6 +1510,7 @@ void CPlayerPlaylistBar::OnDrawItem(int nIDCtl, LPDRAWITEMSTRUCT lpDrawItemStruc
     int nItem = lpDrawItemStruct->itemID;
     CRect rcItem = lpDrawItemStruct->rcItem;
     POSITION pos = FindPos(nItem);
+    if (pos == NULL) return;
     bool itemPlaying = pos == m_pl.GetPos();
     bool itemSelected = !!m_list.GetItemState(nItem, LVIS_SELECTED);
     CPlaylistItem& pli = m_pl.GetAt(pos);


### PR DESCRIPTION
Fix https://github.com/clsid2/mpc-hc/issues/760#issuecomment-739853587 by simply add NULL check. It happend because the count of m_list entry is lesser than the count of m_pl entry. That's why I can see there are only part of entries on list.