### PR TITLE
saving m3u is not looks good help need

### DIFF
--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -2151,7 +2151,9 @@ void CPlayerPlaylistBar::OnContextMenu(CWnd* /*pWnd*/, CPoint point)
 
             if (idx == 2) {
                 f.WriteString(_T("[playlist]\n"));
-            } else if (idx == 4) {
+            } else if (idx == 3) {
+                f.WriteString(_T("#EXTM3U\n"));
+            else if (idx == 4) {
                 f.WriteString(_T("<ASX version = \"3.0\">\n"));
             }
 


### PR DESCRIPTION
youtube-dl links should not saved as long (processed) url, should saved as original (ydlSourceURL) url because it cannot display later on. It can be like favorites. Mpc-Be is good handle on playlist save (filepath is not youtube-dl's long url.)

- Additionally on hover playlist shows processed url and it is not also looks fine. If it is not corrupt anything can ydlSourceURL shows up in this situation.

https://sourceforge.net/p/mpcbe/code/HEAD/tree/trunk/src/apps/mplayerc/PlayerPlaylistBar.cpp#l3648
Expected beavior:
#EXTM3U
#EXTINF:000,Title
File path (if url it should unconverted link) (Mpc-be handles it with both playlist and single file in playlist saving)