### PR TITLE
updates to support c++latest (20) and default lang to cpp17

### DIFF
--- a/src/Subtitles/OpenTypeLangTags.h
+++ b/src/Subtitles/OpenTypeLangTags.h
@@ -9,7 +9,7 @@ public:
     typedef char HintStr[OTLangHintLen + 1];
     typedef struct OpenTypeLangTag {
         HintStr lang;
-        wchar_t* langDescription;
+        const wchar_t* langDescription;
     } T;
     static OpenTypeLangTag OpenTypeLangTags[763];
 };

--- a/src/Subtitles/RTS.h
+++ b/src/Subtitles/RTS.h
@@ -226,7 +226,7 @@ public:
     CClipper(CStringW str, const CSize& size, double scalex, double scaley, bool inverse, const CPoint& cpOffset,
              RenderingCaches& renderingCaches);
 
-    void CClipper::SetEffect(const Effect& effect, int effectType) {
+    void SetEffect(const Effect& effect, int effectType) {
         m_effectType = effectType;
         m_effect = effect;
     }

--- a/src/Subtitles/Rasterizer.cpp
+++ b/src/Subtitles/Rasterizer.cpp
@@ -737,7 +737,7 @@ void Rasterizer::CreateWidenedRegionFast(int rx, int ry)
                     int xRight = it->x;
 
                     if (xLeft < xRight) {
-                        dst.emplace_back(unsigned __int64(y) << 32 | xLeft, unsigned __int64(y) << 32 | xRight);
+                        dst.emplace_back(static_cast<unsigned __int64>(y) << 32 | xLeft, static_cast<unsigned __int64>(y) << 32 | xRight);
                     }
                 }
 

--- a/src/common.props
+++ b/src/common.props
@@ -13,11 +13,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/w34127 /w34701 /w34706 /Zo /Zc:inline,referenceBinding,rvalueCast,ternary,throwingNew /Gw %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(ANALYZE)'=='true'">/wd4005 /wd6031 /wd6246 /wd6309 /wd6387 /wd28204 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(VisualStudioVersion)' >= '16.0'">/std:c++17 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(VisualStudioVersion)' == '15.0'">/std:c++latest %(AdditionalOptions)</AdditionalOptions>
-      <EnablePREfast Condition="'$(ANALYZE)'=='true'">true</EnablePREfast>
+	  <EnablePREfast Condition="'$(ANALYZE)'=='true'">true</EnablePREfast>
       <BufferSecurityCheck>true</BufferSecurityCheck>
       <ExceptionHandling>Sync</ExceptionHandling>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/src/filters/muxer/MatroskaMuxer/MatroskaFile.h
+++ b/src/filters/muxer/MatroskaMuxer/MatroskaFile.h
@@ -164,17 +164,17 @@ namespace MatroskaWriter
     public:
         QWORD Size(bool fWithHeader = true) {
             QWORD len = 0;
-            POSITION pos = GetHeadPosition();
+            POSITION pos = CAutoPtrList<T>::GetHeadPosition();
             while (pos) {
-                len += GetNext(pos)->Size(fWithHeader);
+                len += CAutoPtrList<T>::GetNext(pos)->Size(fWithHeader);
             }
             return len;
         }
         HRESULT Write(IStream* pStream) {
-            POSITION pos = GetHeadPosition();
+            POSITION pos = CAutoPtrList<T>::GetHeadPosition();
             while (pos) {
                 HRESULT hr;
-                if (FAILED(hr = GetNext(pos)->Write(pStream))) {
+                if (FAILED(hr = CAutoPtrList<T>::GetNext(pos)->Write(pStream))) {
                     return hr;
                 }
             }

--- a/src/mpc-hc/CMPCThemePropPageFrame.cpp
+++ b/src/mpc-hc/CMPCThemePropPageFrame.cpp
@@ -5,7 +5,7 @@
 #include "TreePropSheet/PropPageFrameDefault.h"
 #include "../DSUtil/WinAPIUtils.h"
 
-CBrush CMPCThemePropPageFrame::mpcThemeBorderBrush = CBrush();
+CBrush CMPCThemePropPageFrame::mpcThemeBorderBrush;
 
 CMPCThemePropPageFrame::CMPCThemePropPageFrame() : CPropPageFrameDefault()
 {
@@ -51,7 +51,7 @@ void CMPCThemePropPageFrame::DrawCaption(CDC* pDC, CRect rect, LPCTSTR lpszCapti
 
     LOGFONT lf;
     GetMessageFont(&lf);
-    lf.lfHeight = -.8f * rect.Height();
+    lf.lfHeight = static_cast<long>(-.8f * rect.Height());
     lf.lfWeight = FW_BOLD;
     CFont f;
     f.CreateFontIndirect(&lf);

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -13,10 +13,10 @@
 #include "CMPCThemeWin10Api.h"
 #undef SubclassWindow
 
-CBrush CMPCThemeUtil::contentBrush = CBrush();
-CBrush CMPCThemeUtil::windowBrush = CBrush();
-CBrush CMPCThemeUtil::controlAreaBrush = CBrush();
-CBrush CMPCThemeUtil::W10DarkThemeFileDialogInjectedBGBrush = CBrush();
+CBrush CMPCThemeUtil::contentBrush;
+CBrush CMPCThemeUtil::windowBrush;
+CBrush CMPCThemeUtil::controlAreaBrush;
+CBrush CMPCThemeUtil::W10DarkThemeFileDialogInjectedBGBrush;
 
 CMPCThemeUtil::CMPCThemeUtil()
 {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -13309,7 +13309,7 @@ int CMainFrame::SetupAudioStreams()
 
                 // If the splitter is the internal LAV Splitter and no language preferences
                 // have been set at splitter level, we can override its choice safely
-                CComQIPtr<IBaseFilter> pBF = bIsSplitter ? pSS : pObject;
+                CComQIPtr<IBaseFilter> pBF = bIsSplitter ? pSS : reinterpret_cast<IBaseFilter*>(pObject.p);
                 if (pBF && CFGFilterLAV::IsInternalInstance(pBF)) {
                     bSkipTrack = false;
                     if (CComQIPtr<ILAVFSettings> pLAVFSettings = pBF) {

--- a/src/thirdparty/RARFileSource/OutputPin.cpp
+++ b/src/thirdparty/RARFileSource/OutputPin.cpp
@@ -293,7 +293,7 @@ STDMETHODIMP CRFSOutputPin::Request (IMediaSample* pSample, DWORD_PTR dwUser)
     CRFSFile::ReadThread *thread = new CRFSFile::ReadThread(m_file, llPosition, lLength, pBuffer);
 
     request->threadHandle = CreateThread(NULL, 0, CRFSFile::ReadThread::ThreadStartStatic, (void*)this, 0, &request->threadID);
-	if (request->threadHandle != S_OK)
+	if (request->threadHandle != static_cast<HANDLE>(S_OK))
 	{
 		DWORD err = GetLastError ();
 		ErrorMsg (err, L"CRFSOutputPin::Request - ReadFile");

--- a/src/thirdparty/VirtualDub/h/vd2/system/VDRingBuffer.h
+++ b/src/thirdparty/VirtualDub/h/vd2/system/VDRingBuffer.h
@@ -110,7 +110,7 @@ VDRingBuffer<T, Allocator>::~VDRingBuffer() {
 template<class T, class Allocator>
 void VDRingBuffer<T, Allocator>::Init(int size) {
 	Shutdown();
-	pBuffer		= allocate(nSize = size, 0);
+	pBuffer		= Allocator::allocate(nSize = size, 0);
 	nLevel		= 0;
 	nReadPoint	= 0;
 	nWritePoint	= 0;
@@ -119,7 +119,7 @@ void VDRingBuffer<T, Allocator>::Init(int size) {
 template<class T, class Allocator>
 void VDRingBuffer<T, Allocator>::Shutdown() {
 	if (pBuffer) {
-		deallocate(pBuffer, nSize);
+        Allocator::deallocate(pBuffer, nSize);
 		pBuffer = NULL;
 	}
 }

--- a/src/thirdparty/VirtualDub/h/vd2/system/vdstl.h
+++ b/src/thirdparty/VirtualDub/h/vd2/system/vdstl.h
@@ -1175,7 +1175,7 @@ public:
 
 	vdfastvector& operator=(const vdfastvector& x) {
 		if (this != &x)
-			assign(x.mpBegin, x.mpEnd);
+            vdfastvector::assign(x.mpBegin, x.mpEnd);
 
 		return *this;
 	}

--- a/src/thirdparty/VirtualDub/h/vd2/system/vdstl_hashmap.h
+++ b/src/thirdparty/VirtualDub/h/vd2/system/vdstl_hashmap.h
@@ -589,7 +589,7 @@ void vdhashmap<K, V, Hash, Pred, A>::rehash(size_type n) {
 
 template<class K, class V, class Hash, class Pred, class A>
 void vdhashmap<K, V, Hash, Pred, A>::rehash_to_size(size_type n) {
-	size_type buckets = compute_bucket_count(n);
+	size_type buckets = vdhashtable_base::compute_bucket_count(n);
 	rehash(buckets);
 }
 

--- a/src/thirdparty/sanear/src/DspChunk.cpp
+++ b/src/thirdparty/sanear/src/DspChunk.cpp
@@ -231,7 +231,7 @@ namespace SaneAudioRenderer
             assert(!chunk.IsEmpty() && OutputFormat != inputFormat);
 
             DspChunk outputChunk(OutputFormat, chunk.GetChannelCount(), chunk.GetFrameCount(), chunk.GetRate());
-            auto outputData = reinterpret_cast<DspFormatTraits<OutputFormat>::SampleType*>(outputChunk.GetData());
+            auto outputData = reinterpret_cast<typename DspFormatTraits<OutputFormat>::SampleType*>(outputChunk.GetData());
 
             switch (inputFormat)
             {


### PR DESCRIPTION
With these updates, it compiles with cpplatest, as well, provided the "/permissive" flag is set.

The problem with cpplatest is that it enables permissive- by default, thus causing a bunch of errors we normally could ignore.  However, given that "cpplatest" is a flag designed for testing, and is not a fixed version, I believe we should stick with cpp17 for now.  Also, cpp17 is supported by VS2017, though I can't guarantee it will compile given a few caveats listed by Microsoft for cpp17 on VS2017.

If it will not compile with cpp17 on 2017, we should provide a workaround in the ifdef or abandon support for VS2017 (my preference).