### PR TITLE
Show a login prompt when selecting OpenSubtitles provider

### DIFF
--- a/src/mpc-hc/PPageSubMisc.cpp
+++ b/src/mpc-hc/PPageSubMisc.cpp
@@ -260,8 +260,8 @@ void CPPageSubMisc::OnRightClick(NMHDR* pNMHDR, LRESULT* pResult)
                 CString szPass(UTF8To16(provider.Password().c_str()));
                 CString szDomain(provider.Name().c_str());
                 if (ERROR_SUCCESS == PromptForCredentials(GetSafeHwnd(),
-                                                          ResStr(IDS_SUB_CREDENTIALS_TITLE), ResStr(IDS_SUB_CREDENTIALS_MSG) + CString(provider.Url().c_str()),
-                                                          szDomain, szUser, szPass, /*&bSave*/nullptr)) {
+                                                          ResStr(IDS_SUB_CREDENTIALS_TITLE), ResStr(IDS_SUB_CREDENTIALS_MSG) +
+                                                          CString(provider.Url().c_str()), szDomain, szUser, szPass, /*&bSave*/nullptr)) {
                     provider.LogOut();
                     provider.UserName(static_cast<const char*>(UTF16To8(szUser)));
                     provider.Password(static_cast<const char*>(UTF16To8(szPass)));
@@ -317,6 +317,29 @@ void CPPageSubMisc::OnItemChanged(NMHDR* pNMHDR, LRESULT* pResult)
     LPNMLISTVIEW pNMLV = (LPNMLISTVIEW)pNMHDR;
 
     if (pNMLV->uOldState + pNMLV->uNewState == 0x3000) {
+        // Show a dialog asking for the user's login info if
+        // OpenSubtitles provider is to be enabled/disabled
+        if (pNMLV->iItem == 0 && ListView_GetCheckState(pNMHDR->hwndFrom, 0)) {
+            auto openSubProvider = m_pSubtitlesProviders->Providers()[0];
+
+            CString szUser(UTF8To16(openSubProvider->UserName().c_str()));
+            CString szPass(UTF8To16(openSubProvider->Password().c_str()));
+            CString szDomain(UTF8To16(openSubProvider->Name().c_str()));
+
+            if (ERROR_SUCCESS != PromptForCredentials(GetSafeHwnd(), ResStr(
+                                                          IDS_SUB_CREDENTIALS_TITLE), ResStr(IDS_SUB_CREDENTIALS_MSG) +
+                                                      CString(openSubProvider->Url().c_str()), szDomain, szUser,
+                                                      szPass, nullptr)) {
+                ListView_SetCheckState(pNMHDR->hwndFrom, 0, FALSE);
+                return;
+            } else {
+                openSubProvider->LogOut();
+                openSubProvider->UserName(static_cast<const char*>(UTF16To8(szUser)));
+                openSubProvider->Password(static_cast<const char*>(UTF16To8(szPass)));
+                m_list.SetItemText(pNMLV->iItem, 1, szUser);
+            }
+        }
+
         SetModified();
     }
 }


### PR DESCRIPTION
When I used to use the original version of this software, I would get this message box every time I tried to watch something:

![image](https://user-images.githubusercontent.com/9315210/104401569-8d64eb00-55a8-11eb-8099-fa2d32e7740c.png)

This was very confusing to me since no place to enter login information was referenced in the error message, nor could I see any obvious place to enter this information in the relevant settings pages.

It finally became so annoying and frustrating that I decided to fix it! Searching for the relevant pieces of code led me to realise that the subtitles provider has to be right-clicked to show a context menu, which allows entering login information when the 'Setup' menu item is clicked.

This is still too unintuitive IMO, so in the interest of helping others, this pull request will introduce a change whereby selecting the OpenSubtitles provider **forces** the user to enter their login information, using the same Windows UI that is currently used.

Hope you guys like it! 😄 