### PR TITLE
Fix language display in status bar

### DIFF
--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -175,7 +175,7 @@ void CPPageAdvanced::InitSettings()
     addBoolItem(SNAPSHOTKEEPVIDEOEXTENSION, IDS_RS_SNAPSHOTKEEPVIDEOEXTENSION, true, s.bSnapShotKeepVideoExtension, StrRes(IDS_PPAGEADVANCED_SNAPSHOTKEEPVIDEOEXTENSION));
     addIntItem(STREAMPOSPOLLER_INTERVAL, IDS_RS_TIME_REFRESH_INTERVAL, 100, s.nStreamPosPollerInterval, std::make_pair(40, 500), _T("Refresh interval (in milliseconds) of time in status bar"));
     addBoolItem(LANG_STATUSBAR, IDS_RS_SHOW_LANG_STATUSBAR, false, s.bShowLangInStatusbar, _T("Display current audio and subtitle language in status bar"));
-    addBoolItem(LANG_STATUSBAR, IDS_RS_SHOW_FPS_STATUSBAR, false, s.bShowFPSInStatusbar, _T("Display current fps and rate in status bar"));
+    addBoolItem(FPS_STATUSBAR, IDS_RS_SHOW_FPS_STATUSBAR, false, s.bShowFPSInStatusbar, _T("Display current fps and rate in status bar"));
     addBoolItem(ADD_LANGCODE_WHEN_SAVE_SUBTITLES, IDS_RS_ADD_LANGCODE_WHEN_SAVE_SUBTITLES, true, s.bAddLangCodeWhenSaveSubtitles, _T("When save the subtitles file, the language code (if available) text will be added to suggested file name by default."));
     addBoolItem(USE_TITLE_IN_RECENT_FILE_LIST, IDS_RS_USE_TITLE_IN_RECENT_FILE_LIST, true, s.bUseTitleInRecentFileList, _T("Use title in recent file list."));
 }


### PR DESCRIPTION
Fix for the following bug:
Advanced settings: "ShowLangInStatusbar" references "bShowFPSInStatusbar" internally, rendering the option useless and leading to inconsistent state as shown in the screenshot (close and reopen of Option window necessary for reproduction):
![grafik](https://user-images.githubusercontent.com/17830502/105573159-e1679080-5d5b-11eb-83a5-ac91a67bcf2f.png)
