### PR TITLE
Update mpc-hc.rc

### DIFF
--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -414,22 +414,22 @@ BEGIN
     COMBOBOX        IDC_COMBO4,203,76,138,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Show chapter marks in seek bar",IDC_CHECK2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,93,343,8
     CONTROL         "Display ""Now Playing"" information in Skype's mood message",IDC_CHECK4,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,122,343,8
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,123,343,8
     CONTROL         "Prevent minimizing the player when in fullscreen on a non default monitor",IDC_CHECK6,
-                    "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,6,136,343,17
+                    "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,6,168,343,17
     CONTROL         "Use enhanced taskbar features",IDC_CHECK_ENHANCED_TASKBAR,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,158,343,8
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,138,343,8
     CONTROL         "Open previous/next file in folder on ""Skip back/forward"" when there is only one item in playlist",IDC_CHECK7,
-                    "Button",BS_AUTOCHECKBOX | BS_VCENTER | BS_MULTILINE | WS_TABSTOP,6,178,348,18
+                    "Button",BS_AUTOCHECKBOX | BS_VCENTER | BS_MULTILINE | WS_TABSTOP,6,183,343,17
     CONTROL         "Show time tooltip:",IDC_CHECK8,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,207,162,8
     COMBOBOX        IDC_COMBO3,203,204,138,64,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "OSD font:",IDC_STATIC,6,228,98,8
     COMBOBOX        IDC_COMBO1,137,226,168,64,CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
     COMBOBOX        IDC_COMBO2,310,226,31,64,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Enable Logitech LCD support (experimental)",IDC_CHECK_LCD,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,169,343,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,153,343,10
     CONTROL         "Auto-hide the mouse pointer during playback in windowed mode",IDC_CHECK3,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,107,343,8
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,108,343,8
     CONTROL         "Show preview on seek bar",IDC_SEEK_PREVIEW,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,47,167,8
     LTEXT           "Preview width (% of screen width)",IDC_STATIC,6,60,178,8
     EDITTEXT        IDC_EDIT4,203,56,40,14,ES_CENTER | ES_AUTOHSCROLL
@@ -669,7 +669,7 @@ BEGIN
     LTEXT           "Spacing",IDC_STATIC,12,61,67,8
     EDITTEXT        IDC_EDIT3,84,59,42,13,ES_RIGHT | ES_AUTOHSCROLL
     CONTROL         "",IDC_SPIN3,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | UDS_NOTHOUSANDS,112,59,14,13
-    LTEXT           "Angle (z,°)",IDC_STATIC,12,82,67,8
+    LTEXT           "Angle (z,Â°)",IDC_STATIC,12,82,67,8
     EDITTEXT        IDC_EDIT4,84,79,42,13,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
     CONTROL         "",IDC_SPIN10,"msctls_updown32",UDS_WRAP | UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | UDS_NOTHOUSANDS,112,79,14,13
     LTEXT           "Scale (x,%)",IDC_STATIC,12,102,67,8
@@ -749,8 +749,8 @@ STYLE DS_SETFONT | WS_CHILD
 FONT 9, "Segoe UI", 400, 0, 0x1
 BEGIN
     CONTROL         "",IDC_LOGOPREVIEW,"Static",SS_BITMAP | SS_CENTERIMAGE,6,6,341,196
-    CONTROL         "Internal:",IDC_RADIO1,"Button",BS_AUTORADIOBUTTON | WS_GROUP,8,248,71,8
-    CONTROL         "External:",IDC_RADIO2,"Button",BS_AUTORADIOBUTTON,8,268,70,8
+    CONTROL         "Internal:",IDC_RADIO1,"Button",BS_AUTORADIOBUTTON | WS_GROUP,8,248,65,8
+    CONTROL         "External:",IDC_RADIO2,"Button",BS_AUTORADIOBUTTON,8,268,65,8
     CONTROL         "",IDC_SPIN1,"msctls_updown32",UDS_ARROWKEYS | UDS_HORZ,76,246,43,13
     EDITTEXT        IDC_LOGOFILENAME,77,266,208,13,ES_AUTOHSCROLL | ES_READONLY
     PUSHBUTTON      "Browse...",IDC_BUTTON2,289,266,60,14
@@ -3762,7 +3762,7 @@ BEGIN
     IDS_AFTERPLAYBACK_DONOTHING "After Playback: Do nothing"
     IDS_OSD_BRIGHTNESS      "Brightness: %s"
     IDS_OSD_CONTRAST        "Contrast: %s"
-    IDS_OSD_HUE             "Hue: %s°"
+    IDS_OSD_HUE             "Hue: %sÂ°"
     IDS_OSD_SATURATION      "Saturation: %s"
     IDS_OSD_RESET_COLOR     "Color settings restored"
     IDS_OSD_NO_COLORCONTROL "Color control is not supported"


### PR DESCRIPTION
- usunięto błąd z nachodzącymi się na siebie polami (IDD_PPAGELOGO DIALOGEX),
- poprawiono rozmieszczenie kontrolek (równe odstępy i szerokość pól) (IDD_PPAGETWEAKS DIALOGEX).

![IDD_PPAGETWEAKS DIALOGEX](https://user-images.githubusercontent.com/50518882/107691821-3be57400-6cac-11eb-9a79-fbdcd78f0abd.png)
![IDD_PPAGELOGO DIALOGEX](https://user-images.githubusercontent.com/50518882/107691823-3d16a100-6cac-11eb-9316-33559677ea00.png)