### PR TITLE
Fix SVG toolbar not loading because of custom scale

### DIFF
--- a/src/mpc-hc/PlayerToolBar.cpp
+++ b/src/mpc-hc/PlayerToolBar.cpp
@@ -94,6 +94,7 @@ void CPlayerToolBar::LoadToolbarImage()
 {
     // We are currently not aware of any cases where the scale factors are different
     float dpiScaling = (float)std::min(m_pMainFrame->m_dpi.ScaleFactorX(), m_pMainFrame->m_dpi.ScaleFactorY());
+    dpiScaling = round(dpiScaling * 8) / 8.0f;
     float defaultToolbarScaling = AfxGetAppSettings().nDefaultToolbarSize / 16.0f;
 
     CImage image, themedImage, origImage;


### PR DESCRIPTION
Closes #952

Rounding the scale to a 1/8 value (any smaller doesn't work) fixes the issue. (e.g. 1.12 will be rounded to 1.125)