### PR TITLE
use utf-16 for rc file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh text eol=lf
 *.po text eol=crlf
+src/mpc-hc/mpc-hc.rc text working-tree-encoding=UTF-16 eol=CRLF

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -16,7 +16,6 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(65001) // UTF-8
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -1543,7 +1542,7 @@ BEGIN
             MENUITEM "&Normal",                     ID_VIEW_PRESETS_NORMAL
         END
         MENUITEM SEPARATOR
-        MENUITEM "Dark Theme (restart)", ID_VIEW_MPCTHEME
+        MENUITEM "Dark Theme (restart)",        ID_VIEW_MPCTHEME
         MENUITEM SEPARATOR
         MENUITEM "F&ull Screen",                ID_VIEW_FULLSCREEN
         POPUP "&Zoom"
@@ -1944,7 +1943,7 @@ BEGIN
                 MENUITEM "&Normal",                     ID_VIEW_PRESETS_NORMAL
             END
             MENUITEM SEPARATOR
-            MENUITEM "Dark Theme (restart)", ID_VIEW_MPCTHEME
+            MENUITEM "Dark Theme (restart)",        ID_VIEW_MPCTHEME
         END
         POPUP "R&enderer Settings"
         BEGIN
@@ -2072,7 +2071,7 @@ BEGIN
                 MENUITEM "&Normal",                     ID_VIEW_PRESETS_NORMAL
             END
             MENUITEM SEPARATOR
-            MENUITEM "Dark Theme (restart)", ID_VIEW_MPCTHEME
+            MENUITEM "Dark Theme (restart)",        ID_VIEW_MPCTHEME
             MENUITEM SEPARATOR
             MENUITEM "F&ull Screen",                ID_VIEW_FULLSCREEN
             POPUP "&Zoom"
@@ -3980,11 +3979,20 @@ BEGIN
     IDS_POSTSIZE_SHADERS_ENABLED "Post-Resize Pixel Shaders: on"
     IDS_POSTSIZE_SHADERS_DISABLED "Post-Resize Pixel Shaders: off"
     IDS_POSTSIZE_SHADERS_TOGGLE "Enable Post-Resize Pixel Shaders"
-    IDS_PPAGEADVANCED_TIME_REFRESH_INTERVAL "Refresh interval (in milliseconds) of time in status bar"
-    IDS_PPAGEADVANCED_SHOW_LANG_STATUSBAR "Display current audio and subtitle language in status bar"
-    IDS_PPAGEADVANCED_SHOW_FPS_STATUSBAR "Display current fps and rate in status bar"
-    IDS_PPAGEADVANCED_ADD_LANGCODE_WHEN_SAVE_SUBTITLES "When save the subtitles file, the language code (if available) text will be added to suggested file name by default."
-    IDS_PPAGEADVANCED_USE_TITLE_IN_RECENT_FILE_LIST "Use title in recent file list."
+    IDS_PPAGEADVANCED_TIME_REFRESH_INTERVAL 
+                            "Refresh interval (in milliseconds) of time in status bar"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_PPAGEADVANCED_SHOW_LANG_STATUSBAR 
+                            "Display current audio and subtitle language in status bar"
+    IDS_PPAGEADVANCED_SHOW_FPS_STATUSBAR 
+                            "Display current fps and rate in status bar"
+    IDS_PPAGEADVANCED_ADD_LANGCODE_WHEN_SAVE_SUBTITLES 
+                            "When save the subtitles file, the language code (if available) text will be added to suggested file name by default."
+    IDS_PPAGEADVANCED_USE_TITLE_IN_RECENT_FILE_LIST 
+                            "Use title in recent file list."
 END
 
 #endif    // English (United States) resources
@@ -4006,7 +4014,7 @@ END
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE 9, 1
-#pragma code_page(1252)
+#pragma code_page(65001)
 #include "afxres.rc"     // Standard components
 #include "res\mpc-hc.rc2"  // non-Microsoft Visual C++ edited resources
 #endif

--- a/src/mpc-hc/mpcresources/TranslationData.py
+++ b/src/mpc-hc/mpcresources/TranslationData.py
@@ -28,7 +28,7 @@ def xstr(s):
 
 
 def detectEncoding(filename):
-    encoding = 'utf-8'
+    encoding = 'utf_16_le'
 
     with codecs.open(filename, 'rb') as f:
         bytes = min(32, os.path.getsize(filename))


### PR DESCRIPTION
UTF-8 for the rc file did not work well, VS keeps changing it back to 1252 when using the internal editor.  After research, they don't appear to support utf-8 for .rc files...

UTF-16 is working fine.  Here is a patch to use that, instead.