### PR TITLE
Don't show title in recent file list if title is included in filename.

### DIFF
--- a/src/DSUtil/text.cpp
+++ b/src/DSUtil/text.cpp
@@ -353,8 +353,6 @@ int LastIndexOfCString(const CString& text, const CString& pattern) {
 }
 
 bool IsNameSimilar(const CString& title, const CString& fileName) {
-    if (title.Left(25) == fileName.Left(25)) return true;
-    int m = fileName.ReverseFind(_T('.'));
-    if (m > -1 && title == fileName.Left(m)) return true;
+    if (fileName.Find(title.Left(25)) > -1) return true;
     return false;
 }


### PR DESCRIPTION
This patch will fix the situation when title is a part of filename, it will still display title in recent file list.
![image](https://user-images.githubusercontent.com/41434272/112423408-878c4280-8d6d-11eb-85f1-a1f8e183e9f8.png)
![image](https://user-images.githubusercontent.com/41434272/112423516-ba363b00-8d6d-11eb-8461-937bc567b7d7.png)
