### PR TITLE
Revert incorrect changes to RLE subtitles

### DIFF
--- a/src/SubPic/SubPicImpl.cpp
+++ b/src/SubPic/SubPicImpl.cpp
@@ -139,7 +139,6 @@ STDMETHODIMP CSubPicImpl::GetSourceAndDest(RECT rcWindow, RECT rcVideo,
             videoRect.left += stretch;
             videoRect.right -= stretch;
             CSize szVideo = videoRect.Size();
-            CRect windowRect(rcWindow);
 
             double subtitleAR = double(m_virtualTextureSize.cx) / m_virtualTextureSize.cy;
             double videoAR = double(szVideo.cx) / szVideo.cy;
@@ -148,14 +147,8 @@ STDMETHODIMP CSubPicImpl::GetSourceAndDest(RECT rcWindow, RECT rcVideo,
             double dCRVideoHeight = szVideo.cx / subtitleAR;
 
             if ((dCRVideoHeight > dCRVideoWidth) != (videoAR > subtitleAR)) {
-                if (dCRVideoHeight > windowRect.Height()) { //this must be letterbox cropped, and the window isn't showing the black bars, so subs could get lost
-                    scaleFactor = double(windowRect.Height()) / m_virtualTextureSize.cy;
-                    offset.y = lround((szVideo.cy - double(windowRect.Height())) / 2.0);
-                    offset.x += lround((dCRVideoHeight - windowRect.Height()) * subtitleAR / 2.0);
-                } else {
-                    scaleFactor = dCRVideoHeight / m_virtualTextureSize.cy;
-                    offset.y = lround((szVideo.cy - dCRVideoHeight) / 2.0);
-                }
+                scaleFactor = dCRVideoHeight / m_virtualTextureSize.cy;
+                offset.y = lround((szVideo.cy - dCRVideoHeight) / 2.0);
             } else {
                 scaleFactor = dCRVideoWidth / m_virtualTextureSize.cx;
                 offset.x = lround((szVideo.cx - dCRVideoWidth) / 2.0);

--- a/src/Subtitles/DVBSub.cpp
+++ b/src/Subtitles/DVBSub.cpp
@@ -698,9 +698,3 @@ void CDVBSub::RemoveOldPages(REFERENCE_TIME rt)
         m_pages.RemoveHeadNoReturn();
     }
 }
-
-STDMETHODIMP CDVBSub::GetRelativeTo(POSITION pos, RelativeTo& relativeTo)
-{
-    relativeTo = RelativeTo::BEST_FIT;
-    return S_OK;
-}

--- a/src/Subtitles/DVBSub.h
+++ b/src/Subtitles/DVBSub.h
@@ -41,7 +41,6 @@ public:
     STDMETHODIMP_(bool)           IsAnimated(POSITION pos);
     STDMETHODIMP                  Render(SubPicDesc& spd, REFERENCE_TIME rt, double fps, RECT& bbox);
     STDMETHODIMP                  GetTextureSize(POSITION pos, SIZE& MaxTextureSize, SIZE& VirtualSize, POINT& VirtualTopLeft);
-    STDMETHODIMP                  GetRelativeTo(POSITION pos, RelativeTo& relativeTo);
 
     virtual HRESULT ParseSample(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, BYTE* pData, size_t nLen);
     virtual void    EndOfStream();

--- a/src/Subtitles/PGSSub.cpp
+++ b/src/Subtitles/PGSSub.cpp
@@ -498,12 +498,6 @@ void CPGSSub::RemoveOldSegments(REFERENCE_TIME rt)
     }
 }
 
-STDMETHODIMP CPGSSub::GetRelativeTo(POSITION pos, RelativeTo& relativeTo)
-{
-    relativeTo = RelativeTo::BEST_FIT;
-    return S_OK;
-}
-
 CPGSSubFile::CPGSSubFile(CCritSec* pLock)
     : CPGSSub(pLock, _T("PGS External Subtitle"), 0)
     , m_bStopParsing(false)

--- a/src/Subtitles/PGSSub.h
+++ b/src/Subtitles/PGSSub.h
@@ -42,7 +42,6 @@ public:
     STDMETHODIMP_(bool)           IsAnimated(POSITION pos);
     STDMETHODIMP                  Render(SubPicDesc& spd, REFERENCE_TIME rt, double fps, RECT& bbox);
     STDMETHODIMP                  GetTextureSize(POSITION pos, SIZE& MaxTextureSize, SIZE& VirtualSize, POINT& VirtualTopLeft);
-    STDMETHODIMP                  GetRelativeTo(POSITION pos, RelativeTo& relativeTo);
 
     virtual HRESULT ParseSample(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, BYTE* pData, size_t nLen);
     virtual void    EndOfStream() { /* Nothing to do */ };

--- a/src/Subtitles/RLECodedSubtitle.cpp
+++ b/src/Subtitles/RLECodedSubtitle.cpp
@@ -47,7 +47,7 @@ STDMETHODIMP CRLECodedSubtitle::NonDelegatingQueryInterface(REFIID riid, void** 
 
 STDMETHODIMP CRLECodedSubtitle::GetRelativeTo(POSITION pos, RelativeTo& relativeTo)
 {
-    relativeTo = WINDOW;
+    relativeTo = BEST_FIT;
     return S_OK;
 }
 


### PR DESCRIPTION
First change was a mistake that lead to second change that broke the logic of best-fit. Revert both and restore working state. I'm open for suggestions, but back it the day I spend some time finding best way to handle all broken (cropped, resized etc.) files universally and it was proven to work well. 