### PR TITLE
improve evr-cp preview handling

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -7542,6 +7542,10 @@ void CMainFrame::OnUpdateViewPanNScanPresets(CCmdUI* pCmdUI)
     pCmdUI->Enable(GetLoadState() == MLS::LOADED && !m_fAudioOnly && nID >= 0 && nID <= s.m_pnspresets.GetCount() && s.iDSVideoRendererType != VIDRNDT_DS_EVR);
 }
 
+int nearest90(int angle) {
+    return int(float(angle) / 90 + 0.5) * 90;
+}
+
 bool CMainFrame::PerformFlipRotate()
 {
     HRESULT hr = E_NOTIMPL;
@@ -7576,7 +7580,8 @@ bool CMainFrame::PerformFlipRotate()
         SetPreviewVideoPosition();
         //adipose: using defaultvideoangle instead of videoangle, as some oddity with AR shows up when using normal rotate with EVRCP.
         //Since we only need to support 4 angles, this will work, but it *should* work with SetVideoAngle...
-        hr = m_pCAP2_preview->SetDefaultVideoAngle(Vector(Vector::DegToRad(m_AngleX), Vector::DegToRad(m_AngleY), Vector::DegToRad(defaultVideoAngle + m_AngleZ)));
+
+        hr = m_pCAP2_preview->SetDefaultVideoAngle(Vector(Vector::DegToRad(nearest90(m_AngleX)), Vector::DegToRad(nearest90(m_AngleY)), Vector::DegToRad(defaultVideoAngle + nearest90(m_AngleZ))));
     }
 
     return true;
@@ -10457,7 +10462,8 @@ CSize CMainFrame::GetVideoSizeWithRotation() const
     const CAppSettings& s = AfxGetAppSettings();
     CSize ret = GetVideoSize();
     if (m_pCAP && !m_pCAP3) { //videosize does not consider manual rotation
-        int rotation = ((360 - m_AngleZ) % 360) / 90; //do not add in m_iDefRotation
+
+        int rotation = ((360 - nearest90(m_AngleZ)) % 360) / 90; //do not add in m_iDefRotation
         if (rotation == 1 || rotation == 3) { //90 degrees
             std::swap(ret.cx, ret.cy);
         }

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -840,6 +840,7 @@ CMainFrame::CMainFrame()
     , queuedSeek({0,0,false})
     , lastSeekStart(0)
     , lastSeekFinish(0)
+    , defaultVideoAngle(0)
 {
     // Don't let CFrameWnd handle automatically the state of the menu items.
     // This means that menu items without handlers won't be automatically
@@ -7569,6 +7570,15 @@ bool CMainFrame::PerformFlipRotate()
         m_AngleX = m_AngleY = m_AngleZ = 0;
         return false;
     }
+    if (m_pCAP2_preview) { //we support rotating preview
+        PreviewWindowHide();
+        m_wndPreView.SetWindowSize();
+        SetPreviewVideoPosition();
+        //adipose: using defaultvideoangle instead of videoangle, as some oddity with AR shows up when using normal rotate with EVRCP.
+        //Since we only need to support 4 angles, this will work, but it *should* work with SetVideoAngle...
+        hr = m_pCAP2_preview->SetDefaultVideoAngle(Vector(Vector::DegToRad(m_AngleX), Vector::DegToRad(m_AngleY), Vector::DegToRad(defaultVideoAngle + m_AngleZ)));
+    }
+
     return true;
 }
 
@@ -10442,6 +10452,19 @@ void CMainFrame::SetPlaybackMode(int iNewStatus)
     m_iPlaybackMode = iNewStatus;
 }
 
+CSize CMainFrame::GetVideoSizeWithRotation() const
+{
+    const CAppSettings& s = AfxGetAppSettings();
+    CSize ret = GetVideoSize();
+    if (m_pCAP && !m_pCAP3) { //videosize does not consider manual rotation
+        int rotation = ((360 - m_AngleZ) % 360) / 90; //do not add in m_iDefRotation
+        if (rotation == 1 || rotation == 3) { //90 degrees
+            std::swap(ret.cx, ret.cy);
+        }
+    }
+    return ret;
+}
+
 CSize CMainFrame::GetVideoSize() const
 {
     CSize ret;
@@ -11074,7 +11097,7 @@ void CMainFrame::SetPreviewVideoPosition() {
         int w = ws.cx;
         int h = ws.cy;
 
-        const CSize arxy(GetVideoSize());
+        const CSize arxy(GetVideoSizeWithRotation());
         {
             const int dh = ws.cy;
             const int dw = MulDiv(dh, arxy.cx, arxy.cy);
@@ -11094,9 +11117,10 @@ void CMainFrame::SetPreviewVideoPosition() {
 
         const CPoint pos(int(m_PosX * (wr.Width() * 3 - w) - wr.Width()), int(m_PosY * (wr.Height() * 3 - h) - wr.Height()));
         const CRect vr(pos, CSize(w, h));
-
+        
         if (m_pMFVDC_preview) {
             m_pMFVDC_preview->SetVideoPosition(nullptr, wr);
+            m_pMFVDC_preview->SetAspectRatioMode(MFVideoARMode_PreservePicture);
         }
         if (m_pVMR9C_preview) {
             m_pVMR9C_preview->SetVideoPosition(nullptr, wr);
@@ -13699,14 +13723,14 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
             m_pGB_preview->FindInterface(IID_PPV_ARGS(&m_pVMR9C_preview), TRUE);
             m_pGB_preview->FindInterface(IID_PPV_ARGS(&m_pCAP2_preview), TRUE);
 
-            RECT Rect;
-            m_wndPreView.GetClientRect(&Rect);
+            RECT wr;
+            m_wndPreView.GetVideoRect(&wr);
             if (m_pMFVDC_preview) {
                 m_pMFVDC_preview->SetVideoWindow(m_wndPreView.GetVideoHWND());
-                m_pMFVDC_preview->SetVideoPosition(nullptr, &Rect);
+                m_pMFVDC_preview->SetVideoPosition(nullptr, &wr);
             }
             if (m_pCAP2_preview) {
-                m_pCAP2_preview->SetPosition(Rect, Rect);
+                m_pCAP2_preview->SetPosition(wr, wr);
             }
         }
 
@@ -13769,7 +13793,8 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
                                     m_pCAP2->SetDefaultVideoAngle(Vector(0, 0, Vector::DegToRad(360 - rotatevalue)));
                                 }
                                 if (m_pCAP2_preview) {
-                                    m_pCAP2_preview->SetDefaultVideoAngle(Vector(0, 0, Vector::DegToRad(360 - rotatevalue)));
+                                    defaultVideoAngle = 360 - rotatevalue;
+                                    m_pCAP2_preview->SetDefaultVideoAngle(Vector(0, 0, Vector::DegToRad(defaultVideoAngle)));
                                 }
                             }
                         }

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -249,6 +249,7 @@ private:
     CComPtr<IVMRWindowlessControl9> m_pVMR9C_preview;
     CComPtr<IMFVideoProcessor>      m_pMFVP_preview;
     CComPtr<ISubPicAllocatorPresenter2> m_pCAP2_preview;
+    int defaultVideoAngle;
     //
     CComPtr<IVMRMixerControl9> m_pVMRMC;
     CComPtr<IMFVideoDisplayControl> m_pMFVDC;
@@ -588,6 +589,7 @@ public:
     void SetTrayTip(CString str);
 
     CSize GetVideoSize() const;
+    CSize GetVideoSizeWithRotation() const;
     void ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasTo);
     void ToggleD3DFullscreen(bool fSwitchScreenResWhenHasTo);
     void MoveVideoWindow(bool fShowStats = false, bool bSetStoppedVideoRect = false);

--- a/src/mpc-hc/PlayerPreView.cpp
+++ b/src/mpc-hc/PlayerPreView.cpp
@@ -191,7 +191,7 @@ void CPreView::SetWindowSize() {
     // the preview size should not be larger than half size of the main window, but not less than 160
     w = std::max(160, std::min(w, wr.Width() / 2));
 
-    CSize vs = m_pMainFrame->GetVideoSize();
+    CSize vs = m_pMainFrame->GetVideoSizeWithRotation();
     if (vs.cx == 0) {
         vs.cx = 160;
         vs.cy = 90;


### PR DESCRIPTION
This should handle manually rotated videos better.  I have given up making EVR-CP rotate in the preview with SetVideoAngle().  I don't understand why it won't work.  SetDefaultVideoAngle() is adequate for the task, but something strange happens with SetVideoAngle().  Probably some oddity that is handled by the mpc main video window better than the preview, but I couldn't figure out what it was.