### PR TITLE
fix: draw repeat marker before chapter marker

### DIFF
--- a/src/mpc-hc/PlayerSeekBar.cpp
+++ b/src/mpc-hc/PlayerSeekBar.cpp
@@ -615,8 +615,20 @@ void CPlayerSeekBar::OnPaint()
             m_lastThumbRect = r;
         }
 
-        // Chapters
         if (m_bHasDuration) {
+            // A-B Repeat
+            REFERENCE_TIME aPos, bPos;
+            bool aEnabled, bEnabled;
+            if (m_pMainFrame->CheckABRepeat(aPos, bPos, aEnabled, bEnabled)) {
+                if (aEnabled) {
+                    funcMarkChannel(aPos, 1, CMPCTheme::SeekbarABColor);
+                }
+                if (bEnabled) {
+                    funcMarkChannel(bPos, 1, CMPCTheme::SeekbarABColor);
+                }
+            }
+
+            // Chapters
             CAutoLock lock(&m_csChapterBag);
             if (m_pChapterBag) {
                 for (DWORD i = 0; i < m_pChapterBag->ChapGetCount(); i++) {
@@ -626,16 +638,6 @@ void CPlayerSeekBar::OnPaint()
                     } else {
                         ASSERT(FALSE);
                     }
-                }
-            }
-            REFERENCE_TIME aPos, bPos;
-            bool aEnabled, bEnabled;
-            if (m_pMainFrame->CheckABRepeat(aPos, bPos, aEnabled, bEnabled)) {
-                if (aEnabled) {
-                    funcMarkChannel(aPos, 1, CMPCTheme::SeekbarABColor);
-                }
-                if (bEnabled) {
-                    funcMarkChannel(bPos, 1, CMPCTheme::SeekbarABColor);
                 }
             }
         }
@@ -694,8 +696,20 @@ void CPlayerSeekBar::OnPaint()
             m_lastThumbRect = r;
         }
 
-        // Chapters
         if (m_bHasDuration) {
+            // A-B Repeat
+            REFERENCE_TIME aPos, bPos;
+            bool aEnabled, bEnabled;
+            if (m_pMainFrame->CheckABRepeat(aPos, bPos, aEnabled, bEnabled)) {
+                if (aEnabled) {
+                    funcMarkChannel(aPos, 0, CMPCTheme::SeekbarABColor);
+                }
+                if (bEnabled) {
+                    funcMarkChannel(bPos, 0, CMPCTheme::SeekbarABColor);
+                }
+            }
+
+            // Chapters
             CAutoLock lock(&m_csChapterBag);
             if (m_pChapterBag) {
                 for (DWORD i = 0; i < m_pChapterBag->ChapGetCount(); i++) {
@@ -706,17 +720,6 @@ void CPlayerSeekBar::OnPaint()
                         ASSERT(FALSE);
                     }
                 }
-            }
-        }
-
-        REFERENCE_TIME aPos, bPos;
-        bool aEnabled, bEnabled;
-        if (m_pMainFrame->CheckABRepeat(aPos, bPos, aEnabled, bEnabled)) {
-            if (aEnabled) {
-                funcMarkChannel(aPos, 0, CMPCTheme::SeekbarABColor);
-            }
-            if (bEnabled) {
-                funcMarkChannel(bPos, 0, CMPCTheme::SeekbarABColor);
             }
         }
 


### PR DESCRIPTION
Assume there is an audio (or video) file contain chapter markers, if we add an A-B repeat point at the same position of a chapter marker, the A-B repeat marker will be not able to draw on the seek bar since `funcMarkChannel` uses `ExcludeClipRect()` to remove a region if we already marked.

This patch moves the A-B repeat point logic above the chapter marker logic, so the A-B repeat point will always be able to draw and the user will no longer get confused when adding a repeat point at a chapter marker point and doesn't actually see the repeat marker on the seek bar.

![image](https://user-images.githubusercontent.com/10095765/124755859-74893100-df5e-11eb-919a-3c1a3eec581f.png)

Upper one: when the patch is applied, bottom one: current version.
