### PR TITLE
[Feature] External Chapters

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -12384,6 +12384,87 @@ void CMainFrame::OpenFile(OpenFileData* pOFD)
 
     SetPlaybackMode(PM_FILE);
 }
+void CMainFrame::SetupExternalChapters()
+{
+    // .XCHP (eXternal CHaPters) file format:
+    // - Preferably, a UTF-8 multiline text file
+    // - Each line will have the chapter definition (Reference Time and, optionally, Name)
+    // - It'll override any internal (embedded in the video) chapter definition 
+    // - It should have the same file stem of the video but with the .xchp extension instead
+    // - It should be in the same directory as the corresponding video file
+    // - Each line should start with 12 characters for the Reference Time
+    // - Only format allowed for Reference Time: hh:mm:ss.ddd
+    // - Any other start of line will mean the line will be ignored
+    // - Everything after the 12th character of the line will be the Name
+    // - The Name can be omitted (ie, it can be empty)
+    // - Any whitespaces at the start and end of the Name will be ignored (trimmed)
+    // - It won't be applicable for internet based files (URLs)
+
+    CPlaylistItem* pli = m_wndPlaylistBar.GetCur();
+
+    if (!pli) {
+        return;
+    }
+
+    CString fn = m_wndPlaylistBar.GetCurFileName(true);
+
+    if (!pli->m_bYoutubeDL && m_pFSF) {
+        CComHeapPtr<OLECHAR> pFN;
+        if (SUCCEEDED(m_pFSF->GetCurFile(&pFN, nullptr))) {
+            fn = pFN;
+        }
+    }
+
+    if (PathUtils::IsURL(fn)) {
+        return;
+    }
+
+    CPath cp(fn);
+
+    cp.RenameExtension(_T(".xchp"));
+
+    if (!cp.FileExists()) {
+        return;
+    }
+
+    fn = cp.m_strPath;
+
+    CWebTextFile f(CTextFile::UTF8);
+    f.SetFallbackEncoding(CTextFile::ANSI);
+
+    CString str;
+
+    if (!f.Open(fn) || !f.ReadString(str)) {
+        return;
+    }
+
+    f.Seek(0, CFile::SeekPosition::begin);
+
+    while (f.ReadString(str)) {
+        REFERENCE_TIME rt = 0;
+        CString name = "";
+
+        if (str.GetLength() > 11) {
+            int lHour = 0;
+            int lMinute = 0;
+            int lSecond = 0;
+            int lMillisec = 0;
+
+            if (_stscanf_s(str.Left(12), _T("%02d:%02d:%02d.%03d"), &lHour, &lMinute, &lSecond, &lMillisec) == 4) {
+                rt = ((((lHour * 60) + lMinute) * 60 + lSecond) * MILLISECONDS + lMillisec) * (UNITS / MILLISECONDS);
+
+                if (str.GetLength() > 12) {
+                    name = str.Mid(12);
+                    name.Trim();
+                }
+
+                m_pCB->ChapAppend(rt, name);
+            }
+        }
+    }
+
+    m_pCB->ChapSort();
+}
 
 void CMainFrame::SetupChapters()
 {
@@ -12392,6 +12473,8 @@ void CMainFrame::SetupChapters()
     // be deleted until all classes release it.
     m_pCB.Release();
     m_pCB = DEBUG_NEW CDSMChapterBag(nullptr, nullptr);
+
+    SetupExternalChapters(); // Any external chapters (.xchpt file) will override any internally defined chapters
 
     CInterfaceList<IBaseFilter> pBFs;
     BeginEnumFilters(m_pGB, pEF, pBF);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -12385,6 +12385,88 @@ void CMainFrame::OpenFile(OpenFileData* pOFD)
     SetPlaybackMode(PM_FILE);
 }
 
+void CMainFrame::SetupExternalChapters()
+{
+    // .XCHP (eXternal CHaPters) file format:
+    // - Preferably, a UTF-8 multiline text file
+    // - Each line will have the chapter definition (Reference Time and, optionally, Name)
+    // - It'll override any internal (embedded in the video) chapter definition 
+    // - It should have the same file stem of the video but with the .xchp extension instead
+    // - It should be in the same directory as the corresponding video file
+    // - Each line should start with 12 characters for the Reference Time
+    // - Only format allowed for Reference Time: hh:mm:ss.ddd
+    // - Any other start of line will mean the line will be ignored
+    // - Everything after the 12th character of the line will be the Name
+    // - The Name can be omitted (ie, it can be empty)
+    // - Any whitespaces at the start and end of the Name will be ignored (trimmed)
+    // - It won't be applicable for internet based files (URLs)
+
+    CPlaylistItem* pli = m_wndPlaylistBar.GetCur();
+
+    if (!pli) {
+        return;
+    }
+
+    CString fn = m_wndPlaylistBar.GetCurFileName(true);
+
+    if (!pli->m_bYoutubeDL && m_pFSF) {
+        CComHeapPtr<OLECHAR> pFN;
+        if (SUCCEEDED(m_pFSF->GetCurFile(&pFN, nullptr))) {
+            fn = pFN;
+        }
+    }
+
+    if (PathUtils::IsURL(fn)) {
+        return;
+    }
+
+    CPath cp(fn);
+
+    cp.RenameExtension(_T(".xchp"));
+
+    if (!cp.FileExists()) {
+        return;
+    }
+
+    fn = cp.m_strPath;
+
+    CWebTextFile f(CTextFile::UTF8);
+    f.SetFallbackEncoding(CTextFile::ANSI);
+
+    CString str;
+
+    if (!f.Open(fn) || !f.ReadString(str)) {
+        return;
+    }
+
+    f.Seek(0, CFile::SeekPosition::begin);
+
+    while (f.ReadString(str)) {
+        REFERENCE_TIME rt = 0;
+        CString name = "";
+
+        if (str.GetLength() > 11) {
+            int lHour = 0;
+            int lMinute = 0;
+            int lSecond = 0;
+            int lMillisec = 0;
+
+            if (_stscanf_s(str.Left(12), _T("%02d:%02d:%02d.%03d"), &lHour, &lMinute, &lSecond, &lMillisec) == 4) {
+                rt = ((((lHour * 60) + lMinute) * 60 + lSecond) * MILLISECONDS + lMillisec) * (UNITS / MILLISECONDS);
+
+                if (str.GetLength() > 12) {
+                    name = str.Mid(12);
+                    name.Trim();
+                }
+
+                m_pCB->ChapAppend(rt, name);
+            }
+        }
+    }
+
+    m_pCB->ChapSort();
+}
+
 void CMainFrame::SetupChapters()
 {
     // Release the old chapter bag and create a new one.
@@ -12392,6 +12474,8 @@ void CMainFrame::SetupChapters()
     // be deleted until all classes release it.
     m_pCB.Release();
     m_pCB = DEBUG_NEW CDSMChapterBag(nullptr, nullptr);
+
+    SetupExternalChapters(); // Any external chapters (.xchpt file) will override any internally defined chapters
 
     CInterfaceList<IBaseFilter> pBFs;
     BeginEnumFilters(m_pGB, pEF, pBF);

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1260,4 +1260,6 @@ private:
 public:
     afx_msg void OnSettingChange(UINT uFlags, LPCTSTR lpszSection);
     afx_msg void OnMouseHWheel(UINT nFlags, short zDelta, CPoint pt);
+private:
+    void SetupExternalChapters();
 };

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1260,6 +1260,4 @@ private:
 public:
     afx_msg void OnSettingChange(UINT uFlags, LPCTSTR lpszSection);
     afx_msg void OnMouseHWheel(UINT nFlags, short zDelta, CPoint pt);
-private:
-    void SetupExternalChapters();
 };


### PR DESCRIPTION
### Presentation

This feature allows the user to add chapters to any (except internet based) video file or override the embedded chapters in any video file that possess them.

### Motivation

This is very useful to me and can be for others (I surmise). There can be many advantages to this but instead of being too exhaustive (and exhausting) some of them can be gleaned from [here](http://forum.bsplayer.com/general-talk-support/21000-i-need-help-getting-ctrl-b-next-chapter-work.html#post66349).

### Definition

To achieve the described functionality a text (UTF-8 or ANSI) file with the same file stem of the video file but with the **.XCHP** file extension should be placed in the same directory of the corresponding video file.

The **.XCHP** file should have multiple lines (one for each chapter) and each line should have 12 characters defining the **Chapter Reference Time**, in the form: `HH:MM:SS.DDD` (which is the same used in MPC and referred in the GUI as **High Precision**). If a line does not adhere to that format it'll be ignored.

Any characters after 12th position in the line are considered to be the **Chapter Name**. It can be omitted (empty) though. Any leading and/or trailing whitespace of the **Chapter Name** will be trimmed.

An example of a possible **.XCHP** file follows:

```
00:00:00.000 Exposition
00:41:34.744 Climax
01:18:12:002 Denouement
```

### Implementation notes

I've tried to (re)use existing code where feasible but with the smallest footprint possible. However there is some redundancy in the implementation. The cost of avoiding it was modifying well established code.

One clear case of this was the String to Reference Time conversion function (**StringToReftime**) that I had to duplicate almost verbatim inside the new **SetupExternalChapters** member because the internal time format was different. So here is a clear opportunity for a future refactoring. 


