### PR TITLE
Clicking the systray icon with mouse middle button toggles play/pause…

### DIFF
--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -588,7 +588,7 @@ public:
 
     bool m_bTrayIcon;
     void ShowTrayIcon(bool bShow);
-    void SetTrayTip(CString str);
+    void SetTrayTip(const CString& str);
 
     CSize GetVideoSize() const;
     CSize GetVideoSizeWithRotation() const;


### PR DESCRIPTION
Resolves #1087

Notes (the official documentation https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyicona):
- NIM_SETVERSION must be called every time a notification area icon is added (NIM_ADD). It does not need to be called with NIM_MODIFY. The version setting is not persisted once a user logs off.
- There are now notifications NIN_KEYSELECT and NIN_SELECT that could be implemented to handle keyboard and mouse activation followed by SPACEBAR or ENTER key.