### PR TITLE
Fixed default menu items in DVD audio and subtitle submenus.

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -14634,9 +14634,7 @@ void CMainFrame::SetupAudioSubMenu()
                 }
             }
 
-            str.Replace(_T("&"), _T("&&"));
-
-            VERIFY(subMenu.AppendMenu(flags, id++, str));
+            VERIFY(AppendMenuEx(subMenu, flags, id++, str));
         }
     }
     // If available use the audio switcher for everything but DVDs
@@ -14762,9 +14760,7 @@ void CMainFrame::SetupSubtitlesSubMenu()
                     }
                 }
 
-                str.Replace(_T("&"), _T("&&"));
-
-                VERIFY(subMenu.AppendMenu(flags, id++, str));
+                VERIFY(AppendMenuEx(subMenu, flags, id++, str));
             }
         }
     }
@@ -19745,4 +19741,14 @@ void CMainFrame::updateRecentFileListSub() {
             }            
         }
     }
+}
+
+BOOL CMainFrame::AppendMenuEx(CMenu& menu, UINT nFlags, UINT_PTR nIDNewItem, CString& text)
+{
+    text.Replace(_T("&"), _T("&&"));
+    auto bResult = menu.AppendMenu(nFlags, nIDNewItem, text.GetString());
+    if (bResult && (nFlags & MF_DEFAULT)) {
+        bResult = menu.SetDefaultItem(nIDNewItem);
+    }
+    return bResult;
 }

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1222,6 +1222,9 @@ protected:
 
     bool IsImageFile(CString fn);
 
+    // Handles MF_DEFAULT and escapes '&'
+    static BOOL AppendMenuEx(CMenu& menu, UINT nFlags, UINT_PTR nIDNewItem, CString& text);
+
 public:
     afx_msg UINT OnPowerBroadcast(UINT nPowerEvent, LPARAM nEventData);
     afx_msg void OnSessionChange(UINT nSessionState, UINT nId);


### PR DESCRIPTION
Fixes #1275.

Note: There is a possible simplification in both `CMainFrame::SetupAudioSubMenu()` and `CMainFrame::SetupSubtitlesSubMenu()`: `IDvdInfo2::GetAudioAttributes()`, resp. `GetSubpictureAttributes()` functions return `DVD_xxxAttributes` structures that already have `LCID Language` member, so the previous standalone calls to `GetAudioLanguage` resp. `GetSubpictureLanguage`  can be removed.