### PR TITLE
fix for synchronized behavior between output and audio renderer page

### DIFF
--- a/src/mpc-hc/PPageAudioRenderer.cpp
+++ b/src/mpc-hc/PPageAudioRenderer.cpp
@@ -175,7 +175,12 @@ BOOL CPPageAudioRenderer::OnInitDialog()
     m_slider1.SetPos(crossfeedCuttoffFrequency);
     m_slider2.SetPos(crossfeedLevel);
 
-    curAudioRenderer = s.SelectedAudioRenderer();
+    CPPageOutput* po = static_cast<CPPageOutput*>(FindSiblingPage(RUNTIME_CLASS(CPPageOutput)));
+    if (po) { //output page visible, so we will use its setting (maybe unapplied)
+        curAudioRenderer = po->GetAudioRendererDisplayName();
+    } else {
+        curAudioRenderer = s.SelectedAudioRenderer();
+    }
     m_bIsEnabled = (curAudioRenderer == AUDRNDT_INTERNAL);
 
     UpdateData(FALSE);
@@ -274,6 +279,11 @@ void CPPageAudioRenderer::OnUpdateInternalAudioEnabled(CCmdUI* pCmdUI) {
 
 void CPPageAudioRenderer::SetEnabled(bool enabled) {
     m_bIsEnabled = enabled;
+}
+
+void CPPageAudioRenderer::SetCurAudioRenderer(CString renderer) {
+    curAudioRenderer = renderer;
+    SetEnabled(renderer == AUDRNDT_INTERNAL);
 }
 
 void CPPageAudioRenderer::OnUpdateCrossfeedCutoffLabel(CCmdUI* pCmdUI)

--- a/src/mpc-hc/PPageAudioRenderer.h
+++ b/src/mpc-hc/PPageAudioRenderer.h
@@ -34,6 +34,7 @@ public:
 
     enum { IDD = IDD_PPAGEAUDIORENDERER };
     void SetEnabled(bool enabled);
+    void SetCurAudioRenderer(CString renderer);
 
 protected:
 

--- a/src/mpc-hc/PPageOutput.cpp
+++ b/src/mpc-hc/PPageOutput.cpp
@@ -166,8 +166,7 @@ BOOL CPPageOutput::OnInitDialog()
         }
 
         CStringW str(olestr);
-
-        m_AudioRendererDisplayNames.Add(CString(str));
+        m_AudioRendererDisplayNames.Add(str);
 
         CComPtr<IPropertyBag> pPB;
         if (SUCCEEDED(pMoniker->BindToStorage(0, 0, IID_PPV_ARGS(&pPB)))) {
@@ -424,7 +423,7 @@ BOOL CPPageOutput::OnApply()
     r.iDX9Resizer                           = m_iDX9Resizer;
     r.fVMR9MixerMode                        = !!m_fVMR9MixerMode;
     r.m_AdvRendSets.bVMR9AlterativeVSync    = m_fVMR9AlterativeVSync != FALSE;
-    s.strAudioRendererDisplayName           = m_AudioRendererDisplayNames[m_iAudioRendererType];
+    s.strAudioRendererDisplayName           = GetAudioRendererDisplayName();
     s.fD3DFullscreen                        = m_fD3DFullscreen ? true : false;
 
     if (m_SubtitleRendererCtrl.IsWindowEnabled()) {
@@ -633,10 +632,14 @@ void CPPageOutput::OnDSRendererChange()
 void CPPageOutput::OnAudioRendererChange() {
     UpdateData();
     CPPageAudioRenderer* pAR = static_cast<CPPageAudioRenderer*>(FindSiblingPage(RUNTIME_CLASS(CPPageAudioRenderer)));
-    if (pAR) { //audio renderer page visible, so we have to update the checkbox
-        pAR->SetEnabled(m_AudioRendererDisplayNames[m_iAudioRendererType] == AUDRNDT_INTERNAL);
+    if (pAR) { //audio renderer page visible, so we have to update it, too
+        pAR->SetCurAudioRenderer(GetAudioRendererDisplayName());
     }
     SetModified();
+}
+
+const CString& CPPageOutput::GetAudioRendererDisplayName() {
+    return m_AudioRendererDisplayNames[m_iAudioRendererType];
 }
 
 void CPPageOutput::OnSubtitleRendererChange()

--- a/src/mpc-hc/PPageOutput.h
+++ b/src/mpc-hc/PPageOutput.h
@@ -79,7 +79,7 @@ public:
 
     BOOL m_fD3D9RenderDevice;
     int m_iD3D9RenderDevice;
-
+    const CString& GetAudioRendererDisplayName();
 
 protected:
     virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support


### PR DESCRIPTION
The problem was changing the audio renderer in the output page would update the checkbox in the audio renderer page.  But a state variable of the currently selected renderer was not updated, making the `CPPageAudioRenderer::OnApply()` function save the previous renderer instead of the updated one.  This could only happen if both Output and AudioRenderer property pages had been activated.