### PR TITLE
[WIP] Video info in the statusbar (DO-NOT-MERGE)

### DIFF
--- a/src/DSUtil/DSUtil.h
+++ b/src/DSUtil/DSUtil.h
@@ -28,6 +28,7 @@
 #include "BaseClasses/streams.h"
 #include <atlcoll.h>
 #include <atlpath.h>
+#include <functional>
 #include "MFCHelper.h"
 #include "Utils.h"
 
@@ -59,6 +60,7 @@ extern IPin* AppendFilter(IPin* pPin, CString DisplayName, IGraphBuilder* pGB);
 extern IPin* InsertFilter(IPin* pPin, CString DisplayName, IGraphBuilder* pGB);
 extern void  ExtractMediaTypes(IPin* pPin, CAtlArray<GUID>& types);
 extern void  ExtractMediaTypes(IPin* pPin, CAtlList<CMediaType>& mts);
+extern void  EnumOutputMediaTypes(IFilterGraph* pFG, const std::function<void(const CMediaTypeEx&, const CString&)>& f);
 extern void  ShowPPage(CString DisplayName, HWND hParentWnd);
 extern void  ShowPPage(IUnknown* pUnknown, HWND hParentWnd);
 extern CLSID GetCLSID(IBaseFilter* pBF);

--- a/src/DSUtil/MediaTypeEx.h
+++ b/src/DSUtil/MediaTypeEx.h
@@ -23,6 +23,12 @@
 
 #include <atlcoll.h>
 
+enum class MediaTypeFormat
+{
+    Full,
+    Short,
+};
+
 class CMediaTypeEx : public CMediaType
 {
 public:
@@ -32,11 +38,18 @@ public:
         CMediaType::operator = (mt);
     }
 
-    CString ToString(IPin* pPin = nullptr);
+    CString ToString(IPin* pPin = nullptr) const;
+    CString ToString(MediaTypeFormat format) const;
 
-    static CString GetVideoCodecName(const GUID& subtype, DWORD biCompression);
+    static CString GetVideoCodecName(const GUID& subtype, DWORD biCompression) {
+        return GetVideoCodecNameFull(subtype, biCompression);
+    }
     static CString GetAudioCodecName(const GUID& subtype, WORD wFormatTag);
     static CString GetSubtitleCodecName(const GUID& subtype);
 
     void Dump(CAtlList<CString>& sl);
+
+private:
+    static CString GetVideoCodecNameFull(const GUID& subtype, DWORD biCompression);
+    static CString GetVideoCodecNameShort(const GUID& subtype, DWORD biCompression);
 };


### PR DESCRIPTION
This is work-in-progress video info in the statusbar, mainly for review...

Notes:
- Output pin enumeration was extracted from CPPageFileInfoDetails::InitTrackInfoText() into EnumOutputMediaTypes() helper function and used in CMainFrame::OpenSetupStatusBar() - I did not mean to break the existing splitter-related version there, but I believe it would be much better to have only one such function; it will be also needed for #904,
- Video codec short name is provided by a dedicated GetVideoCodecNameShort() function - I guess it could be somehow combined with GetMediaTypeName() by adding media subtype uuid entries that are not currently present in CGuidNameList, so for example the names map can contain only strings more descriptive than FourCC, then fall-back to CGuidNameList (and use FourCC extracted from the guid) and then fall-back to biCompression.
- The information in the status bar could be constructed by calling CMediaTypeEx.ToString(...Short), e.g. the video info could combine codec name, resolution (aspect ratio) and FPS, similarly audio info could have codec name, bitrate and sub/languages.