### PR TITLE
Copy favorites to clipboard

### DIFF
--- a/src/DSUtil/WinAPIUtils.h
+++ b/src/DSUtil/WinAPIUtils.h
@@ -44,3 +44,21 @@ public:
     CoInitializeHelper();
     ~CoInitializeHelper();
 };
+
+class CClipboard
+{
+public:
+    CClipboard(CWnd* pWnd = nullptr) {
+        m_bOpened = ::OpenClipboard(pWnd->GetSafeHwnd());
+    }
+    ~CClipboard() {
+        if(m_bOpened) {
+            VERIFY(::CloseClipboard());
+        }
+    }
+
+    BOOL SetText(const CString& text) const;
+
+protected:
+    BOOL m_bOpened;
+};

--- a/src/mpc-hc/AboutDlg.cpp
+++ b/src/mpc-hc/AboutDlg.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "stdafx.h"
+#include <WinAPIFunc.h>
+#include <WinAPIUtils.h>
 #include "AboutDlg.h"
 #include "mpc-hc_config.h"
 #ifndef MPCHC_LITE
@@ -28,8 +30,6 @@
 #include "FileVersionInfo.h"
 #include "PathUtils.h"
 #include "VersionInfo.h"
-#include "WinapiFunc.h"
-#include <afxole.h>
 
 /////////////////////////////////////////////////////////////////////////////
 // CAboutDlg dialog used for App About
@@ -247,31 +247,6 @@ void CAboutDlg::OnCopyToClipboard()
         pD3D9->Release();
     }
 
-    // Allocate a global memory object for the text
-    int len = info.GetLength() + 1;
-    HGLOBAL hGlob = GlobalAlloc(GMEM_MOVEABLE, len * sizeof(WCHAR));
-    if (hGlob) {
-        // Lock the handle and copy the text to the buffer
-        LPVOID pData = GlobalLock(hGlob);
-        if (pData) {
-            wcscpy_s((WCHAR*)pData, len, (LPCWSTR)info);
-            GlobalUnlock(hGlob);
-
-            if (GetParent()->OpenClipboard()) {
-                // Place the handle on the clipboard, if the call succeeds
-                // the system will take care of the allocated memory
-                if (::EmptyClipboard() && ::SetClipboardData(CF_UNICODETEXT, hGlob)) {
-                    hGlob = nullptr;
-                }
-
-                ::CloseClipboard();
-            }
-        }
-
-        if (hGlob) {
-            GlobalFree(hGlob);
-        }
-    }
+    CClipboard clipboard(this);
+    VERIFY(clipboard.SetText(info));
 }
-
-

--- a/src/mpc-hc/AboutDlg.h
+++ b/src/mpc-hc/AboutDlg.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <afxwin.h>
 #include "resource.h"
 #include "CMPCThemeDialog.h"
 
@@ -48,8 +47,6 @@ public:
 
     virtual BOOL OnInitDialog();
 
-    afx_msg void OnHomepage(NMHDR* pNMHDR, LRESULT* pResult);
-
     // Dialog Data
     //{{AFX_DATA(CAboutDlg)
     enum { IDD = IDD_ABOUTBOX };
@@ -64,9 +61,8 @@ protected:
     // Implementation
 protected:
     //{{AFX_MSG(CAboutDlg)
-    // No message handlers
+    afx_msg void OnCopyToClipboard();
+    afx_msg void OnHomepage(NMHDR* pNMHDR, LRESULT* pResult);
     //}}AFX_MSG
     DECLARE_MESSAGE_MAP()
-
-    afx_msg void OnCopyToClipboard();
 };

--- a/src/mpc-hc/FavoriteOrganizeDlg.h
+++ b/src/mpc-hc/FavoriteOrganizeDlg.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include <afxcmn.h>
-#include <afxwin.h>
 #include "CMPCThemeResizableDialog.h"
 #include "CMPCThemeTabCtrl.h"
 #include "CMPCThemePlayerListCtrl.h"
@@ -56,6 +54,7 @@ protected:
     void UpdateColumnsSizes();
     void MoveItem(int nItem, int offset);
     void PlayFavorite(int nItem);
+    void CopyToClipboard();
 
     DECLARE_MESSAGE_MAP()
 public:

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -10117,48 +10117,12 @@ void CMainFrame::OnFavoritesFile(UINT nID)
     }
 }
 
-void CMainFrame::PlayFavoriteFile(CString fav)
+void CMainFrame::PlayFavoriteFile(const CString& fav)
 {
     CAtlList<CString> args;
     REFERENCE_TIME rtStart = 0;
-    BOOL bRelativeDrive = FALSE;
 
-    ExplodeEsc(fav, args, _T(';'));
-    args.RemoveHeadNoReturn(); // desc / name
-    _stscanf_s(args.RemoveHead(), _T("%I64d"), &rtStart);    // pos
-    _stscanf_s(args.RemoveHead(), _T("%d"), &bRelativeDrive);    // relative drive
-    rtStart = std::max(rtStart, 0ll);
-
-    // NOTE: This is just for the favorites but we could add a global settings that does this always when on. Could be useful when using removable devices.
-    //       All you have to do then is plug in your 500 gb drive, full with movies and/or music, start MPC-HC (from the 500 gb drive) with a preloaded playlist and press play.
-    if (bRelativeDrive) {
-        // Get the drive MPC-HC is on and apply it to the path list
-        CString exePath = PathUtils::GetProgramPath(true);
-
-        CPath exeDrive(exePath);
-
-        if (exeDrive.StripToRoot()) {
-            POSITION pos = args.GetHeadPosition();
-
-            while (pos != nullptr) {
-                CString& stringPath = args.GetNext(pos);
-                CPath path(stringPath);
-
-                int rootLength = path.SkipRoot();
-
-                if (path.StripToRoot()) {
-                    if (_tcsicmp(exeDrive, path) != 0) {   // Do we need to replace the drive letter ?
-                        // Replace drive letter
-                        CString newPath(exeDrive);
-
-                        newPath += stringPath.Mid(rootLength);  //newPath += stringPath.Mid( 3 );
-
-                        stringPath = newPath;
-                    }
-                }
-            }
-        }
-    }
+    ParseFavoriteFile(fav, args, &rtStart);
 
     SendMessage(WM_COMMAND, ID_FILE_CLOSEMEDIA);
 
@@ -10173,6 +10137,55 @@ void CMainFrame::PlayFavoriteFile(CString fav)
         OnPlayPlay();
     } else {
         OpenCurPlaylistItem(rtStart);
+    }
+}
+
+void CMainFrame::ParseFavoriteFile(const CString& fav, CAtlList<CString>& args, REFERENCE_TIME* prtStart)
+{
+    REFERENCE_TIME rtStart = 0;
+    BOOL bRelativeDrive = FALSE;
+
+    ExplodeEsc(fav, args, _T(';'));
+    args.RemoveHeadNoReturn(); // desc / name
+    _stscanf_s(args.RemoveHead(), _T("%I64d"), &rtStart);    // pos
+    _stscanf_s(args.RemoveHead(), _T("%d"), &bRelativeDrive);    // relative drive
+    rtStart = std::max(rtStart, 0ll);
+
+    if (prtStart) {
+        *prtStart = rtStart;
+    }
+
+    // NOTE: This is just for the favorites but we could add a global settings that
+    // does this always when on. Could be useful when using removable devices.
+    // All you have to do then is plug in your 500 gb drive, full with movies and/or music,
+    // start MPC-HC (from the 500 gb drive) with a preloaded playlist and press play.
+    if (bRelativeDrive) {
+        // Get the drive MPC-HC is on and apply it to the path list
+        CString exePath = PathUtils::GetProgramPath(true);
+
+        CPath exeDrive(exePath);
+
+        if (exeDrive.StripToRoot()) {
+            POSITION pos = args.GetHeadPosition();
+
+            while (pos != nullptr) {
+                CString& stringPath = args.GetNext(pos);    // Note the reference (!)
+                CPath path(stringPath);
+
+                int rootLength = path.SkipRoot();
+
+                if (path.StripToRoot()) {
+                    if (_tcsicmp(exeDrive, path) != 0) {   // Do we need to replace the drive letter ?
+                        // Replace drive letter
+                        CString newPath(exeDrive);
+
+                        newPath += stringPath.Mid(rootLength);
+
+                        stringPath = newPath;   // Note: Changes args.GetHead()
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -8677,31 +8677,8 @@ void CMainFrame::OnPlayFiltersCopyToClipboard()
         filtersList.AppendFormat(_T("  - %s\r\n"), filterName.GetString());
     }
 
-    // Allocate a global memory object for the text
-    int len = filtersList.GetLength() + 1;
-    HGLOBAL hGlob = GlobalAlloc(GMEM_MOVEABLE, len * sizeof(WCHAR));
-    if (hGlob) {
-        // Lock the handle and copy the text to the buffer
-        LPVOID pData = GlobalLock(hGlob);
-        if (pData) {
-            wcscpy_s((WCHAR*)pData, len, (LPCWSTR)filtersList);
-            GlobalUnlock(hGlob);
-
-            if (OpenClipboard()) {
-                // Place the handle on the clipboard, if the call succeeds
-                // the system will take care of the allocated memory
-                if (::EmptyClipboard() && ::SetClipboardData(CF_UNICODETEXT, hGlob)) {
-                    hGlob = nullptr;
-                }
-
-                ::CloseClipboard();
-            }
-        }
-
-        if (hGlob) {
-            GlobalFree(hGlob);
-        }
-    }
+    CClipboard clipboard(this);
+    VERIFY(clipboard.SetText(filtersList));
 }
 
 void CMainFrame::OnPlayFilters(UINT nID)

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -579,8 +579,9 @@ protected:
 public:
     void OpenCurPlaylistItem(REFERENCE_TIME rtStart = 0, bool reopen = false);
     void OpenMedia(CAutoPtr<OpenMediaData> pOMD);
-    void PlayFavoriteFile(CString fav);
+    void PlayFavoriteFile(const CString& fav);
     void PlayFavoriteDVD(CString fav);
+    void ParseFavoriteFile(const CString& fav, CAtlList<CString>& args, REFERENCE_TIME* prtStart = nullptr);
     bool ResetDevice();
     bool DisplayChange();
     void CloseMedia(bool bNextIsQueued = false);

--- a/src/mpc-hc/PPageSubMisc.cpp
+++ b/src/mpc-hc/PPageSubMisc.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "stdafx.h"
+#include <WinAPIUtils.h>
 #include "mplayerc.h"
 #include "MainFrm.h"
 #include "AuthDlg.h"
@@ -228,30 +229,8 @@ void CPPageSubMisc::OnRightClick(NMHDR* pNMHDR, LRESULT* pResult)
                 break;
             case COPY_URL: {
                 if (!provider.Url().empty()) {
-                    size_t len = provider.Url().length() + 1;
-                    HGLOBAL hGlob = ::GlobalAlloc(GMEM_MOVEABLE, len * sizeof(CHAR));
-                    if (hGlob) {
-                        // Lock the handle and copy the text to the buffer
-                        LPVOID pData = ::GlobalLock(hGlob);
-                        if (pData) {
-                            ::strcpy_s((CHAR*)pData, len, (LPCSTR)provider.Url().c_str());
-                            ::GlobalUnlock(hGlob);
-
-                            if (GetParent()->OpenClipboard()) {
-                                // Place the handle on the clipboard, if the call succeeds
-                                // the system will take care of the allocated memory
-                                if (::EmptyClipboard() && ::SetClipboardData(CF_TEXT, hGlob)) {
-                                    hGlob = nullptr;
-                                }
-
-                                ::CloseClipboard();
-                            }
-                        }
-
-                        if (hGlob) {
-                            ::GlobalFree(hGlob);
-                        }
-                    }
+                    CClipboard clipboard(this);
+                    VERIFY(clipboard.SetText(provider.Url().c_str()));
                 }
                 break;
             }

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -2025,8 +2025,7 @@ void CPlayerPlaylistBar::OnContextMenu(CWnd* /*pWnd*/, CPoint point)
         case M_RANDOMIZE:
             Randomize();
             break;
-        case M_CLIPBOARD:
-            if (OpenClipboard() && EmptyClipboard()) {
+        case M_CLIPBOARD: {
                 CString str;
 
                 CPlaylistItem& pli = m_pl.GetAt(pos);
@@ -2036,14 +2035,8 @@ void CPlayerPlaylistBar::OnContextMenu(CWnd* /*pWnd*/, CPoint point)
                 }
                 str.Trim();
 
-                if (HGLOBAL h = GlobalAlloc(GMEM_MOVEABLE, (str.GetLength() + 1) * sizeof(TCHAR))) {
-                    if (TCHAR* cp = (TCHAR*)GlobalLock(h)) {
-                        _tcscpy_s(cp, str.GetLength() + 1, str);
-                        GlobalUnlock(h);
-                        SetClipboardData(CF_UNICODETEXT, h);
-                    }
-                }
-                CloseClipboard();
+                CClipboard clipboard(this);
+                VERIFY(clipboard.SetText(str));
             }
             break;
         case M_SHOWFOLDER:

--- a/src/mpc-hc/SubtitleDlDlg.cpp
+++ b/src/mpc-hc/SubtitleDlDlg.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "stdafx.h"
+#include <WinAPIUtils.h>
 #include "SubtitleDlDlg.h"
 #include "SubtitlesProvider.h"
 #include "mplayerc.h"
@@ -523,30 +524,8 @@ void CSubtitleDlDlg::OnRightClick(NMHDR* pNMHDR, LRESULT* pResult)
                 break;
             case COPY_URL: {
                 if (!subtitlesInfo.url.empty()) {
-                    size_t len = subtitlesInfo.url.length() + 1;
-                    HGLOBAL hGlob = ::GlobalAlloc(GMEM_MOVEABLE, len * sizeof(CHAR));
-                    if (hGlob) {
-                        // Lock the handle and copy the text to the buffer
-                        LPVOID pData = ::GlobalLock(hGlob);
-                        if (pData) {
-                            ::strcpy_s((CHAR*)pData, len, (LPCSTR)subtitlesInfo.url.c_str());
-                            ::GlobalUnlock(hGlob);
-
-                            if (GetParent()->OpenClipboard()) {
-                                // Place the handle on the clipboard, if the call succeeds
-                                // the system will take care of the allocated memory
-                                if (::EmptyClipboard() && ::SetClipboardData(CF_TEXT, hGlob)) {
-                                    hGlob = nullptr;
-                                }
-
-                                ::CloseClipboard();
-                            }
-                        }
-
-                        if (hGlob) {
-                            ::GlobalFree(hGlob);
-                        }
-                    }
+                    CClipboard clipboard(this);
+                    VERIFY(clipboard.SetText(subtitlesInfo.url.c_str()));
                 }
                 break;
             }

--- a/src/mpc-hc/SubtitleUpDlg.cpp
+++ b/src/mpc-hc/SubtitleUpDlg.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "stdafx.h"
+#include <WinAPIUtils.h>
 #include "SubtitleUpDlg.h"
 #include "SubtitlesProvider.h"
 #include "MainFrm.h"
@@ -320,30 +321,8 @@ void CSubtitleUpDlg::OnRightClick(NMHDR* pNMHDR, LRESULT* pResult)
                 break;
             case COPY_URL: {
                 if (!provider.Url().empty()) {
-                    size_t len = provider.Url().length() + 1;
-                    HGLOBAL hGlob = ::GlobalAlloc(GMEM_MOVEABLE, len * sizeof(CHAR));
-                    if (hGlob) {
-                        // Lock the handle and copy the text to the buffer
-                        LPVOID pData = ::GlobalLock(hGlob);
-                        if (pData) {
-                            ::strcpy_s((CHAR*)pData, len, (LPCSTR)provider.Url().c_str());
-                            ::GlobalUnlock(hGlob);
-
-                            if (GetParent()->OpenClipboard()) {
-                                // Place the handle on the clipboard, if the call succeeds
-                                // the system will take care of the allocated memory
-                                if (::EmptyClipboard() && ::SetClipboardData(CF_TEXT, hGlob)) {
-                                    hGlob = nullptr;
-                                }
-
-                                ::CloseClipboard();
-                            }
-                        }
-
-                        if (hGlob) {
-                            ::GlobalFree(hGlob);
-                        }
-                    }
+                    CClipboard clipboard(this);
+                    VERIFY(clipboard.SetText(provider.Url().c_str()));
                 }
                 break;
             }


### PR DESCRIPTION
Resolves #1033

Added <kbd>Ctrl</kbd>+<kbd>C</kbd> handler to copy selected file favorites into clipboard. This allows for easy export to m3u playlist:

1. [Optional] <kbd>Ctrl</kbd>+<kbd>A</kbd> to select all items,
2. <kbd>Ctrl</kbd>+<kbd>C</kbd> to copy the selected items into clipboard,
3. <kbd>Ctrl</kbd>+<kbd>V</kbd> to paste into a .m3u file.

Context menu or a dedicated "Export..." button can be added in a future version (the current implementation does not require any translation changes).

Notes:
- I have checked all refactored clipboard copying, except CSubtitleUpDlg that is currently disabled,
- There seems to be a lot of unnecessary include-s in the whole codebase, I might contribute an optimized version in future (the usual order of #include-s is `"stdafx.h"`, then `<external.h>` (e.g. project Additional Include Directories), then `"local.h"` (project includes)).