### PR TITLE
Added subtitle delay commands to external renderers

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -74,7 +74,6 @@
 #include "../filters/PinInfoWnd.h"
 #include "../filters/renderer/SyncClock/SyncClock.h"
 #include "../filters/transform/BufferFilter/BufferFilter.h"
-#include "../filters/transform/VSFilter/IDirectVobSub.h"
 
 #include <AllocatorCommon.h>
 #include <NullRenderers.h>
@@ -8624,16 +8623,40 @@ void CMainFrame::SetAudioDelay(REFERENCE_TIME rtShift)
     }
 }
 
-void CMainFrame::SetSubtitleDelay(int delay_ms)
+void CMainFrame::SetSubtitleDelay(int delay_ms, bool relative)
 {
-    if (m_pCAP) {
-        m_pCAP->SetSubtitleDelay(delay_ms);
-
-        CString strSubDelay;
-        strSubDelay.Format(IDS_MAINFRM_139, delay_ms);
-        SendStatusMessage(strSubDelay, 3000);
-        m_OSD.DisplayMessage(OSD_TOPLEFT, strSubDelay);
+    if (!m_pCAP && !m_pDVS) {
+        return;
     }
+
+    if (m_pDVS) {
+        int currentDelay, speedMul, speedDiv;
+        if (FAILED(m_pDVS->get_SubtitleTiming(&currentDelay, &speedMul, &speedDiv))) {
+            return;
+        }
+        if (relative) {
+            delay_ms += currentDelay;
+        }
+
+        VERIFY(SUCCEEDED(m_pDVS->put_SubtitleTiming(delay_ms, speedMul, speedDiv)));
+    }
+    else {
+        ASSERT(m_pCAP != nullptr);
+        if (m_pSubStreams.IsEmpty()) {
+            SendStatusMessage(StrRes(IDS_SUBTITLES_ERROR), 3000);
+            return;
+        }
+        if (relative) {
+            delay_ms += m_pCAP->GetSubtitleDelay();
+        }
+
+        m_pCAP->SetSubtitleDelay(delay_ms);
+    }
+
+    CString strSubDelay;
+    strSubDelay.Format(IDS_MAINFRM_139, delay_ms);
+    SendStatusMessage(strSubDelay, 3000);
+    m_OSD.DisplayMessage(OSD_TOPLEFT, strSubDelay);
 }
 
 void CMainFrame::OnPlayChangeAudDelay(UINT nID)
@@ -13523,6 +13546,14 @@ int CMainFrame::SetupAudioStreams()
 int CMainFrame::SetupSubtitleStreams()
 {
     const CAppSettings& s = AfxGetAppSettings();
+
+    BeginEnumFilters(m_pGB, pEF, pBF) {
+        if (m_pDVS = pBF) {
+            break;
+        }
+    }
+    EndEnumFilters;
+
     int selected = -1;
 
     if (!m_pSubStreams.IsEmpty()) {
@@ -14045,6 +14076,7 @@ void CMainFrame::CloseMediaPrivate()
     m_pKFI.Release();
     m_pAMMC.Release();
     m_pAMNS.Release();
+    m_pDVS.Release();
 
     if (m_pGB) {
         m_pGB->RemoveFromROT();
@@ -17679,24 +17711,13 @@ afx_msg void CMainFrame::OnShiftSubtitle(UINT nID)
 
 afx_msg void CMainFrame::OnSubtitleDelay(UINT nID)
 {
-    if (m_pCAP) {
-        if (m_pSubStreams.IsEmpty()) {
-            SendStatusMessage(StrRes(IDS_SUBTITLES_ERROR), 3000);
-            return;
-        }
+    int nDelayStep = AfxGetAppSettings().nSubDelayStep;
 
-        int newDelay;
-        int oldDelay = m_pCAP->GetSubtitleDelay();
-        int nDelayStep = AfxGetAppSettings().nSubDelayStep;
-
-        if (nID == ID_SUB_DELAY_DOWN) {
-            newDelay = oldDelay - nDelayStep;
-        } else {
-            newDelay = oldDelay + nDelayStep;
-        }
-
-        SetSubtitleDelay(newDelay);
+    if (nID == ID_SUB_DELAY_DOWN) {
+        nDelayStep = -nDelayStep;
     }
+
+    SetSubtitleDelay(nDelayStep, /*relative=*/ true);
 }
 
 void CMainFrame::ProcessAPICommand(COPYDATASTRUCT* pCDS)

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -50,6 +50,7 @@
 #include <qnetwork.h>
 #include "../DSUtil/FontInstaller.h"
 #include "AppSettings.h"
+#include "../filters/transform/VSFilter/IDirectVobSub.h"
 
 #define AfxGetMainFrame() dynamic_cast<CMainFrame*>(AfxGetMainWnd())
 
@@ -282,6 +283,8 @@ private:
     CComPtr<IAMDroppedFrames> m_pAMDF;
 
     CComPtr<IUnknown> m_pProv;
+
+    CComQIPtr<IDirectVobSub> m_pDVS;
 
     bool m_bUsingDXVA;
     LPCTSTR m_HWAccelType;
@@ -1134,7 +1137,7 @@ public:
     void        SetClosedCaptions(bool enable);
     LPCTSTR     GetDVDAudioFormatName(const DVD_AudioAttributes& ATR) const;
     void        SetAudioDelay(REFERENCE_TIME rtShift);
-    void        SetSubtitleDelay(int delay_ms);
+    void        SetSubtitleDelay(int delay_ms, bool relative = false);
     //void      AutoSelectTracks();
     bool        IsRealEngineCompatible(CString strFilename) const;
     void        SetTimersPlay();


### PR DESCRIPTION
Resolves #214 

Implemented only subtitle delay commands F1, F2; porting the other functionality for external filters mentioned in https://github.com/clsid2/mpc-hc/issues/214#issuecomment-602188671 exceeds my current abilities (resp. would require too much testing).