### PR TITLE
Fixed status bar FPS value when changing playback speed

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -3676,7 +3676,14 @@ void CMainFrame::OnUpdatePlayerStatus(CCmdUI* pCmdUI)
                 }
             }
             if (s.bShowFPSInStatusbar && m_pCAP) {
-                msg.AppendFormat(_T("\u2001[%.2lf fps (%.2lfx)]"), m_pCAP->GetFPS(), m_dSpeedRate);
+                double fps;
+                int avgFrameRate;
+                if (m_pQP && SUCCEEDED(m_pQP->get_AvgFrameRate(&avgFrameRate))) {
+                    fps = avgFrameRate/100.0;
+                } else {
+                    fps = m_pCAP->GetFPS();
+                }
+                msg.AppendFormat(_T("\u2001[%.2lf fps (%.2lfx)]"), fps, m_dSpeedRate);
             }
             if (s.bShowABMarksInStatusbar) {
                 if (abRepeatPositionAEnabled || abRepeatPositionBEnabled) {


### PR DESCRIPTION
Fixes #880

Note:
- Because the status bar text is being updated almost continuously (onidle processing), the FPS value (from `IQualProp`) is changing very often and it takes some time to "settle down" and be almost the same as the value in Stats bar (which is updated only once a second). I guess this is not completely wrong as the information in status bar can be seen to reflect the 'current' run time/playback state - but in case the FPS is updated really too often, some time interval check could be added (i.e. save the timestamp and update only if now - lastFpsUpdate > 1000 ms or such).