### PR TITLE
[UNRAR] Fix support for ARM64

### DIFF
--- a/src/thirdparty/unrar/os.hpp
+++ b/src/thirdparty/unrar/os.hpp
@@ -79,8 +79,10 @@
   #include <direct.h>
   #include <intrin.h>
 
-  #define USE_SSE
-  #define SSE_ALIGNMENT 16
+  #if defined(_M_IX86) || defined(_M_AMD64)
+    #define USE_SSE
+    #define SSE_ALIGNMENT 16
+  #endif // _M_IX86 || _M_AMD64
 #else
   #include <dirent.h>
 #endif // _MSC_VER

--- a/src/thirdparty/unrar/rdwrfn.cpp
+++ b/src/thirdparty/unrar/rdwrfn.cpp
@@ -172,7 +172,7 @@ void ComprDataIO::UnpWrite(byte *Addr,size_t Count)
       // even though in year 2001 we announced in unrar.dll whatsnew.txt
       // that it will be PASCAL type (for compatibility with Visual Basic).
 #if defined(_MSC_VER)
-#ifndef _WIN_64
+#ifdef _M_IX86
       __asm mov ebx,esp
 #endif
 #elif defined(_WIN_ALL) && defined(__BORLANDC__)
@@ -183,7 +183,7 @@ void ComprDataIO::UnpWrite(byte *Addr,size_t Count)
       // Restore ESP after ProcessDataProc with wrongly defined calling
       // convention broken it.
 #if defined(_MSC_VER)
-#ifndef _WIN_64
+#ifdef _M_IX86
       __asm mov esp,ebx
 #endif
 #elif defined(_WIN_ALL) && defined(__BORLANDC__)

--- a/src/thirdparty/unrar/volume.cpp
+++ b/src/thirdparty/unrar/volume.cpp
@@ -221,7 +221,7 @@ bool DllVolChange(RAROptions *Cmd,wchar *NextName,size_t NameSize)
     // even though in year 2001 we announced in unrar.dll whatsnew.txt
     // that it will be PASCAL type (for compatibility with Visual Basic).
 #if defined(_MSC_VER)
-#ifndef _WIN_64
+#ifdef _M_IX86
     __asm mov ebx,esp
 #endif
 #elif defined(_WIN_ALL) && defined(__BORLANDC__)
@@ -232,7 +232,7 @@ bool DllVolChange(RAROptions *Cmd,wchar *NextName,size_t NameSize)
     // Restore ESP after ChangeVolProc with wrongly defined calling
     // convention broken it.
 #if defined(_MSC_VER)
-#ifndef _WIN_64
+#ifdef _M_IX86
     __asm mov esp,ebx
 #endif
 #elif defined(_WIN_ALL) && defined(__BORLANDC__)


### PR DESCRIPTION
I'm trying to build MPC-HC for ARM64 and I noticed that I could not compile few sources of UnRar. These issues are easy to fix, hopefully.

The fixes are:
- Enable SSE macros only if it's building for i686 or x86_64 CPUs.
- Allow i686 32bit inline assembly instructions only if the target CPU supports them: _M_IX86 must be used instead of WIN_64, otherwise they are also used when building for ARM64.