### PR TITLE
basic support System Media Transport Controls

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -19899,7 +19899,8 @@ CString CMainFrame::getBestTitle(bool fTitleBarTextTitle) {
 void CMainFrame::updateMediaTransControl() {
     if (m_media_trans_control.updater) {
         boolean enabled;
-        assert(m_media_trans_control.controls->get_IsEnabled(&enabled) == S_OK);
+        HRESULT ret = m_media_trans_control.controls->get_IsEnabled(&enabled);
+        ASSERT(ret == S_OK);
         if (enabled) {
             m_media_trans_control.updater->put_Type(ABI::Windows::Media::MediaPlaybackType_Video);
             CString title = getBestTitle();
@@ -19909,7 +19910,8 @@ void CMainFrame::updateMediaTransControl() {
             if (!title.IsEmpty()) {
                 HSTRING ttitle;
                 if (WindowsCreateString(title.GetString(), title.GetLength(), &ttitle) == S_OK) {
-                    assert(m_media_trans_control.video->put_Title(ttitle) == S_OK);
+                    ret = m_media_trans_control.video->put_Title(ttitle);
+                    ASSERT(ret == S_OK);
                 }
             }
             if (m_pAMMC) {
@@ -19920,12 +19922,14 @@ void CMainFrame::updateMediaTransControl() {
                     if (!author.IsEmpty()) {
                         HSTRING ttitle;
                         if (WindowsCreateString(author.GetString(), author.GetLength(), &ttitle) == S_OK) {
-                            assert(m_media_trans_control.video->put_Subtitle(ttitle) == S_OK);
+                            ret = m_media_trans_control.video->put_Subtitle(ttitle);
+                            ASSERT(ret == S_OK);
                         }
                     }
                 }
             }
-            assert(m_media_trans_control.updater->Update() == S_OK);
+            ret = m_media_trans_control.updater->Update();
+            ASSERT(ret == S_OK);
         }
     }
 }

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -19986,14 +19986,6 @@ void CMainFrame::updateMediaTransControl() {
                     ASSERT(ret == S_OK);
                 }
             }
-            CString album_artist;  // TODO: Read album artist from file tags
-            if (!album_artist.IsEmpty()) {
-                HSTRING temp;
-                if (WindowsCreateString(album_artist.GetString(), album_artist.GetLength(), &temp) == S_OK) {
-                    ret = m_media_trans_control.audio->put_AlbumArtist(temp);
-                    ASSERT(ret == S_OK);
-                }
-            }
             ret = m_media_trans_control.updater->Update();
             ASSERT(ret == S_OK);
         }

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -19903,7 +19903,7 @@ void CMainFrame::updateMediaTransControl() {
         boolean enabled;
         HRESULT ret = m_media_trans_control.controls->get_IsEnabled(&enabled);
         ASSERT(ret == S_OK);
-        if (enabled) {
+        if (ret == S_OK && enabled) {
             m_media_trans_control.updater->put_Type(ABI::Windows::Media::MediaPlaybackType_Video);
             CString title = getBestTitle();
             if (title.IsEmpty()) {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1110,7 +1110,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 
     m_popupMenu.fulfillThemeReqs();
     m_mainPopupMenu.fulfillThemeReqs();
-    m_media_trans_control.configure(this->GetSafeHwnd());
+    m_media_trans_control.Init(this);
     return 0;
 }
 

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -19903,7 +19903,7 @@ void CMainFrame::updateMediaTransControl() {
         boolean enabled;
         HRESULT ret = m_media_trans_control.controls->get_IsEnabled(&enabled);
         ASSERT(ret == S_OK);
-        if (ret == S_OK && enabled) {
+        if (ret == S_OK && enabled && !m_fAudioOnly) {
             m_media_trans_control.updater->put_Type(ABI::Windows::Media::MediaPlaybackType_Video);
             CString title = getBestTitle();
             if (title.IsEmpty()) {
@@ -19954,6 +19954,44 @@ void CMainFrame::updateMediaTransControl() {
                             have_secondary_title = true;
                         }
                     }
+                }
+            }
+            ret = m_media_trans_control.updater->Update();
+            ASSERT(ret == S_OK);
+        } else if (ret == S_OK && enabled && m_fAudioOnly) {
+            m_media_trans_control.updater->put_Type(ABI::Windows::Media::MediaPlaybackType_Music);
+            CString title = getBestTitle();
+            CString author;
+            if (title.IsEmpty()) {
+                title = GetFileName();
+            }
+            if (!title.IsEmpty()) {
+                HSTRING ttitle;
+                if (WindowsCreateString(title.GetString(), title.GetLength(), &ttitle) == S_OK) {
+                    ret = m_media_trans_control.audio->put_Title(ttitle);
+                    ASSERT(ret == S_OK);
+                }
+            }
+            if (author.IsEmpty() && m_pAMMC) {
+                CComBSTR bstr;
+                if (SUCCEEDED(m_pAMMC->get_AuthorName(&bstr)) && bstr.Length()) {
+                    author = bstr.m_str;
+                    author.Trim();
+                }
+            }
+            if (!author.IsEmpty()) {
+                HSTRING temp;
+                if (WindowsCreateString(author.GetString(), author.GetLength(), &temp) == S_OK) {
+                    ret = m_media_trans_control.audio->put_Artist(temp);
+                    ASSERT(ret == S_OK);
+                }
+            }
+            CString album_artist;  // TODO: Read album artist from file tags
+            if (!album_artist.IsEmpty()) {
+                HSTRING temp;
+                if (WindowsCreateString(album_artist.GetString(), album_artist.GetLength(), &temp) == S_OK) {
+                    ret = m_media_trans_control.audio->put_AlbumArtist(temp);
+                    ASSERT(ret == S_OK);
                 }
             }
             ret = m_media_trans_control.updater->Update();

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1295,6 +1295,7 @@ public:
     MediaTransControls m_media_trans_control;
 
     void updateMediaTransControl();
+    void updateMediaTransControlThumbnail();
 
 private:
     bool watchingFileDialog;

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -51,6 +51,7 @@
 #include "../DSUtil/FontInstaller.h"
 #include "AppSettings.h"
 #include "../filters/transform/VSFilter/IDirectVobSub.h"
+#include "MediaTransControls.h"
 
 #define AfxGetMainFrame() dynamic_cast<CMainFrame*>(AfxGetMainWnd())
 
@@ -1284,6 +1285,16 @@ public:
     bool CanSendToYoutubeDL(const CString url);
     bool ProcessYoutubeDLURL(CString url, bool append, bool replace = false);
     bool DownloadWithYoutubeDL(CString url, CString filename);
+
+    /**
+     * @brief Get title of file
+     * @param fTitleBarTextTitle 
+     * @return 
+    */
+    CString getBestTitle(bool fTitleBarTextTitle = true);
+    MediaTransControls m_media_trans_control;
+
+    void updateMediaTransControl();
 
 private:
     bool watchingFileDialog;

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1296,6 +1296,7 @@ public:
 
     void updateMediaTransControl();
     void updateMediaTransControlThumbnail();
+    void MediaTransControlUpdateState(OAFilterState state);
 
 private:
     bool watchingFileDialog;

--- a/src/mpc-hc/MediaTransControls.cpp
+++ b/src/mpc-hc/MediaTransControls.cpp
@@ -85,6 +85,15 @@ bool MediaTransControls::Init(CMainFrame* main) {
         updater = nullptr;
         return false;
     }
+    ret = this->updater->put_Type(MediaPlaybackType::MediaPlaybackType_Music);
+    ret = this->updater->get_MusicProperties(&this->audio);
+    ASSERT(ret == S_OK);
+    if (ret != S_OK) {
+        controls = nullptr;
+        updater = nullptr;
+        video = nullptr;
+        return false;
+    }
     m_pMainFrame = main;
     auto callbackButtonPressed = Callback<ABI::Windows::Foundation::ITypedEventHandler<SystemMediaTransportControls*, SystemMediaTransportControlsButtonPressedEventArgs*>>(
         [this](ISystemMediaTransportControls*, ISystemMediaTransportControlsButtonPressedEventArgs* pArgs) {
@@ -102,6 +111,7 @@ bool MediaTransControls::Init(CMainFrame* main) {
         controls = nullptr;
         updater = nullptr;
         video = nullptr;
+        audio = nullptr;
         return false;
     }
     this->controls->put_IsPlayEnabled(true);
@@ -199,7 +209,6 @@ void MediaTransControls::loadThumbnail(BYTE* content, size_t size) {
 
 void MediaTransControls::loadThumbnailFromUrl(CString url) {
     if (url.IsEmpty() || !updater) return;
-    if (PathUtils::IsFile(url)) return loadThumbnail(url);
     HRESULT ret;
     CComPtr<ABI::Windows::Foundation::IUriRuntimeClassFactory> u;
     if ((ret = Windows::Foundation::GetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(), &u)) != S_OK) {

--- a/src/mpc-hc/MediaTransControls.cpp
+++ b/src/mpc-hc/MediaTransControls.cpp
@@ -63,6 +63,7 @@ inline bool IsWindowsVersionOrLater(uint32_t aVersion) {
 }
 
 bool MediaTransControls::configure(HWND main) {
+    /// Windows 8.1 or later is required
     if (!IsWindowsVersionOrLater(0x06030000ul)) return false;
     CComPtr<ISystemMediaTransportControlsInterop> op;
     HRESULT ret;
@@ -75,9 +76,12 @@ bool MediaTransControls::configure(HWND main) {
         return false;
     }
     this->controls->put_PlaybackStatus(MediaPlaybackStatus::MediaPlaybackStatus_Closed);
-    assert(S_OK == this->controls->get_DisplayUpdater(&this->updater));
-    assert(S_OK == this->updater->put_Type(MediaPlaybackType::MediaPlaybackType_Video));
-    assert(S_OK == this->updater->get_VideoProperties(&this->video));
+    ret = this->controls->get_DisplayUpdater(&this->updater);
+    ASSERT(ret == S_OK);
+    ret = this->updater->put_Type(MediaPlaybackType::MediaPlaybackType_Video);
+    ASSERT(ret == S_OK);
+    ret = this->updater->get_VideoProperties(&this->video);
+    ASSERT(ret == S_OK);
     return true;
 }
 

--- a/src/mpc-hc/MediaTransControls.cpp
+++ b/src/mpc-hc/MediaTransControls.cpp
@@ -221,3 +221,14 @@ void MediaTransControls::OnButtonPressed(SystemMediaTransportControlsButton butt
         break;
     }
 }
+
+bool MediaTransControls::IsActive() {
+    if (controls) {
+        boolean enabled;
+        HRESULT hr;
+        if ((hr = controls->get_IsEnabled(&enabled)) == S_OK) {
+            return enabled;
+        }
+    }
+    return false;
+}

--- a/src/mpc-hc/MediaTransControls.cpp
+++ b/src/mpc-hc/MediaTransControls.cpp
@@ -1,0 +1,162 @@
+#include "stdafx.h"
+#include "MediaTransControls.h"
+
+/// #include <SystemMediaTransportControlsInterop.h>
+#include <wrl.h>
+#include <string>
+
+/// The file content of SystemMediaTransportControlsInterop.h
+#ifndef ISystemMediaTransportControlsInterop
+EXTERN_C const IID IID_ISystemMediaTransportControlsInterop;
+MIDL_INTERFACE("ddb0472d-c911-4a1f-86d9-dc3d71a95f5a")
+ISystemMediaTransportControlsInterop : public IInspectable{
+ public:
+  virtual HRESULT STDMETHODCALLTYPE GetForWindow(
+      /* [in] */ __RPC__in HWND appWindow,
+      /* [in] */ __RPC__in REFIID riid,
+      /* [iid_is][retval][out] */
+      __RPC__deref_out_opt void** mediaTransportControl) = 0;
+};
+#  endif
+
+using namespace Windows::Foundation;
+using namespace ABI::Windows::Media;
+using namespace ABI::Windows::Storage;
+using namespace Microsoft::WRL::Wrappers;
+
+inline bool IsWindowsVersionOrLater(uint32_t aVersion) {
+    static uint32_t minVersion(0);
+    static uint32_t maxVersion(UINT32_MAX);
+
+    if (minVersion >= aVersion) {
+        return true;
+    }
+
+    if (aVersion >= maxVersion) {
+        return false;
+    }
+
+    OSVERSIONINFOEXW info;
+    ZeroMemory(&info, sizeof(OSVERSIONINFOEXW));
+    info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEXW);
+    info.dwMajorVersion = aVersion >> 24;
+    info.dwMinorVersion = (aVersion >> 16) & 0xFF;
+    info.wServicePackMajor = (aVersion >> 8) & 0xFF;
+    info.wServicePackMinor = aVersion & 0xFF;
+
+    DWORDLONG conditionMask = 0;
+    VER_SET_CONDITION(conditionMask, VER_MAJORVERSION, VER_GREATER_EQUAL);
+    VER_SET_CONDITION(conditionMask, VER_MINORVERSION, VER_GREATER_EQUAL);
+    VER_SET_CONDITION(conditionMask, VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+    VER_SET_CONDITION(conditionMask, VER_SERVICEPACKMINOR, VER_GREATER_EQUAL);
+
+    if (VerifyVersionInfoW(&info,
+        VER_MAJORVERSION | VER_MINORVERSION |
+        VER_SERVICEPACKMAJOR | VER_SERVICEPACKMINOR,
+        conditionMask)) {
+        minVersion = aVersion;
+        return true;
+    }
+
+    maxVersion = aVersion;
+    return false;
+}
+
+bool MediaTransControls::configure(HWND main) {
+    if (!IsWindowsVersionOrLater(0x06030000ul)) return false;
+    CComPtr<ISystemMediaTransportControlsInterop> op;
+    HRESULT ret;
+    if ((ret = GetActivationFactory(HStringReference(L"Windows.Media.SystemMediaTransportControls").Get(), &op)) != S_OK) {
+        this->controls = nullptr;
+        return false;
+    }
+    if ((ret = op->GetForWindow(main, IID_PPV_ARGS(&this->controls))) != S_OK) {
+        this->controls = nullptr;
+        return false;
+    }
+    this->controls->put_PlaybackStatus(MediaPlaybackStatus::MediaPlaybackStatus_Closed);
+    assert(S_OK == this->controls->get_DisplayUpdater(&this->updater));
+    assert(S_OK == this->updater->put_Type(MediaPlaybackType::MediaPlaybackType_Video));
+    assert(S_OK == this->updater->get_VideoProperties(&this->video));
+    return true;
+}
+
+void MediaTransControls::stop() {
+    if (this->controls != nullptr) {
+        this->controls->put_IsEnabled(false);
+        this->controls->put_PlaybackStatus(MediaPlaybackStatus::MediaPlaybackStatus_Closed);
+        this->updater->ClearAll();
+    }
+}
+
+void MediaTransControls::play() {
+    if (this->controls != nullptr) {
+        this->controls->put_IsEnabled(true);
+        this->controls->put_IsPlayEnabled(true);
+        this->controls->put_PlaybackStatus(MediaPlaybackStatus::MediaPlaybackStatus_Playing);
+    }
+}
+
+template <typename T>
+bool AwaitForIAsyncOperation(CComPtr<ABI::Windows::Foundation::IAsyncOperation<T>> io) {
+    CComPtr<ABI::Windows::Foundation::IAsyncInfo> info;
+    ABI::Windows::Foundation::AsyncStatus status;
+    HRESULT ret;
+    info = io;
+    while (true) {
+        if ((ret = info->get_Status(&status)) != S_OK) {
+            return false;
+        }
+        if (status != ABI::Windows::Foundation::AsyncStatus::Started) {
+            if (status == ABI::Windows::Foundation::AsyncStatus::Completed) return true;
+            return false;
+        }
+        Sleep(10);
+    }
+}
+
+void MediaTransControls::loadThumbnail(CString fn) {
+    if (fn.IsEmpty() || !updater) return;
+    HRESULT ret;
+    CComPtr<IStorageFileStatics> sfs;
+    if ((ret = GetActivationFactory(HStringReference(L"Windows.Storage.StorageFile").Get(), &sfs)) != S_OK) {
+        return;
+    }
+    CComPtr<ABI::Windows::Foundation::IAsyncOperation<StorageFile*>> af;
+    if ((ret = sfs->GetFileFromPathAsync(HStringReference(fn.GetString()).Get(), &af)) != S_OK) {
+        return;
+    }
+    /// Present file
+    CComPtr<IStorageFile> f;
+    if (!AwaitForIAsyncOperation(af)) {
+        return;
+    }
+    if ((ret = af->GetResults(&f)) != S_OK) {
+        return;
+    }
+    CComPtr<Streams::IRandomAccessStreamReferenceStatics> rasrs;
+    if ((ret = GetActivationFactory(HStringReference(L"Windows.Storage.Streams.RandomAccessStreamReference").Get(), &rasrs)) != S_OK) {
+        return;
+    }
+    CComPtr<Streams::IRandomAccessStreamReference> stream;
+    if ((ret = rasrs->CreateFromFile(f, &stream)) != S_OK) {
+        return;
+    }
+    updater->put_Thumbnail(stream);
+}
+
+void MediaTransControls::loadThumbnail(BYTE* content, size_t size) {
+    if (!content || !size || !updater) return;
+    wchar_t pb[MAX_PATH + 1];
+    if (!GetTempPathW(MAX_PATH + 1, pb)) {
+        return;
+    }
+    wchar_t pn[MAX_PATH + 1];
+    if (!GetTempFileNameW(pb, L"thumbnail_", 0, pn)) return;
+    FILE* f;
+    if (_wfopen_s(&f, pn, L"wb")) return;
+    if (!f) return;
+    fwrite(content, sizeof(BYTE), size, f);
+    fclose(f);
+    loadThumbnail(pn);
+}

--- a/src/mpc-hc/MediaTransControls.cpp
+++ b/src/mpc-hc/MediaTransControls.cpp
@@ -22,6 +22,7 @@
 #include "MediaTransControls.h"
 #include "shcore.h"
 #include "PathUtils.h"
+#include "SysVersion.h"
 
 #pragma comment(lib, "RuntimeObject.lib")
 #pragma comment(lib, "ShCore.lib")
@@ -50,47 +51,9 @@ using namespace ABI::Windows::Storage;
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 
-inline bool IsWindowsVersionOrLater(uint32_t aVersion) {
-    static uint32_t minVersion(0);
-    static uint32_t maxVersion(UINT32_MAX);
-
-    if (minVersion >= aVersion) {
-        return true;
-    }
-
-    if (aVersion >= maxVersion) {
-        return false;
-    }
-
-    OSVERSIONINFOEXW info;
-    ZeroMemory(&info, sizeof(OSVERSIONINFOEXW));
-    info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEXW);
-    info.dwMajorVersion = aVersion >> 24;
-    info.dwMinorVersion = (aVersion >> 16) & 0xFF;
-    info.wServicePackMajor = (aVersion >> 8) & 0xFF;
-    info.wServicePackMinor = aVersion & 0xFF;
-
-    DWORDLONG conditionMask = 0;
-    VER_SET_CONDITION(conditionMask, VER_MAJORVERSION, VER_GREATER_EQUAL);
-    VER_SET_CONDITION(conditionMask, VER_MINORVERSION, VER_GREATER_EQUAL);
-    VER_SET_CONDITION(conditionMask, VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
-    VER_SET_CONDITION(conditionMask, VER_SERVICEPACKMINOR, VER_GREATER_EQUAL);
-
-    if (VerifyVersionInfoW(&info,
-        VER_MAJORVERSION | VER_MINORVERSION |
-        VER_SERVICEPACKMAJOR | VER_SERVICEPACKMINOR,
-        conditionMask)) {
-        minVersion = aVersion;
-        return true;
-    }
-
-    maxVersion = aVersion;
-    return false;
-}
-
 bool MediaTransControls::Init(CMainFrame* main) {
     /// Windows 8.1 or later is required
-    if (!IsWindowsVersionOrLater(0x06030000ul)) return false;
+    if (!SysVersion::IsWin81orLater()) return false;
     CComPtr<ISystemMediaTransportControlsInterop> op;
     HRESULT ret;
     if ((ret = GetActivationFactory(HStringReference(L"Windows.Media.SystemMediaTransportControls").Get(), &op)) != S_OK) {

--- a/src/mpc-hc/MediaTransControls.cpp
+++ b/src/mpc-hc/MediaTransControls.cpp
@@ -67,10 +67,24 @@ bool MediaTransControls::Init(CMainFrame* main) {
     this->controls->put_PlaybackStatus(MediaPlaybackStatus::MediaPlaybackStatus_Closed);
     ret = this->controls->get_DisplayUpdater(&this->updater);
     ASSERT(ret == S_OK);
+    if (ret != S_OK) {
+        controls = nullptr;
+        return false;
+    }
     ret = this->updater->put_Type(MediaPlaybackType::MediaPlaybackType_Video);
     ASSERT(ret == S_OK);
+    if (ret != S_OK) {
+        controls = nullptr;
+        updater = nullptr;
+        return false;
+    }
     ret = this->updater->get_VideoProperties(&this->video);
     ASSERT(ret == S_OK);
+    if (ret != S_OK) {
+        controls = nullptr;
+        updater = nullptr;
+        return false;
+    }
     m_pMainFrame = main;
     auto callbackButtonPressed = Callback<ABI::Windows::Foundation::ITypedEventHandler<SystemMediaTransportControls*, SystemMediaTransportControlsButtonPressedEventArgs*>>(
         [this](ISystemMediaTransportControls*, ISystemMediaTransportControlsButtonPressedEventArgs* pArgs) {
@@ -84,6 +98,12 @@ bool MediaTransControls::Init(CMainFrame* main) {
         });
     ret = controls->add_ButtonPressed(callbackButtonPressed.Get(), &m_EventRegistrationToken);
     ASSERT(ret == S_OK);
+    if (ret != S_OK) {
+        controls = nullptr;
+        updater = nullptr;
+        video = nullptr;
+        return false;
+    }
     this->controls->put_IsPlayEnabled(true);
     this->controls->put_IsPauseEnabled(true);
     this->controls->put_IsStopEnabled(true);

--- a/src/mpc-hc/MediaTransControls.h
+++ b/src/mpc-hc/MediaTransControls.h
@@ -31,6 +31,11 @@ public:
         this->updater = nullptr;
         this->video = nullptr;
     }
+    ~MediaTransControls(void) {
+        if (controls && m_EventRegistrationToken.value) {
+            controls->remove_ButtonPressed(m_EventRegistrationToken);
+        }
+    }
     /**
      * @brief Intitialize the interface
      * @param main 
@@ -51,4 +56,8 @@ public:
     void loadThumbnail(CString fn);
     void loadThumbnail(BYTE* content, size_t size);
     void loadThumbnailFromUrl(CString url);
+protected:
+    CMainFrame* m_pMainFrame;
+    EventRegistrationToken m_EventRegistrationToken;
+    void OnButtonPressed(ABI::Windows::Media::SystemMediaTransportControlsButton button);
 };

--- a/src/mpc-hc/MediaTransControls.h
+++ b/src/mpc-hc/MediaTransControls.h
@@ -53,6 +53,7 @@ public:
     CComPtr<ABI::Windows::Media::ISystemMediaTransportControls> controls;
     CComPtr<ABI::Windows::Media::ISystemMediaTransportControlsDisplayUpdater> updater;
     CComPtr<ABI::Windows::Media::IVideoDisplayProperties> video;
+    CComPtr<ABI::Windows::Media::IMusicDisplayProperties> audio;
     void loadThumbnail(CString fn);
     void loadThumbnail(BYTE* content, size_t size);
     void loadThumbnailFromUrl(CString url);

--- a/src/mpc-hc/MediaTransControls.h
+++ b/src/mpc-hc/MediaTransControls.h
@@ -29,6 +29,7 @@ public:
     MediaTransControls(void) {
         this->controls = nullptr;
         this->updater = nullptr;
+        this->video = nullptr;
     }
     /**
      * @brief Intitialize the interface
@@ -49,4 +50,5 @@ public:
     CComPtr<ABI::Windows::Media::IVideoDisplayProperties> video;
     void loadThumbnail(CString fn);
     void loadThumbnail(BYTE* content, size_t size);
+    void loadThumbnailFromUrl(CString url);
 };

--- a/src/mpc-hc/MediaTransControls.h
+++ b/src/mpc-hc/MediaTransControls.h
@@ -1,8 +1,28 @@
+/*
+* (C) 2002-2021 see Authors.txt
+*
+* This file is part of MPC-HC.
+*
+* MPC-HC is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 3 of the License, or
+* (at your option) any later version.
+*
+* MPC-HC is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
 #pragma once
 #include <sdkddkver.h>
-
 #include <atlbase.h>
 #include <windows.media.h>
+
+class CMainFrame;
 
 class MediaTransControls {
 public:
@@ -10,7 +30,12 @@ public:
         this->controls = nullptr;
         this->updater = nullptr;
     }
-    bool configure(HWND main);
+    /**
+     * @brief Intitialize the interface
+     * @param main 
+     * @return 
+    */
+    bool Init(CMainFrame* main);
     /**
      * @brief Set status to stoped and clear all metadata infromations.
     */

--- a/src/mpc-hc/MediaTransControls.h
+++ b/src/mpc-hc/MediaTransControls.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <sdkddkver.h>
+
+#include <atlbase.h>
+#include <windows.media.h>
+
+class MediaTransControls {
+public:
+    MediaTransControls(void) {
+        this->controls = nullptr;
+        this->updater = nullptr;
+    }
+    bool configure(HWND main);
+    /**
+     * @brief Set status to stoped and clear all metadata infromations.
+    */
+    void stop();
+    /**
+     * @brief Change status to play status.
+    */
+    void play();
+    CComPtr<ABI::Windows::Media::ISystemMediaTransportControls> controls;
+    CComPtr<ABI::Windows::Media::ISystemMediaTransportControlsDisplayUpdater> updater;
+    CComPtr<ABI::Windows::Media::IVideoDisplayProperties> video;
+    void loadThumbnail(CString fn);
+    void loadThumbnail(BYTE* content, size_t size);
+};

--- a/src/mpc-hc/MediaTransControls.h
+++ b/src/mpc-hc/MediaTransControls.h
@@ -56,6 +56,7 @@ public:
     void loadThumbnail(CString fn);
     void loadThumbnail(BYTE* content, size_t size);
     void loadThumbnailFromUrl(CString url);
+    bool IsActive();
 protected:
     CMainFrame* m_pMainFrame;
     EventRegistrationToken m_EventRegistrationToken;

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -71,7 +71,7 @@
       <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>delayimp.lib;dsound.lib;dxguid.lib;GdiPlus.lib;Psapi.lib;SetupAPI.lib;UxTheme.lib;Vfw32.lib;Winmm.lib;dwmapi.lib;strmiids.lib;Uuid.Lib;Version.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>delayimp.lib;dsound.lib;dxguid.lib;GdiPlus.lib;Psapi.lib;SetupAPI.lib;UxTheme.lib;Vfw32.lib;Winmm.lib;dwmapi.lib;strmiids.lib;Uuid.Lib;Version.lib;Bcrypt.lib;RuntimeObject.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\include;..\DSUtil;..\filters\renderer\VideoRenderers;..\thirdparty;..\thirdparty\AudioTools;..\thirdparty\MediaInfo\library\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -275,6 +275,7 @@
     <ClCompile Include="Shaders.cpp" />
     <ClCompile Include="ShockwaveGraph.cpp" />
     <ClCompile Include="SkypeMoodMsgHandler.cpp" />
+    <ClCompile Include="MediaTransControls.cpp" />
     <ClCompile Include="SVGImage.cpp" />
     <ClCompile Include="Translations.cpp" />
     <ClCompile Include="StaticLink.cpp" />
@@ -386,6 +387,7 @@
     <ClInclude Include="FullscreenWnd.h" />
     <ClInclude Include="GoToDlg.h" />
     <ClInclude Include="GraphThread.h" />
+    <ClInclude Include="MediaTransControls.h" />
     <ClInclude Include="Ifo.h" />
     <ClInclude Include="IGraphBuilder2.h" />
     <ClInclude Include="ImageGrayer.h" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -594,6 +594,9 @@
       <Filter>Toolbars</Filter>
     </ClCompile>
     <ClCompile Include="RegexUtil.cpp" />
+    <ClCompile Include="MediaTransControls.cpp">
+      <Filter>Main View</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AppSettings.h">
@@ -1127,6 +1130,9 @@
       <Filter>Toolbars</Filter>
     </ClInclude>
     <ClInclude Include="RegexUtil.h" />
+    <ClInclude Include="MediaTransControls.h">
+      <Filter>Main View</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="res\ani.avi">


### PR DESCRIPTION
#660 
Now support display metadata for videos. 
![image](https://user-images.githubusercontent.com/41434272/136383865-5488b650-9f8f-4a7e-a19e-d1aa00f73e4c.png)
# Todos
- [x] Use `InMemoryRandomAccessStream` to load from buffer directly.
- [x] Handle [Button Event](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/mediatransport/isystemmediatransportcontrols-add-buttonpressed)
- [x] Change controls status when pausing video.
- [x] Load video's thumbnail.
- [x] Handle audio.
- [x] Better metadata display for cue sheets.