### PR TITLE
fix Napisy24 subtitles loading

### DIFF
--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -2226,7 +2226,9 @@ static std::vector<int> PreferredOpenFuncts(CString fn) {
         } else if (fileExt == _T("style")) {
             if (OpenFuncts[i].open == OpenSubStationAlpha) functs.push_back(i);
         } else if (fileExt == _T("tmp")) { // used for embedded subs
-            if (OpenFuncts[i].open == OpenSubRipper || OpenFuncts[i].open == OpenSubStationAlpha || OpenFuncts[i].open == OpenVTT) functs.push_back(i);
+            if (OpenFuncts[i].open == OpenSubRipper || OpenFuncts[i].open == OpenSubStationAlpha || OpenFuncts[i].open == OpenVTT) functs.insert(functs.begin(), i);
+            // could be downloaded OpenVPlayer or anything else renamed by processing to *.tmp despite having a name, put at the end
+            else functs.push_back(i);
         } else {
             functs.push_back(i);
         }

--- a/src/mpc-hc/SubtitlesProviders.cpp
+++ b/src/mpc-hc/SubtitlesProviders.cpp
@@ -897,12 +897,29 @@ void SubtitlesThread::Download(SubtitlesInfo& pSubtitlesInfo, BOOL bActivate)
         CheckAbortAndThrow();
         for (const auto& iter : fileData) {
             CheckAbortAndThrow();
+
+            std::string subtitles = iter.second;
+
+            if (pSubtitlesInfo.Provider()->Name() == "Napisy24" && pSubtitlesInfo.languageCode == "pl")
+            {
+                // remove trash
+                int search = 0;
+                while (subtitles[search] == '?' && search < subtitles.length())
+                    search++;
+
+                if (search > 0 && search < subtitles.length())
+                    subtitles = subtitles.substr(search, subtitles.length()- search);
+
+                // do windows-1250 to UTF8
+                subtitles = to_utf8(subtitles, iter.second, 1250);
+            }
+
             struct {
                 SubtitlesInfo* pSubtitlesInfo;
                 BOOL bActivate;
                 std::string fileName;
                 std::string fileContents;
-            } data({ &pSubtitlesInfo, bActivate, iter.first, iter.second });
+            } data({ &pSubtitlesInfo, bActivate, iter.first, subtitles });
 
             if (m_pTask->m_pMainFrame->SendMessage(WM_LOADSUBTITLES, (BOOL)bActivate, (LPARAM)&data) == TRUE) {
                 if (!m_pTask->m_AutoDownload.empty()) {

--- a/src/mpc-hc/SubtitlesProviders.cpp
+++ b/src/mpc-hc/SubtitlesProviders.cpp
@@ -904,7 +904,7 @@ void SubtitlesThread::Download(SubtitlesInfo& pSubtitlesInfo, BOOL bActivate)
             {
                 // remove trash
                 int search = 0;
-                while (subtitles[search] == '?' && search < subtitles.length())
+                while (search < subtitles.length() && subtitles[search] == '?')
                     search++;
 
                 if (search > 0 && search < subtitles.length())

--- a/src/mpc-hc/SubtitlesProvidersUtils.cpp
+++ b/src/mpc-hc/SubtitlesProvidersUtils.cpp
@@ -38,6 +38,7 @@
 #include <WinCrypt.h>
 #include <sstream>
 #include <cstdlib>
+#include <codecvt>
 
 int SubtitlesProvidersUtils::LevenshteinDistance(std::string s, std::string t)
 {
@@ -844,4 +845,22 @@ UINT64 SubtitlesProvidersUtils::GenerateOSHash(SubtitlesInfo& pFileInfo)
     }
     std::free(buffer);
     return fileHash;
+}
+
+
+std::string SubtitlesProvidersUtils::to_utf8(const std::string& input, const std::string& fallback, UINT codePage)
+{
+    int size_needed = MultiByteToWideChar(codePage, MB_ERR_INVALID_CHARS, input.c_str(), (int)input.size(), NULL, 0);
+
+    if (size_needed == 0)
+    {
+        return fallback;
+    }
+    else
+    {
+        std::wstring wstrTo(size_needed, 0);
+        MultiByteToWideChar(codePage, 0, input.c_str(), (int)input.size(), &wstrTo[0], size_needed);
+        std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converterX;
+        return converterX.to_bytes(wstrTo);
+    }
 }

--- a/src/mpc-hc/SubtitlesProvidersUtils.h
+++ b/src/mpc-hc/SubtitlesProvidersUtils.h
@@ -84,6 +84,7 @@ namespace SubtitlesProvidersUtils
     std::list<std::string> LanguagesISO6391();
     std::list<std::string> LanguagesISO6392();
     UINT64 GenerateOSHash(SubtitlesInfo& pFileInfo);
+    std::string to_utf8(const std::string& input, const std::string& fallback, UINT codePage);
 
     template <typename T>
     std::string JoinContainer(const T& c, LPCSTR delim)


### PR DESCRIPTION
Currently subtitles downloaded using Napisy24 don't work any longer: searching/downloading/extracting work fine but then the subtitles are ignored by the program.

Fixes:
- Downloaded subtitles file after decompressing loses its extension after renaming to '*.tmp' so only SubRipper, SubStationAlpha, VTT work and all the others will fail if downloaded and extracted. Fix: append any other possible subtitles engines to the end of the preferred list.
- It's very common (if not always) that Napisy24 subtitles are windows-1250 encoded. Subtitle processing assumes it's UTF8 and it fails to initialize them. Fix: add windows-1250 to UTF8 trans-coding for just Napisy24 provider.