### PR TITLE
Workaround: Omit error message when making horizontal scroll with pen tablet

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -3163,6 +3163,9 @@ LRESULT CMainFrame::OnNcHitTest(CPoint point)
 
 void CMainFrame::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 {
+    // pScrollBar is null when making horizontal scroll with pen tablet
+    if (!pScrollBar) return;
+    
     if (pScrollBar->IsKindOf(RUNTIME_CLASS(CVolumeCtrl))) {
         OnPlayVolume(0);
     } else if (pScrollBar->IsKindOf(RUNTIME_CLASS(CPlayerSeekBar)) && GetLoadState() == MLS::LOADED) {


### PR DESCRIPTION
Horizontal scroll using pen tablet produces "Encountered an improper argument." error message:

![image](https://user-images.githubusercontent.com/2091529/146670331-65a6c41d-48af-419f-a97b-e34bee6e026a.png)

The cause is `pScrollBar` being null when making horizontal scroll with pen tablet, I have no idea why that is.

Note this doesn't make horizontal scroll with pen tablet work, just omits the annoying error messages.

---
Also, GitHub said:
>We’ve detected the file has mixed line endings. When you commit changes we will normalize them to Windows-style (CRLF).

You might want to check your local git settings to fix this.