### PR TITLE
Added small zoom adjustment

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -553,6 +553,8 @@ static constexpr wmcmd_base default_wmcmds[] = {
     { ID_VIEW_ZOOM_200,                   '3', FVIRTKEY | FALT | FNOINVERT,             IDS_AG_ZOOM_200 },
     { ID_VIEW_ZOOM_AUTOFIT,               '4', FVIRTKEY | FALT | FNOINVERT,             IDS_AG_ZOOM_AUTO_FIT },
     { ID_VIEW_ZOOM_AUTOFIT_LARGER,        '5', FVIRTKEY | FALT | FNOINVERT,             IDS_AG_ZOOM_AUTO_FIT_LARGER },
+    { ID_VIEW_ZOOM_ADD,                     0, FVIRTKEY | FNOINVERT,                    IDS_AG_ZOOM_ADD },
+    { ID_VIEW_ZOOM_SUB,                     0, FVIRTKEY | FNOINVERT,                    IDS_AG_ZOOM_SUB },
     { ID_ASPECTRATIO_NEXT,                  0, FVIRTKEY | FNOINVERT,                    IDS_AG_NEXT_AR_PRESET },
     { ID_VIEW_VF_HALF,                      0, FVIRTKEY | FNOINVERT,                    IDS_AG_VIDFRM_HALF },
     { ID_VIEW_VF_NORMAL,                    0, FVIRTKEY | FNOINVERT,                    IDS_AG_VIDFRM_NORMAL },

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -384,6 +384,10 @@ BEGIN_MESSAGE_MAP(CMainFrame, CFrameWnd)
     ON_UPDATE_COMMAND_UI(ID_VIEW_ZOOM_AUTOFIT, OnUpdateViewZoom)
     ON_COMMAND(ID_VIEW_ZOOM_AUTOFIT_LARGER, OnViewZoomAutoFitLarger)
     ON_UPDATE_COMMAND_UI(ID_VIEW_ZOOM_AUTOFIT_LARGER, OnUpdateViewZoom)
+    ON_COMMAND_RANGE(ID_VIEW_ZOOM_ADD, ID_VIEW_ZOOM_ADD, OnViewModifySize)
+    ON_UPDATE_COMMAND_UI_RANGE(ID_VIEW_ZOOM_ADD, ID_VIEW_ZOOM_ADD, OnUpdateViewZoom)
+    ON_COMMAND_RANGE(ID_VIEW_ZOOM_SUB, ID_VIEW_ZOOM_SUB, OnViewModifySize)
+    ON_UPDATE_COMMAND_UI_RANGE(ID_VIEW_ZOOM_SUB, ID_VIEW_ZOOM_SUB, OnUpdateViewZoom)
     ON_COMMAND_RANGE(ID_VIEW_VF_HALF, ID_VIEW_VF_ZOOM2, OnViewDefaultVideoFrame)
     ON_UPDATE_COMMAND_UI_RANGE(ID_VIEW_VF_HALF, ID_VIEW_VF_ZOOM2, OnUpdateViewDefaultVideoFrame)
     ON_COMMAND(ID_VIEW_VF_SWITCHZOOM, OnViewSwitchVideoFrame)
@@ -7458,6 +7462,24 @@ void CMainFrame::OnViewZoomAutoFitLarger()
 {
     ZoomVideoWindow(ZOOM_AUTOFIT_LARGER);
     m_OSD.DisplayMessage(OSD_TOPLEFT, ResStr(IDS_OSD_ZOOM_AUTO_LARGER), 3000);
+}
+
+void CMainFrame::OnViewModifySize(UINT nID)
+{
+    CSize videoSize = m_fAudioOnly ? m_wndView.GetLogoSize() : GetVideoSize();
+    double videoRatio = double(videoSize.cy) / double(videoSize.cx);
+
+    CRect videoRect;
+    m_pVideoWnd->GetWindowRect(&videoRect);
+    LONG newWidth = videoRect.Width() + 32 * (nID == ID_VIEW_ZOOM_ADD ? 1 : ID_VIEW_ZOOM_SUB ? -1 : 0);
+    LONG newHeight = ceil(newWidth * videoRatio);
+
+    CRect rect;
+    GetWindowRect(&rect);
+    rect.right = rect.right + newWidth - videoRect.Width();
+    rect.bottom = rect.bottom + newHeight - videoRect.Height();
+    
+    MoveWindow(&rect);
 }
 
 void CMainFrame::OnViewDefaultVideoFrame(UINT nID)

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -947,6 +947,7 @@ public:
     afx_msg void OnUpdateViewZoom(CCmdUI* pCmdUI);
     afx_msg void OnViewZoomAutoFit();
     afx_msg void OnViewZoomAutoFitLarger();
+    afx_msg void OnViewModifySize(UINT nID);
     afx_msg void OnViewDefaultVideoFrame(UINT nID);
     afx_msg void OnUpdateViewDefaultVideoFrame(CCmdUI* pCmdUI);
     afx_msg void OnViewSwitchVideoFrame();

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -3473,6 +3473,12 @@ END
 
 STRINGTABLE
 BEGIN
+    IDS_AG_ZOOM_ADD         "Zoom Window +"
+    IDS_AG_ZOOM_SUB         "Zoom Window -"
+END
+
+STRINGTABLE
+BEGIN
     IDS_AG_VIDFRM_ZOOM1     "VidFrm Zoom 1"
     IDS_AG_VIDFRM_ZOOM2     "VidFrm Zoom 2"
     IDS_AG_VIDFRM_SWITCHZOOM "VidFrm Switch Zoom"

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -1082,6 +1082,10 @@
 #define ID_PLAY_REPEAT_AB_MARK_A        33454
 #define IDS_AG_MOUSE_FS_MODIFIER        33454
 #define ID_PLAY_REPEAT_AB_MARK_B        33455
+#define ID_VIEW_ZOOM_SUB                33456
+#define ID_VIEW_ZOOM_ADD                33457
+#define IDS_AG_ZOOM_ADD                 33458
+#define IDS_AG_ZOOM_SUB                 33459
 #define ID_RECENT_FILE_START            34000
 #define ID_RECENT_FILE_END              34999
 #define IDS_MFMT_AVI                    39001
@@ -1694,7 +1698,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        20069
-#define _APS_NEXT_COMMAND_VALUE         33456
+#define _APS_NEXT_COMMAND_VALUE         33460
 #define _APS_NEXT_CONTROL_VALUE         22087
 #define _APS_NEXT_SYMED_VALUE           24052
 #endif


### PR DESCRIPTION
The primary use is that the Zoom +/- functions can be bound to the mousewheel or keys, with which the window size (or zoom) can be adjusted step-by-step. The function is unbound by default.