### PR TITLE
Added an option to not open the recording panel automatically when opening a device

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -246,6 +246,7 @@ CAppSettings::CAppSettings()
     , bLockNoPause(false)
     , bUseSMTC(false)
     , iReloadAfterLongPause(30)
+    , bOpenRecPanelWhenOpeningDevice(true)
 {
     // Internal source filter
 #if INTERNAL_SOURCEFILTER_CDDA
@@ -1166,6 +1167,7 @@ void CAppSettings::SaveSettings()
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_LOCK_NOPAUSE, bLockNoPause);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_USE_SMTC, bUseSMTC);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_RELOAD_AFTER_LONG_PAUSE, iReloadAfterLongPause);
+    pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_OPEN_REC_PANEL_WHEN_OPENING_DEVICE, bOpenRecPanelWhenOpeningDevice);
 
     {
         CComHeapPtr<WCHAR> pDeviceId;
@@ -1996,6 +1998,7 @@ void CAppSettings::LoadSettings()
     bLockNoPause = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_LOCK_NOPAUSE, FALSE);
     bUseSMTC = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_USE_SMTC, FALSE);
     iReloadAfterLongPause = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_RELOAD_AFTER_LONG_PAUSE, 30);
+    bOpenRecPanelWhenOpeningDevice = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_OPEN_REC_PANEL_WHEN_OPENING_DEVICE, TRUE);
 
     if (fLaunchfullscreen && slFiles.GetCount() > 0) {
         nCLSwitches |= CLSW_FULLSCREEN;

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -615,6 +615,7 @@ public:
     bool            bLockNoPause;
     bool            bUseSMTC;
     int             iReloadAfterLongPause;
+    bool            bOpenRecPanelWhenOpeningDevice;
 
     enum class AfterPlayback {
         DO_NOTHING,

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -3820,22 +3820,27 @@ LRESULT CMainFrame::OnFilePostOpenmedia(WPARAM wParam, LPARAM lParam)
         UpdateControlState(CMainFrame::UPDATE_LOGO);
     }
 
-    if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
-        // show navigation panel when it's available and not disabled
-        if (!s.fHideNavigation) {
-            m_wndNavigationBar.m_navdlg.UpdateElementList();
-            if (!m_controls.ControlChecked(CMainFrameControls::Panel::NAVIGATION)) {
-                m_controls.ToggleControl(CMainFrameControls::Panel::NAVIGATION);
-            } else {
-                ASSERT(FALSE);
+    if (s.bOpenRecPanelWhenOpeningDevice) {
+        if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
+            // show navigation panel when it's available and not disabled
+            if (!s.fHideNavigation) {
+                m_wndNavigationBar.m_navdlg.UpdateElementList();
+                if (!m_controls.ControlChecked(CMainFrameControls::Panel::NAVIGATION)) {
+                    m_controls.ToggleControl(CMainFrameControls::Panel::NAVIGATION);
+                }
+                else {
+                    ASSERT(FALSE);
+                }
             }
         }
-    } else if (GetPlaybackMode() == PM_ANALOG_CAPTURE) {
-        // show capture bar
-        if (!m_controls.ControlChecked(CMainFrameControls::Panel::CAPTURE)) {
-            m_controls.ToggleControl(CMainFrameControls::Panel::CAPTURE);
-        } else {
-            ASSERT(FALSE);
+        else if (GetPlaybackMode() == PM_ANALOG_CAPTURE) {
+            // show capture bar
+            if (!m_controls.ControlChecked(CMainFrameControls::Panel::CAPTURE)) {
+                m_controls.ToggleControl(CMainFrameControls::Panel::CAPTURE);
+            }
+            else {
+                ASSERT(FALSE);
+            }
         }
     }
 

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -187,6 +187,7 @@ void CPPageAdvanced::InitSettings()
         std::make_pair(10, 30), StrRes(IDS_PPAGEADVANCED_SCORE));
     addIntItem(AUTO_DOWNLOAD_SCORE_SERIES, IDS_RS_AUTODOWNLOADSCORESERIES, 0x18, s.nAutoDownloadScoreSeries,
         std::make_pair(10, 30), StrRes(IDS_PPAGEADVANCED_SCORE));
+    addBoolItem(OPEN_REC_PANEL_WHEN_OPENING_DEVICE, IDS_RS_OPEN_REC_PANEL_WHEN_OPENING_DEVICE, true, s.bOpenRecPanelWhenOpeningDevice, StrRes(IDS_PPAGEADVANCED_OPEN_REC_PANEL_WHEN_OPENING_DEVICE));
 }
 
 BOOL CPPageAdvanced::OnApply()

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -222,6 +222,7 @@ private:
         FULLSCREEN_DELAY,
         AUTO_DOWNLOAD_SCORE_MOVIES,
         AUTO_DOWNLOAD_SCORE_SERIES,
+        OPEN_REC_PANEL_WHEN_OPENING_DEVICE,
     };
 
     enum {

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -100,6 +100,7 @@
 #define IDS_RS_LOCK_NOPAUSE                 _T("LockNoPause")
 #define IDS_RS_USE_SMTC                     _T("UseSMTC")
 #define IDS_RS_RELOAD_AFTER_LONG_PAUSE      _T("ReloadAfterLongPause")
+#define IDS_RS_OPEN_REC_PANEL_WHEN_OPENING_DEVICE _T("OpenRecordingPanelWhenOpeningDevice")
 
 // Audio
 #define IDS_RS_VOLUME                       _T("Volume")

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -4010,6 +4010,8 @@ BEGIN
                             "Display current A-B repeat marks in status bar."
     IDS_PPAGEADVANCED_SHOW_VIDEOINFO_STATUSBAR 
                             "Display video info (codec name, resolution) in status bar."
+    IDS_PPAGEADVANCED_OPEN_REC_PANEL_WHEN_OPENING_DEVICE
+                            "Show the recording settings dialog automatically when opening a device."
 END
 
 STRINGTABLE

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -1692,6 +1692,7 @@
 #define IDS_ARS_WASAPI_METHOD           57618
 #define IDS_ARS_DUMMY_CHANNELS          57619
 #define IDS_AG_DEFAULT                  57620
+#define IDS_PPAGEADVANCED_OPEN_REC_PANEL_WHEN_OPENING_DEVICE 57621
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
This is useful when just watching TV over a recording device