### PR TITLE
Fixed audio capture info not initializing at startup

### DIFF
--- a/src/mpc-hc/PlayerCaptureDialog.cpp
+++ b/src/mpc-hc/PlayerCaptureDialog.cpp
@@ -1183,6 +1183,10 @@ void CPlayerCaptureDialog::SetupAudioControls(
     if (!pAMAIM.IsEmpty()) {
         m_pAMAIM.Copy(pAMAIM);
     }
+
+    if (pAMSC || !pAMAIM.IsEmpty()) {
+        UpdateAudioControls();
+    }
 }
 
 void CPlayerCaptureDialog::UpdateAudioControls()


### PR DESCRIPTION
This issue caused CMainFrame::BuildGraphVideoAudio not to be able to read the audio media type, so it did not call SetLatency correctly.