### PR TITLE
workaround windows preview peek bug with subtitle dialog

### DIFF
--- a/src/DSUtil/SysVersion.h
+++ b/src/DSUtil/SysVersion.h
@@ -20,35 +20,7 @@
 
 #pragma once
 
-#include <VersionHelpers.h>
-
-#ifndef _WIN32_WINNT_WINTHRESHOLD
-#define _WIN32_WINNT_WINTHRESHOLD 0x0A00
-
-VERSIONHELPERAPI
-IsWindows10OrGreater()
-{
-	return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WINTHRESHOLD), LOBYTE(_WIN32_WINNT_WINTHRESHOLD), 0);
-}
-#endif
-
-static VERSIONHELPERAPI
-IsWindowsVersionOrGreaterBuild(WORD wMajorVersion, WORD wMinorVersion, DWORD dwBuildNumber)
-{
-    OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
-    DWORDLONG        const dwlConditionMask = VerSetConditionMask(
-        VerSetConditionMask(
-        VerSetConditionMask(
-            0, VER_MAJORVERSION, VER_GREATER_EQUAL),
-               VER_MINORVERSION, VER_GREATER_EQUAL),
-               VER_BUILDNUMBER, VER_GREATER_EQUAL);
-
-    osvi.dwMajorVersion = wMajorVersion;
-    osvi.dwMinorVersion = wMinorVersion;
-    osvi.dwBuildNumber = dwBuildNumber;
-
-    return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, dwlConditionMask) != FALSE;
-}
+#include "VersionHelpersInternal.h"
 
 static bool IsWindows64()
 {
@@ -88,7 +60,11 @@ namespace SysVersion
 		const static bool bIsWin10RS4orLater = IsWindowsVersionOrGreaterBuild(HIBYTE(_WIN32_WINNT_WINTHRESHOLD), LOBYTE(_WIN32_WINNT_WINTHRESHOLD), 17134);
 		return bIsWin10RS4orLater;
 	}
-	inline const bool IsW64() {
+    inline const bool IsWin11orLater() {
+        const static bool bIsWin11orLater = IsWindows11OrGreater();
+        return bIsWin11orLater;
+    }
+    inline const bool IsW64() {
 		const static bool bIsW64 = IsWindows64();
 		return bIsW64;
 	}

--- a/src/DSUtil/VersionHelpersInternal.h
+++ b/src/DSUtil/VersionHelpersInternal.h
@@ -24,13 +24,38 @@
 
 // Remove once newer SDK is used
 #ifndef _WIN32_WINNT_WINTHRESHOLD
-
 #define _WIN32_WINNT_WINTHRESHOLD 0x0A00
 
 VERSIONHELPERAPI
 IsWindows10OrGreater()
 {
     return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WINTHRESHOLD), LOBYTE(_WIN32_WINNT_WINTHRESHOLD), 0);
+}
+
+#endif
+
+static VERSIONHELPERAPI
+IsWindowsVersionOrGreaterBuild(WORD wMajorVersion, WORD wMinorVersion, DWORD dwBuildNumber) {
+    OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
+    DWORDLONG        const dwlConditionMask = VerSetConditionMask(
+        VerSetConditionMask(
+            VerSetConditionMask(
+                0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+            VER_MINORVERSION, VER_GREATER_EQUAL),
+        VER_BUILDNUMBER, VER_GREATER_EQUAL);
+
+    osvi.dwMajorVersion = wMajorVersion;
+    osvi.dwMinorVersion = wMinorVersion;
+    osvi.dwBuildNumber = dwBuildNumber;
+
+    return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, dwlConditionMask) != FALSE;
+}
+
+#ifndef IsWindows11OrGreater
+
+VERSIONHELPERAPI
+IsWindows11OrGreater() {
+    return IsWindowsVersionOrGreaterBuild(HIBYTE(_WIN32_WINNT_WINTHRESHOLD), LOBYTE(_WIN32_WINNT_WINTHRESHOLD), 22000);
 }
 
 #endif

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1094,7 +1094,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 
     m_pSubtitlesProviders = std::make_unique<SubtitlesProviders>(this);
     m_wndSubtitlesDownloadDialog.Create(m_wndSubtitlesDownloadDialog.IDD, this);
-    m_wndSubtitlesDownloadDialog.ShowWindow(FALSE);
+    m_wndSubtitlesDownloadDialog.ShowWindow(SW_HIDE);
     //m_wndSubtitlesUploadDialog.Create(m_wndSubtitlesUploadDialog.IDD, this);
 
     if (s.nCmdlnWebServerPort != 0) {

--- a/src/mpc-hc/SubtitleDlDlg.cpp
+++ b/src/mpc-hc/SubtitleDlDlg.cpp
@@ -29,6 +29,7 @@
 #include "PPageSubMisc.h"
 #include "CMPCTheme.h"
 #include "CMPCThemeMenu.h"
+#include "SysVersion.h"
 
 BEGIN_MESSAGE_MAP(CSubtitleDlDlgListCtrl, CMPCThemePlayerListCtrl)
     ON_NOTIFY_EX(TTN_NEEDTEXT, 0, OnToolNeedText)
@@ -285,6 +286,20 @@ BOOL CSubtitleDlDlg::PreTranslateMessage(MSG* pMsg)
     return __super::PreTranslateMessage(pMsg);
 }
 
+void CSubtitleDlDlg::HideDialog() {
+    // Just hide the dialog, since it's modeless we don't want to call EndDialog
+    if (SysVersion::IsWin11orLater()) {
+        //windows 11 bug with peek preview--shows hidden dialogs.  temporarily flag as tool window which is not a taskbar eligble window
+        ModifyStyleEx(0, WS_EX_TOOLWINDOW);
+        ShowWindow(SW_HIDE);
+        //remove bogus style so it renders properly next time
+        ModifyStyleEx(WS_EX_TOOLWINDOW, 0);
+    } else {
+        ShowWindow(SW_HIDE);
+    }
+}
+
+
 void CSubtitleDlDlg::OnOK()
 {
     if (IsDlgButtonChecked(IDC_CHECK1) == BST_CHECKED) {
@@ -312,15 +327,14 @@ void CSubtitleDlDlg::OnOK()
         }
     }
 
-    // Just hide the dialog, since it's modeless we don't want to call EndDialog
-    ShowWindow(SW_HIDE);
+    HideDialog();
 }
+
 
 
 void CSubtitleDlDlg::OnCancel()
 {
-    // Just hide the dialog, since it's modeless we don't want to call EndDialog
-    ShowWindow(SW_HIDE);
+    HideDialog();
 }
 
 void CSubtitleDlDlg::OnRefresh()

--- a/src/mpc-hc/SubtitleDlDlg.h
+++ b/src/mpc-hc/SubtitleDlDlg.h
@@ -94,6 +94,7 @@ protected:
     virtual void DoDataExchange(CDataExchange* pDX);
     virtual BOOL OnInitDialog();
     virtual BOOL PreTranslateMessage(MSG* pMsg);
+    void HideDialog();
     virtual void OnOK();
     virtual void OnCancel();
 


### PR DESCRIPTION
I am sure this is a Windows 11 bug.  There is no good reason a hidden window should be previewed.  It's definitely hidden, but it gets a preview render request anyway.  Overriding that request doesn't help as it still expects something for a window of that size.

Toolbar windows are not supposed to show up in the taskbar, and thus don't get involved in preview peek requests.  It changes the rendering of the window slightly, so I only enable it right before hiding and disable it right after.  It seems to do the trick.

Bit of a hack but...

Also added / rearranged version checking code to allow detection of Windows 11. SysVersion and VersionHelpersInternal now have no redundant code.