### PR TITLE
clean up code for modeless dialogs

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1097,9 +1097,9 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
     }
 
     m_pSubtitlesProviders = std::make_unique<SubtitlesProviders>(this);
-    m_wndSubtitlesDownloadDialog.Create(m_wndSubtitlesDownloadDialog.IDD, this, true);
+    m_wndSubtitlesDownloadDialog.Create(m_wndSubtitlesDownloadDialog.IDD, this, false);
     //m_wndSubtitlesUploadDialog.Create(m_wndSubtitlesUploadDialog.IDD, this);
-    m_wndFavoriteOrganizeDialog.Create(m_wndFavoriteOrganizeDialog.IDD, this, true);
+    m_wndFavoriteOrganizeDialog.Create(m_wndFavoriteOrganizeDialog.IDD, this, false);
 
     if (s.nCmdlnWebServerPort != 0) {
         if (s.nCmdlnWebServerPort > 0) {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1097,9 +1097,9 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
     }
 
     m_pSubtitlesProviders = std::make_unique<SubtitlesProviders>(this);
-    m_wndSubtitlesDownloadDialog.Create(m_wndSubtitlesDownloadDialog.IDD, this);
-    m_wndSubtitlesDownloadDialog.ShowWindow(SW_HIDE);
+    m_wndSubtitlesDownloadDialog.Create(m_wndSubtitlesDownloadDialog.IDD, this, true);
     //m_wndSubtitlesUploadDialog.Create(m_wndSubtitlesUploadDialog.IDD, this);
+    m_wndFavoriteOrganizeDialog.Create(m_wndFavoriteOrganizeDialog.IDD, this, true);
 
     if (s.nCmdlnWebServerPort != 0) {
         if (s.nCmdlnWebServerPort > 0) {
@@ -10236,9 +10236,6 @@ void CMainFrame::OnFavoritesQuickAddFavorite()
 
 void CMainFrame::OnFavoritesOrganize()
 {
-    if (!::IsWindow(m_wndFavoriteOrganizeDialog.m_hWnd)) {
-        m_wndFavoriteOrganizeDialog.Create(CFavoriteOrganizeDlg::IDD, this);
-    }
     m_wndFavoriteOrganizeDialog.ShowWindow(SW_SHOW);
 }
 

--- a/src/mpc-hc/ModelessResizableDialog.cpp
+++ b/src/mpc-hc/ModelessResizableDialog.cpp
@@ -9,8 +9,8 @@ END_MESSAGE_MAP()
 CModelessResizableDialog::CModelessResizableDialog(UINT nIDTemplate, CWnd* pParent) : CMPCThemeResizableDialog(nIDTemplate, pParent) {
 }
 
-BOOL CModelessResizableDialog::Create(UINT nIDTemplate, CWnd* pParentWnd, bool initiallyHidden /* = false */) {
-    this->initiallyHidden = initiallyHidden;
+BOOL CModelessResizableDialog::Create(UINT nIDTemplate, CWnd* pParentWnd, bool showOnWindowPlacement /* = true */) {
+    this->showOnWindowPlacement = showOnWindowPlacement;
     return CDialog::Create(nIDTemplate, pParentWnd);
 }
 

--- a/src/mpc-hc/ModelessResizableDialog.cpp
+++ b/src/mpc-hc/ModelessResizableDialog.cpp
@@ -9,8 +9,13 @@ END_MESSAGE_MAP()
 CModelessResizableDialog::CModelessResizableDialog(UINT nIDTemplate, CWnd* pParent) : CMPCThemeResizableDialog(nIDTemplate, pParent) {
 }
 
+BOOL CModelessResizableDialog::Create(UINT nIDTemplate, CWnd* pParentWnd, bool initiallyHidden /* = false */) {
+    this->initiallyHidden = initiallyHidden;
+    return CDialog::Create(nIDTemplate, pParentWnd);
+}
+
 void CModelessResizableDialog::HideDialog(INT_PTR ret) {
-    // Just hide the dialog, since it's modeless we don't want to call EndDialog
+    //EndDialog is ok because it doesn't destroy modeless dialogs, just hides them
     if (SysVersion::IsWin10orLater()) {
         //windows 11 bug with peek preview--shows hidden dialogs.  temporarily flag as tool window which is not a taskbar eligble window
         ModifyStyleEx(0, WS_EX_TOOLWINDOW);

--- a/src/mpc-hc/ModelessResizableDialog.h
+++ b/src/mpc-hc/ModelessResizableDialog.h
@@ -3,7 +3,7 @@
 class CModelessResizableDialog : public CMPCThemeResizableDialog {
 public:
     CModelessResizableDialog(UINT nIDTemplate, CWnd* pParent);
-    virtual BOOL Create(UINT nIDTemplate, CWnd* pParentWnd, bool initiallyHidden = false);
+    virtual BOOL Create(UINT nIDTemplate, CWnd* pParentWnd, bool showOnWindowPlacement = true);
     void HideDialog(INT_PTR ret);
     DECLARE_MESSAGE_MAP()
 protected:

--- a/src/mpc-hc/ModelessResizableDialog.h
+++ b/src/mpc-hc/ModelessResizableDialog.h
@@ -3,6 +3,7 @@
 class CModelessResizableDialog : public CMPCThemeResizableDialog {
 public:
     CModelessResizableDialog(UINT nIDTemplate, CWnd* pParent);
+    virtual BOOL Create(UINT nIDTemplate, CWnd* pParentWnd, bool initiallyHidden = false);
     void HideDialog(INT_PTR ret);
     DECLARE_MESSAGE_MAP()
 protected:

--- a/src/thirdparty/ResizableLib/ResizableWndState.cpp
+++ b/src/thirdparty/ResizableLib/ResizableWndState.cpp
@@ -114,10 +114,14 @@ BOOL CResizableWndState::LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 		&rc.right, &rc.bottom, &wp.showCmd, &wp.flags,
 		&wp.ptMinPosition.x, &wp.ptMinPosition.y) == 8)
 	{
-		if (bRectOnly)	// restore size/pos only
+
+        // MPC-HC custom code
+        if (initiallyHidden) {
+            wp.showCmd = SW_HIDE;
+        }
+
+        if (bRectOnly)	// restore size/pos only
 		{
-			// MPC-HC custom code
-			wp.showCmd = SW_HIDE;
 			wp.flags = 0;
 		}
 		// restore also min/max state

--- a/src/thirdparty/ResizableLib/ResizableWndState.cpp
+++ b/src/thirdparty/ResizableLib/ResizableWndState.cpp
@@ -116,7 +116,7 @@ BOOL CResizableWndState::LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly)
 	{
 
         // MPC-HC custom code
-        if (initiallyHidden) {
+        if (!showOnWindowPlacement) {
             wp.showCmd = SW_HIDE;
         }
 

--- a/src/thirdparty/ResizableLib/ResizableWndState.h
+++ b/src/thirdparty/ResizableLib/ResizableWndState.h
@@ -44,7 +44,7 @@ class CResizableWndState : public CResizableState
 {
 protected:
     // MPC-HC custom code
-    bool initiallyHidden = false;
+    bool showOnWindowPlacement = true;
 	//! @brief Load and set the window position and size
 	BOOL LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly);
 

--- a/src/thirdparty/ResizableLib/ResizableWndState.h
+++ b/src/thirdparty/ResizableLib/ResizableWndState.h
@@ -43,7 +43,8 @@
 class CResizableWndState : public CResizableState  
 {
 protected:
-
+    // MPC-HC custom code
+    bool initiallyHidden = false;
 	//! @brief Load and set the window position and size
 	BOOL LoadWindowRect(LPCTSTR pszName, BOOL bRectOnly);
 


### PR DESCRIPTION
This allows creation of a modeless dialog that will not be displayed when EnableSaveRestore() is called.  It is not dependent on the min/max state anymore, which adds flexibility.  It adds one flag to the create method for derived dialogs.

Also was able to remove the SW_HIDE calls as they are non-functional when working.  The two dialogs in question (download subs and fav organize) are set to be invisible on creation.  The only reason fav dialog ever showed is the restorewindowstate call which displays it by default.

No need to create on the fly, either, removed that code for favorites.