### PR TITLE
fix for evr-cp rotation being cut off

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -7823,8 +7823,17 @@ bool CMainFrame::PerformFlipRotate()
             }
         }
     } else if (m_pCAP) {
-        // default angle has already been set, so only apply custom angle
-        hr = m_pCAP->SetVideoAngle(Vector(Vector::DegToRad(m_AngleX), Vector::DegToRad(m_AngleY), Vector::DegToRad(m_AngleZ)));
+        // EVR-CP behavior for custom angles is ignored when choosing video size and zoom
+        // We get better results if we treat the closest 90 as the standard rotation, and custom rotate the remainder (<45deg)
+        int z = m_AngleZ;
+        if (m_pCAP2) {
+            int nZ = nearest90(z);
+            z = z - nZ;
+            Vector defAngle = Vector(0, 0, Vector::DegToRad((nZ + m_iDefRotation) % 360));
+            m_pCAP2->SetDefaultVideoAngle(defAngle);
+        }
+        
+        hr = m_pCAP->SetVideoAngle(Vector(Vector::DegToRad(m_AngleX), Vector::DegToRad(m_AngleY), Vector::DegToRad(z)));
     }
 
     if (FAILED(hr)) {


### PR DESCRIPTION
So this bug has been around a while.  I had to change many areas of the code, both within `CSubPicAllocatorPresenterImpl` and `CMainFrame`, to get it to resize properly, and choose correct sizes when zooming.  A lot of ugly hacks and workarounds.

However, I tried something different now, and it seems to be a pretty simple approach.  Instead of trying to make the code aware of the custom angle, I simply add the largest multiple of 90 to the default rotation, and rotate manually the remainder (should there be any).  It seems to work pretty flawlessly.

One quirk is that doing the Alt+1 rotation causes the video size to "jump" when crossing a 45 degree boundary.  This is because it's choosing the zoom level based on the closest 90 degree angle. So when it's closer to being aliged with the long dimension, it's long (and vice-versa).

See what you think.  We actually have two bug reports around this issue.