### PR TITLE
experimental freetype rendering path

### DIFF
--- a/src/Subtitles/RTS.cpp
+++ b/src/Subtitles/RTS.cpp
@@ -536,6 +536,7 @@ bool CText::CreatePath()
         bool bFirstPath = true;
         bool failedPath = false;
         int ftWidth = width;
+
         for (LPCWSTR s = m_str; *s; s++) {
             if (!getExtent(s)) {
                 return false;
@@ -564,7 +565,7 @@ bool CText::CreatePath()
                 if (!getExtent(s)) {
                     return false;
                 }
-                GetPathFreeType(g_hDC, bFirstPath, s[0], m_style.fontSize, width, 0);
+                GetPathFreeType(g_hDC, bFirstPath, m_style.fontName, s[0], m_style.fontSize, width, 0);
                 bFirstPath = false;
                 width += cx + (int)m_style.fontSpacing;
             }

--- a/src/Subtitles/RTS.cpp
+++ b/src/Subtitles/RTS.cpp
@@ -520,31 +520,54 @@ bool CText::CreatePath()
     HFONT hOldFont = SelectFont(g_hDC, font);
 
     if (m_style.fontSpacing) {
-        int width = 0;
-        bool bFirstPath = true;
-
-        for (LPCWSTR s = m_str; *s; s++) {
+        LONG cx;
+        auto getExtent = [&](LPCWSTR s) {
             CSize extent;
             if (!GetTextExtentPoint32W(g_hDC, s, 1, &extent)) {
                 SelectFont(g_hDC, hOldFont);
                 ASSERT(0);
                 return false;
             }
-            bool wasFirstPath = bFirstPath;
+            cx = extent.cx;
+            return true;
+        };
+
+        int width = 0;
+        bool bFirstPath = true;
+        bool failedPath = false;
+        int ftWidth = width;
+        for (LPCWSTR s = m_str; *s; s++) {
+            if (!getExtent(s)) {
+                return false;
+            }
             PartialBeginPath(g_hDC, bFirstPath);
             bFirstPath = false;
             TextOutW(g_hDC, 0, 0, s, 1);
             int mp = mPathPoints;
             PartialEndPath(g_hDC, width, 0);
             if (mp == mPathPoints && L' ' != s[0]) { //failed to add points, we will try again with FreeType as emulator
-                GetPathFreeType(g_hDC, wasFirstPath, s[0], m_style.fontSize, width, 0);
+                failedPath=true;
+                break;
             }
 #if 0
-            GetPathFreeType(g_hDC, false, s[0], m_style.fontSize, width+ extent.cx + (int)m_style.fontSpacing, 0);
+            GetPathFreeType(g_hDC, false, s[0], m_style.fontSize, width+ cx + (int)m_style.fontSpacing, 0);
             GetPathFreeType(g_hDC, false, s[0], m_style.fontSize, width, m_style.fontSize*2);
 #endif
 
-            width += extent.cx + (int)m_style.fontSpacing;
+            width += cx + (int)m_style.fontSpacing;
+        }
+        if (failedPath) { //try freetype
+            width = ftWidth;
+            bFirstPath = true;
+
+            for (LPCWSTR s = m_str; *s; s++) {
+                if (!getExtent(s)) {
+                    return false;
+                }
+                GetPathFreeType(g_hDC, bFirstPath, s[0], m_style.fontSize, width, 0);
+                bFirstPath = false;
+                width += cx + (int)m_style.fontSpacing;
+            }
         }
     } else {
         CSize extent;

--- a/src/Subtitles/RTS.cpp
+++ b/src/Subtitles/RTS.cpp
@@ -530,11 +530,19 @@ bool CText::CreatePath()
                 ASSERT(0);
                 return false;
             }
-
+            bool wasFirstPath = bFirstPath;
             PartialBeginPath(g_hDC, bFirstPath);
             bFirstPath = false;
             TextOutW(g_hDC, 0, 0, s, 1);
+            int mp = mPathPoints;
             PartialEndPath(g_hDC, width, 0);
+            if (mp == mPathPoints && L' ' != s[0]) { //failed to add points, we will try again with FreeType as emulator
+                GetPathFreeType(g_hDC, wasFirstPath, s[0], m_style.fontSize, width, 0);
+            }
+#if 0
+            GetPathFreeType(g_hDC, false, s[0], m_style.fontSize, width+ extent.cx + (int)m_style.fontSpacing, 0);
+            GetPathFreeType(g_hDC, false, s[0], m_style.fontSize, width, m_style.fontSize*2);
+#endif
 
             width += extent.cx + (int)m_style.fontSpacing;
         }

--- a/src/Subtitles/Rasterizer.cpp
+++ b/src/Subtitles/Rasterizer.cpp
@@ -27,6 +27,11 @@
 #include "Rasterizer.h"
 #include "SeparableFilter.h"
 #include "../SubPic/ISubPic.h"
+#include <ft2build.h>
+#include <freetype/ftoutln.h>
+#include <freetype/internal/ftobjs.h>
+#include FT_FREETYPE_H
+#include FT_SYNTHESIS_H
 
 int Rasterizer::getOverlayWidth() const
 {
@@ -290,14 +295,29 @@ bool Rasterizer::PartialBeginPath(HDC hdc, bool bClearPath)
     return !!::BeginPath(hdc);
 }
 
+bool Rasterizer::ResizePath(int nPoints) {
+    BYTE* pNewTypes;
+    POINT* pNewPoints;
+
+    pNewTypes = (BYTE*)realloc(mpPathTypes, (mPathPoints + nPoints) * sizeof(BYTE));
+    pNewPoints = (POINT*)realloc(mpPathPoints, (mPathPoints + nPoints) * sizeof(POINT));
+
+    if (pNewTypes) {
+        mpPathTypes = pNewTypes;
+    }
+
+    if (pNewPoints) {
+        mpPathPoints = pNewPoints;
+    }
+    return pNewTypes && pNewPoints;
+}
+
 bool Rasterizer::PartialEndPath(HDC hdc, long dx, long dy)
 {
     ::CloseFigure(hdc);
 
     if (::EndPath(hdc)) {
         int nPoints;
-        BYTE* pNewTypes;
-        POINT* pNewPoints;
 
         nPoints = GetPath(hdc, nullptr, nullptr, 0);
 
@@ -305,21 +325,12 @@ bool Rasterizer::PartialEndPath(HDC hdc, long dx, long dy)
             return true;
         }
 
-        pNewTypes = (BYTE*)realloc(mpPathTypes, (mPathPoints + nPoints) * sizeof(BYTE));
-        pNewPoints = (POINT*)realloc(mpPathPoints, (mPathPoints + nPoints) * sizeof(POINT));
-
-        if (pNewTypes) {
-            mpPathTypes = pNewTypes;
-        }
-
-        if (pNewPoints) {
-            mpPathPoints = pNewPoints;
-        }
+        bool resizeSuccess = ResizePath(nPoints);
 
         BYTE* pTypes = DEBUG_NEW BYTE[nPoints];
         POINT* pPoints = DEBUG_NEW POINT[nPoints];
 
-        if (pNewTypes && pNewPoints && nPoints == GetPath(hdc, pPoints, pTypes, nPoints)) {
+        if (resizeSuccess && nPoints == GetPath(hdc, pPoints, pTypes, nPoints)) {
             for (ptrdiff_t i = 0; i < nPoints; ++i) {
                 mpPathPoints[mPathPoints + i].x = pPoints[i].x + dx;
                 mpPathPoints[mPathPoints + i].y = pPoints[i].y + dy;
@@ -1847,4 +1858,120 @@ void Rasterizer::FillSolidRect(SubPicDesc& spd, int x, int y, int nWidth, int nH
     ASSERT(spd.w >= x + nWidth && spd.h >= y + nHeight);
     BYTE* dst = (BYTE*)((DWORD*)(spd.bits + spd.pitch * y) + x);
     DrawInternal(m_bUseAVX2, dst, spd.pitch, BYTE(0x40), nWidth, nHeight, lColor);
+}
+
+FT_Library  library;
+
+void Rasterizer::AddFTPath(BYTE type, FT_Pos x, FT_Pos y, FTPathData *data) {
+    y = data->tmAscent - y + data->dy;
+    x += data->dx;
+    data->ftTypes.push_back(type);
+    data->ftPoints.push_back({ x, y });
+}
+
+static FT_Error ft_move_to(const FT_Vector* to, void* user) {
+    FTPathData* data = (FTPathData*)user;
+    data->r->AddFTPath(PT_MOVETO, to->x / 64, to->y / 64, data);
+    return 0;
+}
+static FT_Error ft_line_to(const FT_Vector* to, void* user) {
+    FTPathData* data = (FTPathData*)user;
+    data->r->AddFTPath(PT_LINETO, to->x / 64, to->y / 64, data);
+    return 0;
+}
+static FT_Error ft_conic_to(const FT_Vector* control_1, const FT_Vector* to, void* user) {
+    FTPathData* data = (FTPathData*)user;
+    data->r->AddFTPath(PT_BEZIERTO, control_1->x / 64, control_1->y / 64, data);
+    data->r->AddFTPath(PT_BEZIERTO, (control_1->x+to->x) / 128, (control_1->y+to->y) / 128, data);
+    data->r->AddFTPath(PT_BEZIERTO, to->x / 64, to->y / 64, data);
+    return 0;
+}
+static FT_Error ft_cubic_to(const FT_Vector* control_1, const FT_Vector* control_2, const FT_Vector* to, void* user) {
+    FTPathData* data = (FTPathData*)user;
+    data->r->AddFTPath(PT_BEZIERTO, control_1->x / 64, control_1->y / 64, data);
+    data->r->AddFTPath(PT_BEZIERTO, control_2->x / 64, control_2->y / 64, data);
+    data->r->AddFTPath(PT_BEZIERTO, to->x / 64, to->y / 64, data);
+    return 0;
+}
+
+FT_DEFINE_OUTLINE_FUNCS(
+    ft_decompose_funcs,
+    (FT_Outline_MoveTo_Func)ft_move_to,   /* move_to  */
+    (FT_Outline_LineTo_Func)ft_line_to,   /* line_to  */
+    (FT_Outline_ConicTo_Func)ft_conic_to,  /* conic_to */
+    (FT_Outline_CubicTo_Func)ft_cubic_to,  /* cubic_to */
+    0,                                      /* shift    */
+    0                                       /* delta    */
+)
+
+bool Rasterizer::GetPathFreeType(HDC hdc, bool bClearPath, wchar_t ch, int size, int dx, int dy) {
+    if (bClearPath) {
+        _TrashPath();
+    }
+
+    FT_Face face;
+    FT_Library library;
+    FT_Error error;
+    error = FT_Init_FreeType(&library);
+
+    if (!error) {
+        DWORD fontSize = GetFontData(hdc, 0, 0, NULL, 0);
+        FT_Byte* fontData = DEBUG_NEW FT_Byte[fontSize];
+        GetFontData(hdc, 0, 0, fontData, fontSize);
+        error = FT_New_Memory_Face(library, fontData, fontSize, 0, &face);
+        if (!error) {
+            TEXTMETRIC GDIMetrics;
+            GetTextMetricsW(hdc, &GDIMetrics);
+
+            FT_UInt glyph_index = FT_Get_Char_Index(face, ch);
+            FT_Set_Pixel_Sizes(face, 0xffff, 0xffff);
+            float ascRatio, heightRatio;
+            //this is a weird hack, but the ratio of the ascent seems a good estimate of the right font size.  Worked perfectly with Arial
+            ascRatio = float(GDIMetrics.tmAscent) / face->size->metrics.ascender;
+            heightRatio = float(GDIMetrics.tmHeight) / face->size->metrics.height;
+            error = FT_Set_Pixel_Sizes(face, 0xffff * ascRatio * 64, 0xffff * ascRatio * 64);
+            //If the ascent ratio didn't work (>3.125%), we will do a basic height ratio.  it works well on other fonts
+            if (std::abs(64 - float(face->size->metrics.height) / GDIMetrics.tmHeight) > 2) { 
+                error = FT_Set_Pixel_Sizes(face, 0xffff * heightRatio * 64, 0xffff * heightRatio * 64);
+            }
+
+            if (!error) {
+                error = FT_Load_Glyph(face, glyph_index, FT_LOAD_FORCE_AUTOHINT | FT_LOAD_NO_BITMAP);
+                if (!error) {
+                    FT_Glyph_Metrics* metrics = &face->glyph->metrics;
+                    FTPathData pd;
+                    pd.dx = dx;
+                    pd.dy = dy;
+                    pd.r = this;
+                    pd.tmAscent = GDIMetrics.tmAscent; //this is the y baseline.  match windows and not Freetype
+                    error = FT_Outline_Decompose(&face->glyph->outline, &ft_decompose_funcs, (void*)&pd);
+#if 0
+                    for (int a = 0; a < mPathPoints; a++) {
+                        TRACE("winxxx\t%d\t%d\t%d\n", mpPathPoints[a].x, mpPathPoints[a].y, mpPathTypes[a]);
+                    }
+#endif
+                    int nPoints = pd.ftPoints.size();
+                    if (ResizePath(nPoints)) {
+                        for (int a = 0; a < pd.ftPoints.size(); a++) {
+                            mpPathTypes[mPathPoints+a] = pd.ftTypes[a];
+                            mpPathPoints[mPathPoints+a] = pd.ftPoints[a];
+                        }
+                        mPathPoints += nPoints;
+                    }
+#if 0
+                    for (int a = mPathPoints - nPoints; a < mPathPoints; a++) {
+                        TRACE("ft\t%d\t%d\t%d\n", mpPathPoints[a].x, mpPathPoints[a].y, mpPathTypes[a]);
+                    }
+#endif
+                }
+            }
+        }
+        delete[] fontData;
+        FT_Done_Face(face);
+        FT_Done_FreeType(library);
+        if (!error) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/Subtitles/Rasterizer.h
+++ b/src/Subtitles/Rasterizer.h
@@ -170,6 +170,8 @@ private:
     struct faceData {
         FT_Byte* fontData;
         FT_Face face;
+        FT_UInt ratio;
+        LONG ascent;
     };
     std::unordered_map<std::wstring, faceData> faceCache;
     bool ftInitialized;

--- a/src/Subtitles/Rasterizer.h
+++ b/src/Subtitles/Rasterizer.h
@@ -125,7 +125,19 @@ struct COverlayData {
     }
 };
 
+class Rasterizer;
+
 typedef std::shared_ptr<COverlayData> COverlayDataSharedPtr;
+typedef signed long  FT_Pos;
+struct FTPathData {
+    std::vector<BYTE> ftTypes;
+    std::vector<POINT> ftPoints;
+    int dx;
+    int dy;
+    Rasterizer* r;
+    LONG tmAscent;
+};
+
 
 class Rasterizer
 {
@@ -153,7 +165,6 @@ private:
     unsigned int mEdgeNext;
 
     unsigned int* mpScanBuffer;
-
 protected:
     CEllipseSharedPtr m_pEllipse;
     COutlineDataSharedPtr m_pOutlineData;
@@ -169,6 +180,7 @@ private:
     template<int flag> __forceinline void _EvaluateLine(int x0, int y0, int x1, int y1);
     static void _OverlapRegion(tSpanBuffer& dst, const tSpanBuffer& src, int dx, int dy);
     void CreateWidenedRegionFast(int borderX, int borderY);
+    bool ResizePath(int nPoints);
 
 public:
     Rasterizer();
@@ -182,6 +194,8 @@ public:
     bool CreateWidenedRegion(int borderX, int borderY);
     bool Rasterize(int xsub, int ysub, int fBlur, double fGaussianBlur);
     int getOverlayWidth() const;
+    bool GetPathFreeType(HDC hdc, bool bClearPath, wchar_t ch, int size, int dx, int dy);
+    void AddFTPath(BYTE type, FT_Pos x, FT_Pos y, FTPathData* data);
 
     CRect Draw(SubPicDesc& spd, CRect& clipRect, byte* pAlphaMask, int xsub, int ysub, const DWORD* switchpts, bool fBody, bool fBorder) const;
     void FillSolidRect(SubPicDesc& spd, int x, int y, int nWidth, int nHeight, DWORD lColor) const;

--- a/src/Subtitles/Rasterizer.h
+++ b/src/Subtitles/Rasterizer.h
@@ -24,7 +24,7 @@
 #include "Ellipse.h"
 #include <memory>
 #include <vector>
-
+#include "freetype/freetype.h"
 
 #define PT_MOVETONC         0xfe
 #define PT_BSPLINETO        0xfc
@@ -165,6 +165,8 @@ private:
     unsigned int mEdgeNext;
 
     unsigned int* mpScanBuffer;
+    FT_Library ftLibrary;
+    bool ftInitialized;
 protected:
     CEllipseSharedPtr m_pEllipse;
     COutlineDataSharedPtr m_pOutlineData;

--- a/src/Subtitles/Rasterizer.h
+++ b/src/Subtitles/Rasterizer.h
@@ -24,6 +24,7 @@
 #include "Ellipse.h"
 #include <memory>
 #include <vector>
+#include <unordered_map>
 #include "freetype/freetype.h"
 
 #define PT_MOVETONC         0xfe
@@ -166,6 +167,11 @@ private:
 
     unsigned int* mpScanBuffer;
     FT_Library ftLibrary;
+    struct faceData {
+        FT_Byte* fontData;
+        FT_Face face;
+    };
+    std::unordered_map<std::wstring, faceData> faceCache;
     bool ftInitialized;
 protected:
     CEllipseSharedPtr m_pEllipse;
@@ -196,8 +202,8 @@ public:
     bool CreateWidenedRegion(int borderX, int borderY);
     bool Rasterize(int xsub, int ysub, int fBlur, double fGaussianBlur);
     int getOverlayWidth() const;
-    bool GetPathFreeType(HDC hdc, bool bClearPath, wchar_t ch, int size, int dx, int dy);
-    void AddFTPath(BYTE type, FT_Pos x, FT_Pos y, FTPathData* data);
+    bool GetPathFreeType(HDC hdc, bool bClearPath, CStringW fontName, wchar_t ch, int size, int dx, int dy);
+    inline void AddFTPath(BYTE type, FT_Pos x, FT_Pos y, FTPathData* data);
 
     CRect Draw(SubPicDesc& spd, CRect& clipRect, byte* pAlphaMask, int xsub, int ysub, const DWORD* switchpts, bool fBody, bool fBorder) const;
     void FillSolidRect(SubPicDesc& spd, int x, int y, int nWidth, int nHeight, DWORD lColor) const;

--- a/src/Subtitles/Subtitles.vcxproj
+++ b/src/Subtitles/Subtitles.vcxproj
@@ -41,7 +41,7 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\include;..\thirdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;..\thirdparty;..\thirdparty\freetype2\freetype2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/src/filters/source/SubtitleSource/SubtitleSource.vcxproj
+++ b/src/filters/source/SubtitleSource/SubtitleSource.vcxproj
@@ -63,7 +63,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\thirdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\thirdparty;..\..\..\thirdparty\freetype2\freetype2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="!$(Configuration.Contains('Filter'))">

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -76,7 +76,7 @@
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\include;..\DSUtil;..\filters\renderer\VideoRenderers;..\thirdparty;..\thirdparty\AudioTools;..\thirdparty\MediaInfo\library\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;..\DSUtil;..\filters\renderer\VideoRenderers;..\thirdparty;..\thirdparty\AudioTools;..\thirdparty\MediaInfo\library\Source;..\thirdparty\freetype2\freetype2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)res\mpc-hc.exe.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>


### PR DESCRIPTION
This is an alternate way to create truetype paths, using Freetype library.  The worst part about this is MM_TEXT, which has scaling that I can't make sense of.  There's some info out there but I couldn't understand it fully.  Right now, I simply tell freetype to scale to a pixel size that comes close to what windows metrics is suggesting.  It's not the same, remotely, as what Freetype thinks for the same font size...

Overall, this is a pretty small amount of code, it only applies during the `m_style.fontSpacing` codepath (meaning one character rendered at a time), and it only activates if the `GetPath` function fails, as it did in issue https://github.com/clsid2/mpc-hc/issues/1775.

The result is that the funny font renders and works.  Most likely this issue is super rare.  We should get libass working, but this is a decent backup option if the other renderer is preferred for some reason.  Even this "fix" could be locked inside an advanced option, I suppose.

See what you think.