### PR TITLE
#1398 Restore old sort behaviour on add current folder to playlist.

### DIFF
--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -2182,6 +2182,8 @@ void CPlayerPlaylistBar::OnContextMenu(CWnd* /*pWnd*/, CPoint point)
             const CString dirName = PathUtils::DirName(m_pl.GetAt(pos).m_fns.GetHead());
             if (PathUtils::IsDir(dirName)) {
                 if (AddItemsInFolder(dirName)) {
+                    // @todo - quickfix to restore old playlist behaviour to sort by path by default. may be a better way to do this?
+                    m_pl.SortByPath();
                     Refresh();
                     SavePlaylist();
                 }


### PR DESCRIPTION
problem described in #1398 

Older version of MPHC would automatically sort files when using the `Add containing folder` option when right clicking on playlist.  Newer and current versions do not and it requires a second click to sort by path again.

