### PR TITLE
Allow response to any origin: Prevent CORS errors with local webservers

### DIFF
--- a/src/mpc-hc/WebClientSocket.cpp
+++ b/src/mpc-hc/WebClientSocket.cpp
@@ -212,6 +212,7 @@ void CWebClientSocket::HandleRequest()
         }
 
         reshdr +=
+            "Access-Control-Allow-Origin: *\r\n"
             "Server: MPC-HC WebServer\r\n"
             "Connection: close\r\n"
             "\r\n";


### PR DESCRIPTION
This sets a header to allow requesting code from any origin to access the web server. 
I'm trying to use a locally hosted web server to interact with MPC-HC but the CORS protection of browsers prevents it from working. 

I want my local mediaserver, Jellyfin, to keep track of MPC-HC track position using requests to the MPC-HC /status.html webpage.

Apparently, setting this header will make it work. I have no idea what I'm doing.
