### PR TITLE
make bFullscreenSeparateControls compatible with launch in fs

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -10771,38 +10771,43 @@ void CMainFrame::SetDefaultFullscreenState()
 {
     CAppSettings& s = AfxGetAppSettings();
 
-    bool clGoFullscreen = !(s.nCLSwitches & CLSW_ADD) && (s.nCLSwitches & CLSW_FULLSCREEN);
+    if (!s.bFullscreenSeparateControls) {
+        bool clGoFullscreen = !(s.nCLSwitches & CLSW_ADD) && (s.nCLSwitches & CLSW_FULLSCREEN);
 
-    if (clGoFullscreen && !s.slFiles.IsEmpty()) {
-        // ignore fullscreen if all files are audio
-        clGoFullscreen = false;
-        const CMediaFormats& mf = AfxGetAppSettings().m_Formats;
-        POSITION pos = s.slFiles.GetHeadPosition();
-        while (pos) {
-            CString fpath = s.slFiles.GetNext(pos);
-            CString ext = fpath.Mid(fpath.ReverseFind('.') + 1);
-            if (!mf.FindExt(ext, true)) {
-                clGoFullscreen = true;
-                break;
+        if (clGoFullscreen && !s.slFiles.IsEmpty()) {
+            // ignore fullscreen if all files are audio
+            clGoFullscreen = false;
+            const CMediaFormats& mf = AfxGetAppSettings().m_Formats;
+            POSITION pos = s.slFiles.GetHeadPosition();
+            while (pos) {
+                CString fpath = s.slFiles.GetNext(pos);
+                CString ext = fpath.Mid(fpath.ReverseFind('.') + 1);
+                if (!mf.FindExt(ext, true)) {
+                    clGoFullscreen = true;
+                    break;
+                }
             }
         }
-    }
 
-    if (clGoFullscreen) {
-        if (s.IsD3DFullscreen()) {
-            m_fStartInD3DFullscreen = true;
-        } else {
-            ToggleFullscreen(true, true);
-            m_fFirstFSAfterLaunchOnFS = true;
+        if (clGoFullscreen) {
+            if (s.IsD3DFullscreen()) {
+                m_fStartInD3DFullscreen = true;
+            }
+            else {
+                ToggleFullscreen(true, true);
+                m_fFirstFSAfterLaunchOnFS = true;
+            }
+            s.nCLSwitches &= ~CLSW_FULLSCREEN;
         }
-        s.nCLSwitches &= ~CLSW_FULLSCREEN;
-    } else if (s.fRememberWindowSize && s.fRememberWindowPos && !m_fFullScreen && s.fLastFullScreen) {
-        // Casimir666 : if fullscreen was on, put it on back
-        if (s.IsD3DFullscreen()) {
-            m_fStartInD3DFullscreen = true;
-        } else {
-            ToggleFullscreen(true, true);
-            m_fFirstFSAfterLaunchOnFS = true;
+        else if (s.fRememberWindowSize && s.fRememberWindowPos && !m_fFullScreen && s.fLastFullScreen) {
+            // Casimir666 : if fullscreen was on, put it on back
+            if (s.IsD3DFullscreen()) {
+                m_fStartInD3DFullscreen = true;
+            }
+            else {
+                ToggleFullscreen(true, true);
+                m_fFirstFSAfterLaunchOnFS = true;
+            }
         }
     }
 }
@@ -11112,7 +11117,7 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
 
     if (fullScreenSecondMonitor) {
         m_fFullScreen = !m_fFullScreen;
-        s.fLastFullScreen = m_fFullScreen;
+        s.fLastFullScreen = false; //not really, just fullScreenSecondMonitor
 
         if (m_fFullScreen) {
             m_eventc.FireEvent(MpcEvent::SWITCHING_TO_FULLSCREEN);


### PR DESCRIPTION
What this does is:

1. If fssc is enabled, just ignore the "default" fullscreen state code.
2. Don't save fullscreen state=true when going fs with fssc.  It's pointless (`#1` means it won't be checked anyway unless fssc is disabled before shutdown)

As far as I can tell this causes no regressions. The code only changes when fssc is enabled.  fssc seems to work as expected, now.  And there is no need to save lastfullscreen if we have an automatic way of going fullscreen.

I also tested it when fs monitor=current monitor.  In that case it doesn't go fssc, but it still successfully goes fullscreen.  Probably it goes through the fssc logic but changes approach once it realizes monitor is the same.