### PR TITLE
dpi improvements

### DIFF
--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -125,6 +125,14 @@ bool CMPCThemePlayerListCtrl::getFlaggedItem(int iItem)
     }
 }
 
+void CMPCThemePlayerListCtrl::DoDPIChanged()
+{
+    if (listMPCThemeFontBold.m_hObject) {
+        listMPCThemeFontBold.DeleteObject();
+    }
+
+}
+
 
 BOOL CMPCThemePlayerListCtrl::PreTranslateMessage(MSG* pMsg)
 {

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.h
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.h
@@ -33,6 +33,7 @@ public:
     void setFlaggedItem(int iItem, bool flagged);
     bool getFlaggedItem(int iItem);
     void setColorInterface(CMPCThemeListCtrlCustomInterface* iface) { customThemeInterface = iface; };
+    void DoDPIChanged();
 
     DECLARE_MESSAGE_MAP()
     afx_msg void OnNcPaint();

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1786,9 +1786,8 @@ LRESULT CMainFrame::OnDpiChanged(WPARAM wParam, LPARAM lParam)
 {
     m_dpi.Override(LOWORD(wParam), HIWORD(wParam));
     m_eventc.FireEvent(MpcEvent::DPI_CHANGED);
+    CMPCThemeUtil::GetMetrics(true); //force reset metrics used by util class
     CMPCThemeMenu::clearDimensions();
-    NONCLIENTMETRICS m = { sizeof(NONCLIENTMETRICS) };
-    ::SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &m, 0);
     if (!restoringWindowRect) { //do not adjust for DPI if restoring saved window position
         MoveWindow(reinterpret_cast<RECT*>(lParam));
     }

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -27,6 +27,8 @@
 #include "CrashReporter.h"
 #include "ExceptionHandler.h"
 
+IMPLEMENT_DYNAMIC(CPPageAdvanced, CMPCThemePPageBase)
+
 CPPageAdvanced::CPPageAdvanced()
     : CMPCThemePPageBase(IDD, IDD)
 {
@@ -46,15 +48,7 @@ void CPPageAdvanced::DoDataExchange(CDataExchange* pDX)
 BOOL CPPageAdvanced::OnInitDialog()
 {
     __super::OnInitDialog();
-
-    if (CFont* pFont = m_list.GetFont()) {
-        if (!m_fontBold.m_hObject) {
-            LOGFONT logfont;
-            pFont->GetLogFont(&logfont);
-            logfont.lfWeight = FW_BOLD;
-            m_fontBold.CreateFontIndirect(&logfont);
-        }
-    }
+    initBoldFont();
 
     SetRedraw(FALSE);
     m_list.SetExtendedStyle(m_list.GetExtendedStyle() /* | LVS_EX_FULLROWSELECT */ | LVS_EX_AUTOSIZECOLUMNS /*| LVS_EX_DOUBLEBUFFER */ | LVS_EX_INFOTIP);
@@ -516,4 +510,24 @@ void CPPageAdvanced::OnEnChangeEdit()
             SetModified();
         }
     }
+}
+
+void CPPageAdvanced::initBoldFont() {
+    if (CFont* pFont = m_list.GetFont()) {
+        if (!m_fontBold.m_hObject) {
+            LOGFONT logfont;
+            pFont->GetLogFont(&logfont);
+            logfont.lfWeight = FW_BOLD;
+            m_fontBold.CreateFontIndirect(&logfont);
+        }
+    }
+}
+
+void CPPageAdvanced::DoDPIChanged()
+{
+    if (m_fontBold.m_hObject) {
+        m_fontBold.DeleteObject();
+    }
+    initBoldFont();
+    m_list.DoDPIChanged(); //themed listctrl stores its own font, and isn't drawn through CPPageAdvanced::OnNMCustomdraw
 }

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -172,9 +172,11 @@ public:
 
 class CPPageAdvanced : public CMPCThemePPageBase
 {
+    DECLARE_DYNAMIC(CPPageAdvanced)
 public:
     CPPageAdvanced();
     virtual ~CPPageAdvanced() = default;
+    virtual void DoDPIChanged();
 
 private:
     enum { IDD = IDD_PPAGEADVANCED };
@@ -266,6 +268,8 @@ protected:
     virtual void DoDataExchange(CDataExchange* pDX) override;
     virtual BOOL OnInitDialog() override;
     virtual BOOL OnApply() override;
+    void initBoldFont();
+
 
     afx_msg void OnBnClickedDefaultButton();
     afx_msg void OnUpdateDefaultButton(CCmdUI* pCmdUI);

--- a/src/mpc-hc/PPageSheet.cpp
+++ b/src/mpc-hc/PPageSheet.cpp
@@ -332,6 +332,10 @@ LRESULT CPPageSheet::OnDpiChanged(WPARAM wParam, LPARAM lParam) {
                     dlgChild = dlgChild->GetNextWindow();
                 }
             }
+            CPPageAdvanced* ppa;
+            if (ppa = DYNAMIC_DOWNCAST(CPPageAdvanced, pChild)) {
+                ppa->DoDPIChanged();
+            }
             pChild = pChild->GetNextWindow();
         }
 

--- a/src/mpc-hc/PlayerStatusBar.cpp
+++ b/src/mpc-hc/PlayerStatusBar.cpp
@@ -94,9 +94,7 @@ CSize CPlayerStatusBar::CalcFixedLayout(BOOL bStretch, BOOL bHorz)
 {
     CSize ret = __super::CalcFixedLayout(bStretch, bHorz);
     ret.cy = std::max<long>(ret.cy, 24);
-    if (!DpiHelper::CanUsePerMonitorV2()) {
-        ret.cy = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(ret.cy);
-    }
+    ret.cy = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(ret.cy);
     return ret;
 }
 

--- a/src/mpc-hc/StatusLabel.cpp
+++ b/src/mpc-hc/StatusLabel.cpp
@@ -44,9 +44,7 @@ void CStatusLabel::ScaleFont(const DpiHelper& dpiHelper)
     LOGFONT lf;
 
     GetStatusFont(&lf);
-    if (!DpiHelper::CanUsePerMonitorV2()) {
-        lf.lfHeight = dpiHelper.ScaleSystemToOverrideY(lf.lfHeight);
-    }
+    lf.lfHeight = dpiHelper.ScaleSystemToOverrideY(lf.lfHeight);
     VERIFY(m_font.CreateFontIndirect(&lf));
 }
 


### PR DESCRIPTION
This fixes a few issues:

1. Status bar wrong height.  I can see the code was trying to avoid scaling when `PerMonitorV2` was enabled, but it was still needed on a lower dpi screen.  I'm not sure when this stopped working or if it ever was working.  Although fonts are supposed to be automatically adjusted by `PerMonitorV2`, it seems scaling is still needed when dpi differs from main screen?
2. Cached fonts on PPageAdvanced weren't updated during a dpi change
3. Cached font metrics (which is used to themed widget font selection) is now reset on dpi changes.  This should fix some theme-specific issues.