### PR TITLE
improvements to FS window handling. clarify FS window name

### DIFF
--- a/src/mpc-hc/ChildView.cpp
+++ b/src/mpc-hc/ChildView.cpp
@@ -29,12 +29,10 @@
 
 CChildView::CChildView(CMainFrame* pMainFrame)
     : m_vrect(0, 0, 0, 0)
-    , CMouseWnd(pMainFrame)
-    , m_pMainFrame(pMainFrame)
+    , CMouseWndWithArtView(pMainFrame)
     , m_bSwitchingFullscreen(false)
     , m_bFirstMedia(true)
 {
-    LoadImg();
     GetEventd().Connect(m_eventc, {
         MpcEvent::SWITCHING_TO_FULLSCREEN,
         MpcEvent::SWITCHED_TO_FULLSCREEN,
@@ -117,68 +115,6 @@ void CChildView::SetVideoRect(const CRect& r)
     Invalidate();
 }
 
-void CChildView::LoadImg(const CString& imagePath)
-{
-    CMPCPngImage img;
-
-    if (!imagePath.IsEmpty()) {
-        img.LoadFromFile(imagePath);
-    }
-
-    LoadImgInternal(img.Detach());
-}
-
-void CChildView::LoadImg(std::vector<BYTE> buffer)
-{
-    CMPCPngImage img;
-
-    if (!buffer.empty()) {
-        img.LoadFromBuffer(buffer.data(), (UINT)buffer.size());
-    }
-
-    LoadImgInternal(img.Detach());
-}
-
-void CChildView::LoadImgInternal(HGDIOBJ hImg)
-{
-    CAppSettings& s = AfxGetAppSettings();
-    bool bHaveLogo = false;
-
-    m_img.DeleteObject();
-    m_resizedImg.Destroy();
-    m_bCustomImgLoaded = !!m_img.Attach(hImg);
-
-    if (!m_bCustomImgLoaded && s.fLogoExternal) {
-        bHaveLogo = !!m_img.LoadFromFile(s.strLogoFileName);
-    }
-
-    if (!bHaveLogo && !m_bCustomImgLoaded) {
-        s.fLogoExternal = false;               // use the built-in logo instead
-        s.strLogoFileName.Empty();             // clear logo file name
-        int useLogoId = s.nLogoId;
-        if (useLogoId == -1) { // if the user has never chosen a logo, we can try loading a theme default logo
-            if (AppIsThemeLoaded()) {
-                useLogoId = CMPCThemeUtil::defaultLogo();
-            } else {
-                useLogoId = DEF_LOGO;
-            }
-        }
-        if (!m_img.Load(useLogoId)) { // try the latest selected build-in logo
-            s.nLogoId = -1;           // upon failure, use default
-            m_img.Load(DEF_LOGO);
-        }
-    }
-
-    if (m_hWnd) {
-        Invalidate();
-    }
-}
-
-CSize CChildView::GetLogoSize()
-{
-    return m_img.GetSize();
-}
-
 IMPLEMENT_DYNAMIC(CChildView, CMouseWnd)
 
 BEGIN_MESSAGE_MAP(CChildView, CMouseWnd)
@@ -193,73 +129,6 @@ void CChildView::OnPaint()
 {
     CPaintDC dc(this);
     m_pMainFrame->RepaintVideo();
-}
-
-BOOL CChildView::OnEraseBkgnd(CDC* pDC)
-{
-    if (!pDC) {
-        ASSERT(FALSE);
-        return FALSE;
-    }
-
-    CRect r;
-    CImage img;
-    img.Attach(m_img);
-
-    if ((m_pMainFrame->GetLoadState() != MLS::CLOSED || (!m_bFirstMedia && m_pMainFrame->m_controls.DelayShowNotLoaded())) &&
-            !m_pMainFrame->HasDedicatedFSVideoWindow() && !m_pMainFrame->m_fAudioOnly) {
-        pDC->ExcludeClipRect(m_vrect);
-    } else if (!img.IsNull()) {
-        const double dImageAR = double(img.GetWidth()) / img.GetHeight();
-
-        GetClientRect(r);
-        int width = r.Width();
-        int height = r.Height();
-        if (!m_bCustomImgLoaded) {
-            // Limit logo size
-            // TODO: Use vector logo to preserve quality and remove limit.
-            width = std::min(img.GetWidth(), width);
-            height = std::min(img.GetHeight(), height);
-        }
-
-        double dImgWidth = height * dImageAR;
-        double dImgHeight;
-        if (width < dImgWidth) {
-            dImgWidth = width;
-            dImgHeight = dImgWidth / dImageAR;
-        } else {
-            dImgHeight = height;
-        }
-
-        int x = std::lround((r.Width() - dImgWidth) / 2.0);
-        int y = std::lround((r.Height() - dImgHeight) / 2.0);
-
-        r = CRect(CPoint(x, y), CSize(std::lround(dImgWidth), std::lround(dImgHeight)));
-
-        if (!r.IsRectEmpty()) {
-            if (m_resizedImg.IsNull() || r.Width() != m_resizedImg.GetWidth() || r.Height() != m_resizedImg.GetHeight() || img.GetBPP() != m_resizedImg.GetBPP()) {
-                m_resizedImg.Destroy();
-                m_resizedImg.Create(r.Width(), r.Height(), std::max(img.GetBPP(), 24));
-
-                HDC hDC = m_resizedImg.GetDC();
-                SetStretchBltMode(hDC, STRETCH_HALFTONE);
-                img.StretchBlt(hDC, 0, 0, r.Width(), r.Height(), SRCCOPY);
-                m_resizedImg.ReleaseDC();
-                if (AfxGetAppSettings().fLogoColorProfileEnabled) {
-                    ColorProfileUtil::applyColorProfile(m_hWnd, m_resizedImg);
-                }
-            }
-
-            m_resizedImg.BitBlt(*pDC, r.TopLeft());
-            pDC->ExcludeClipRect(r);
-        }
-    }
-    img.Detach();
-
-    GetClientRect(r);
-    pDC->FillSolidRect(r, 0);
-
-    return TRUE;
 }
 
 void CChildView::OnSize(UINT nType, int cx, int cy)

--- a/src/mpc-hc/ChildView.cpp
+++ b/src/mpc-hc/ChildView.cpp
@@ -207,7 +207,7 @@ BOOL CChildView::OnEraseBkgnd(CDC* pDC)
     img.Attach(m_img);
 
     if ((m_pMainFrame->GetLoadState() != MLS::CLOSED || (!m_bFirstMedia && m_pMainFrame->m_controls.DelayShowNotLoaded())) &&
-            !m_pMainFrame->HasFullScreenWindow() && !m_pMainFrame->m_fAudioOnly) {
+            !m_pMainFrame->HasDedicatedFSVideoWindow() && !m_pMainFrame->m_fAudioOnly) {
         pDC->ExcludeClipRect(m_vrect);
     } else if (!img.IsNull()) {
         const double dImageAR = double(img.GetWidth()) / img.GetHeight();

--- a/src/mpc-hc/ChildView.h
+++ b/src/mpc-hc/ChildView.h
@@ -21,27 +21,18 @@
 
 #pragma once
 
-#include "MPCPngImage.h"
-#include "MouseTouch.h"
+#include "MouseWndWithArtView.h"
 
-class CChildView : public CMouseWnd
+class CChildView : public CMouseWndWithArtView
 {
     CRect m_vrect;
 
-    CMPCPngImage m_img;
-    CImage m_resizedImg;
-
-    CMainFrame* m_pMainFrame;
-
     bool m_bSwitchingFullscreen;
     bool m_bFirstMedia;
-    bool m_bCustomImgLoaded;
 
     EventClient m_eventc;
 
     void EventCallback(MpcEvent ev);
-
-    void LoadImgInternal(HGDIOBJ hImg);
 
 public:
     CChildView(CMainFrame* pMainFrm);
@@ -52,11 +43,6 @@ public:
     void SetVideoRect(const CRect& r = CRect(0, 0, 0, 0));
     CRect GetVideoRect() const { return m_vrect; }
 
-    void LoadImg(const CString& imagePath = _T(""));
-    void LoadImg(std::vector<BYTE> buffer);
-    CSize GetLogoSize();
-    bool IsCustomImgLoaded() const { return m_bCustomImgLoaded; };
-
 protected:
     virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
     virtual BOOL PreTranslateMessage(MSG* pMsg);
@@ -64,7 +50,6 @@ protected:
     DECLARE_MESSAGE_MAP()
 
     afx_msg void OnPaint();
-    afx_msg BOOL OnEraseBkgnd(CDC* pDC);
     afx_msg void OnSize(UINT nType, int cx, int cy);
     afx_msg LRESULT OnNcHitTest(CPoint point);
     afx_msg void OnNcLButtonDown(UINT nHitTest, CPoint point);

--- a/src/mpc-hc/FullscreenWnd.cpp
+++ b/src/mpc-hc/FullscreenWnd.cpp
@@ -24,9 +24,9 @@
 #include "FullscreenWnd.h"
 #include "MainFrm.h"
 
-IMPLEMENT_DYNAMIC(CFullscreenWnd, CMouseWnd)
+IMPLEMENT_DYNAMIC(CFullscreenWnd, CMouseWndWithArtView)
 CFullscreenWnd::CFullscreenWnd(CMainFrame* pMainFrame)
-    : CMouseWnd(pMainFrame, true)
+    : CMouseWndWithArtView(pMainFrame, true)
     , m_pMainFrame(pMainFrame)
 {
 }
@@ -75,7 +75,8 @@ END_MESSAGE_MAP()
 
 BOOL CFullscreenWnd::OnEraseBkgnd(CDC* pDC)
 {
-    return FALSE;
+    return __super::OnEraseBkgnd(pDC);
+    //return FALSE;
 }
 
 void CFullscreenWnd::OnDestroy()

--- a/src/mpc-hc/FullscreenWnd.h
+++ b/src/mpc-hc/FullscreenWnd.h
@@ -21,11 +21,11 @@
 
 #pragma once
 
-#include "MouseTouch.h"
+#include "MouseWndWithArtView.h"
 
 class CMainFrame;
 
-class CFullscreenWnd final : public CMouseWnd
+class CFullscreenWnd final : public CMouseWndWithArtView
 {
     DECLARE_DYNAMIC(CFullscreenWnd)
 

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -13611,6 +13611,7 @@ void CMainFrame::OpenSetupVideo()
     if (m_fAudioOnly) {
         if (HasFullScreenWindow()) {
             m_pFullscreenWnd->DestroyWindow();
+            m_fFullScreen = false;
         }
     } else {
         m_statusbarVideoSize.Format(_T("%dx%d"), vs.cx, vs.cy);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -3826,7 +3826,7 @@ LRESULT CMainFrame::OnFilePostOpenmedia(WPARAM wParam, LPARAM lParam)
     OpenSetupCaptureBar();
 
     // Load cover-art
-    if (m_fAudioOnly) {
+    if (m_fAudioOnly || HasDedicatedFSVideoWindow()) {
         UpdateControlState(CMainFrame::UPDATE_LOGO);
     }
 
@@ -19756,6 +19756,30 @@ void CMainFrame::UpdateAudioSwitcher()
     }
 }
 
+void CMainFrame::LoadArtToViews(const CString& imagePath)
+{
+    m_wndView.LoadImg(imagePath);
+    if (HasDedicatedFSVideoWindow()) {
+        m_pDedicatedFSVideoWnd->LoadImg(imagePath);
+    }
+}
+
+void CMainFrame::LoadArtToViews(std::vector<BYTE> buffer)
+{
+    m_wndView.LoadImg(buffer);
+    if (HasDedicatedFSVideoWindow()) {
+        m_pDedicatedFSVideoWnd->LoadImg(buffer);
+    }
+}
+
+void CMainFrame::ClearArtFromViews()
+{
+    m_wndView.LoadImg();
+    if (HasDedicatedFSVideoWindow()) {
+        m_pDedicatedFSVideoWnd->LoadImg();
+    }
+}
+
 void CMainFrame::UpdateControlState(UpdateControlTarget target)
 {
     const auto& s = AfxGetAppSettings();
@@ -19785,23 +19809,23 @@ void CMainFrame::UpdateControlState(UpdateControlTarget target)
                 CPlaylistItem* pli = m_wndPlaylistBar.GetCur();
                 std::vector<BYTE> internalCover;
                 if (CoverArt::FindEmbedded(pFilterGraph, internalCover)) {
-                    m_wndView.LoadImg(internalCover);
+                    LoadArtToViews(internalCover);
                     m_currentCoverPath = filename;
                     m_currentCoverAuthor = author;
                 } else if (pli && !pli->m_cover.IsEmpty() && CPath(pli->m_cover).FileExists()) {
-                    m_wndView.LoadImg(pli->m_cover);
+                    LoadArtToViews(pli->m_cover);
                 } else if (!filedir.IsEmpty() && (m_currentCoverPath != filedir || m_currentCoverAuthor != author || currentCoverIsFileArt)) {
                     CString img = CoverArt::FindExternal(filename_no_ext, filedir, author, currentCoverIsFileArt);
-                    m_wndView.LoadImg(img);
+                    LoadArtToViews(img);
                     m_currentCoverPath = filedir;
                     m_currentCoverAuthor = author;
                 } else if (!m_wndView.IsCustomImgLoaded()) {
-                    m_wndView.LoadImg();
+                    ClearArtFromViews();
                 }
             } else {
                 m_currentCoverPath.Empty();
                 m_currentCoverAuthor.Empty();
-                m_wndView.LoadImg();
+                ClearArtFromViews();
             }
             break;
         case UPDATE_SKYPE:

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -13611,7 +13611,9 @@ void CMainFrame::OpenSetupVideo()
     if (m_fAudioOnly) {
         if (HasFullScreenWindow()) {
             m_pFullscreenWnd->DestroyWindow();
-            m_fFullScreen = false;
+            if (AfxGetAppSettings().bFullscreenSeparateControls) {
+                m_fFullScreen = false;
+            }
         }
     } else {
         m_statusbarVideoSize.Format(_T("%dx%d"), vs.cx, vs.cy);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -870,7 +870,7 @@ CMainFrame::CMainFrame()
     , m_wndCaptureBar(this)
     , m_wndNavigationBar(this)
     , m_pVideoWnd(nullptr)
-    , m_pFullscreenWnd(nullptr)
+    , m_pDedicatedFSVideoWnd(nullptr)
     , m_OSD(this)
     , m_bOSDDisplayTime(false)
     , m_nCurSubtitle(-1)
@@ -1029,7 +1029,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
         return -1;      // fail to create
     }
 
-    m_pFullscreenWnd = DEBUG_NEW CFullscreenWnd(this);
+    m_pDedicatedFSVideoWnd = DEBUG_NEW CFullscreenWnd(this);
 
     m_controls.m_toolbars[CMainFrameControls::Toolbar::SEEKBAR] = &m_wndSeekBar;
     m_controls.m_toolbars[CMainFrameControls::Toolbar::CONTROLS] = &m_wndToolBar;
@@ -1165,11 +1165,11 @@ void CMainFrame::OnDestroy()
         }
     }
 
-    if (m_pFullscreenWnd) {
-        if (m_pFullscreenWnd->IsWindow()) {
-            m_pFullscreenWnd->DestroyWindow();
+    if (m_pDedicatedFSVideoWnd) {
+        if (m_pDedicatedFSVideoWnd->IsWindow()) {
+            m_pDedicatedFSVideoWnd->DestroyWindow();
         }
-        delete m_pFullscreenWnd;
+        delete m_pDedicatedFSVideoWnd;
     }
 
     m_wndPreView.DestroyWindow();
@@ -1745,17 +1745,17 @@ void CMainFrame::OnDisplayChange() // untested, not sure if it's working...
         }
     }
 
-    if (HasFullScreenWindow()) {
+    if (HasDedicatedFSVideoWindow()) {
         MONITORINFO MonitorInfo;
         HMONITOR    hMonitor;
 
         ZeroMemory(&MonitorInfo, sizeof(MonitorInfo));
         MonitorInfo.cbSize = sizeof(MonitorInfo);
 
-        hMonitor = MonitorFromWindow(m_pFullscreenWnd->m_hWnd, 0);
+        hMonitor = MonitorFromWindow(m_pDedicatedFSVideoWnd->m_hWnd, 0);
         if (GetMonitorInfo(hMonitor, &MonitorInfo)) {
             CRect MonitorRect = CRect(MonitorInfo.rcMonitor);
-            m_pFullscreenWnd->SetWindowPos(nullptr,
+            m_pDedicatedFSVideoWnd->SetWindowPos(nullptr,
                                            MonitorRect.left,
                                            MonitorRect.top,
                                            MonitorRect.Width(),
@@ -3495,7 +3495,7 @@ BOOL CMainFrame::OnMenu(CMenu* pMenu)
     // Do not show popup menu in D3D fullscreen it has several adverse effects.
     if (IsD3DFullScreenMode()) {
         CWnd* pWnd = WindowFromPoint(point);
-        if (pWnd && *pWnd == *m_pFullscreenWnd) {
+        if (pWnd && *pWnd == *m_pDedicatedFSVideoWnd) {
             return FALSE;
         }
     }
@@ -3756,8 +3756,8 @@ LRESULT CMainFrame::OnFilePostOpenmedia(WPARAM wParam, LPARAM lParam)
     ASSERT(GetMediaStateDirect() == State_Stopped);
 
     // destroy invisible top-level d3dfs window if there is no video renderer
-    if (HasFullScreenWindow() && !m_pMFVDC && !m_pVMRWC && !m_pVW) {
-        m_pFullscreenWnd->DestroyWindow();
+    if (HasDedicatedFSVideoWindow() && !m_pMFVDC && !m_pVMRWC && !m_pVW) {
+        m_pDedicatedFSVideoWnd->DestroyWindow();
         if (s.IsD3DFullscreen()) {
             m_fStartInD3DFullscreen = true;
         } else {
@@ -4086,13 +4086,13 @@ void CMainFrame::OnFilePostClosemedia(bool bNextIsQueued/* = false*/)
     UnloadUnusedExternalObjects();
     SetTimer(TIMER_UNLOAD_UNUSED_EXTERNAL_OBJECTS, 60000, nullptr);
 
-    if (HasFullScreenWindow()) {
+    if (HasDedicatedFSVideoWindow()) {
         if (IsD3DFullScreenMode()) {
             m_fStartInD3DFullscreen = true;
         } else {
             m_fStartInFullscreenMainFrame = true;
         }
-        m_pFullscreenWnd->DestroyWindow();
+        m_pDedicatedFSVideoWnd->DestroyWindow();
     }
 
     UpdateWindow(); // redraw
@@ -11128,7 +11128,7 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
 
             CreateFullScreenWindow(false);
             // Assign the windowed video frame and pass it to the relevant classes.
-            m_pVideoWnd = m_pFullscreenWnd;
+            m_pVideoWnd = m_pDedicatedFSVideoWnd;
             m_OSD.SetVideoWindow(m_pVideoWnd);
             if (m_pMFVDC) {
                 m_pMFVDC->SetVideoWindow(m_pVideoWnd->m_hWnd);
@@ -11155,7 +11155,7 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
             }
 
             // Destroy the Fullscreen window and zoom the windowed video frame
-            m_pFullscreenWnd->DestroyWindow();
+            m_pDedicatedFSVideoWnd->DestroyWindow();
             if (m_fFirstFSAfterLaunchOnFS) {
                 m_fFirstFSAfterLaunchOnFS = false;
                 if (s.fRememberZoomLevel) {
@@ -11208,7 +11208,7 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
                     m_pVW->put_Owner((OAHWND)m_pVideoWnd->m_hWnd);
                 }
             }
-            m_pFullscreenWnd->DestroyWindow();
+            m_pDedicatedFSVideoWnd->DestroyWindow();
 
             if (s.autoChangeFSMode.bEnabled && s.autoChangeFSMode.bApplyDefaultModeAtFSExit && !s.autoChangeFSMode.modes.empty() && s.autoChangeFSMode.modes[0].bChecked) {
                 SetDispMode(s.strFullScreenMonitorID, s.autoChangeFSMode.modes[0].dm, s.fAudioTimeShift ? s.iAudioTimeShift : 0); // Restore default time shift
@@ -11333,7 +11333,7 @@ void CMainFrame::ToggleD3DFullscreen(bool fSwitchScreenResWhenHasTo)
             }
 
             // Destroy the D3D Fullscreen window and zoom the windowed video frame
-            m_pFullscreenWnd->DestroyWindow();
+            m_pDedicatedFSVideoWnd->DestroyWindow();
             if (m_fFirstFSAfterLaunchOnFS) {
                 if (s.fRememberZoomLevel) {
                     ZoomVideoWindow();
@@ -11357,7 +11357,7 @@ void CMainFrame::ToggleD3DFullscreen(bool fSwitchScreenResWhenHasTo)
             m_eventc.FireEvent(MpcEvent::SWITCHING_TO_FULLSCREEN_D3D);
 
             // Assign the windowed video frame and pass it to the relevant classes.
-            m_pVideoWnd = m_pFullscreenWnd;
+            m_pVideoWnd = m_pDedicatedFSVideoWnd;
             m_OSD.SetVideoWindow(m_pVideoWnd);
             if (m_pMFVDC) {
                 m_pMFVDC->SetVideoWindow(m_pVideoWnd->m_hWnd);
@@ -11508,8 +11508,8 @@ void CMainFrame::MoveVideoWindow(bool fShowStats/* = false*/, bool bSetStoppedVi
         CRect windowRect(0, 0, 0, 0);
         CRect videoRect(0, 0, 0, 0);
 
-        if (HasFullScreenWindow()) {
-            m_pFullscreenWnd->GetClientRect(windowRect);
+        if (HasDedicatedFSVideoWindow()) {
+            m_pDedicatedFSVideoWnd->GetClientRect(windowRect);
         } else {
             m_wndView.GetClientRect(windowRect);
         }
@@ -11672,12 +11672,12 @@ void CMainFrame::MoveVideoWindow(bool fShowStats/* = false*/, bool bSetStoppedVi
             }
         }
 
-        if (!HasFullScreenWindow()) {
+        if (!HasDedicatedFSVideoWindow()) {
             m_wndView.SetVideoRect(&windowRect);
         }
         m_OSD.SetSize(windowRect, videoRect);
     } else {
-        if (!HasFullScreenWindow()) {
+        if (!HasDedicatedFSVideoWindow()) {
             m_wndView.SetVideoRect();
         }
     }
@@ -11743,8 +11743,8 @@ void CMainFrame::SetPreviewVideoPosition() {
 void CMainFrame::HideVideoWindow(bool fHide)
 {
     CRect wr;
-    if (HasFullScreenWindow()) {
-        m_pFullscreenWnd->GetClientRect(&wr);
+    if (HasDedicatedFSVideoWindow()) {
+        m_pDedicatedFSVideoWnd->GetClientRect(&wr);
     } else if (!m_fFullScreen) {
         m_wndView.GetClientRect(&wr);
     } else {
@@ -12501,8 +12501,8 @@ CWnd* CMainFrame::GetModalParent()
 {
     const CAppSettings& s = AfxGetAppSettings();
     CWnd* pParentWnd = this;
-    if (HasFullScreenWindow() && s.m_RenderersSettings.m_AdvRendSets.bVMR9FullscreenGUISupport) {
-        pParentWnd = m_pFullscreenWnd;
+    if (HasDedicatedFSVideoWindow() && s.m_RenderersSettings.m_AdvRendSets.bVMR9FullscreenGUISupport) {
+        pParentWnd = m_pDedicatedFSVideoWnd;
     }
     return pParentWnd;
 }
@@ -13609,11 +13609,8 @@ void CMainFrame::OpenSetupVideo()
     }
 
     if (m_fAudioOnly) {
-        if (HasFullScreenWindow()) {
-            m_pFullscreenWnd->DestroyWindow();
-            if (AfxGetAppSettings().bFullscreenSeparateControls) {
-                m_fFullScreen = false;
-            }
+        if (HasDedicatedFSVideoWindow() && !AfxGetAppSettings().bFullscreenSeparateControls) { //DedicateFSWindow allowed for audio
+            m_pDedicatedFSVideoWnd->DestroyWindow();
         }
     } else {
         m_statusbarVideoSize.Format(_T("%dx%d"), vs.cx, vs.cy);
@@ -17796,11 +17793,11 @@ void CMainFrame::OpenMedia(CAutoPtr<OpenMediaData> pOMD)
     // create d3dfs window if launching in fullscreen and d3dfs is enabled
     if (s.IsD3DFullscreen() && m_fStartInD3DFullscreen) {
         CreateFullScreenWindow();
-        m_pVideoWnd = m_pFullscreenWnd;
+        m_pVideoWnd = m_pDedicatedFSVideoWnd;
         m_fStartInD3DFullscreen = false;
     } else if (m_fStartInFullscreenMainFrame) {
         CreateFullScreenWindow(false);
-        m_pVideoWnd = m_pFullscreenWnd;
+        m_pVideoWnd = m_pDedicatedFSVideoWnd;
         m_fStartInFullscreenMainFrame = false;
     } else {
         m_pVideoWnd = &m_wndView;
@@ -18292,8 +18289,8 @@ bool CMainFrame::CreateFullScreenWindow(bool isD3D /* = true */)
     CMonitors monitors;
     CMonitor monitor;
 
-    if (m_pFullscreenWnd->IsWindow()) {
-        m_pFullscreenWnd->DestroyWindow();
+    if (m_pDedicatedFSVideoWnd->IsWindow()) {
+        m_pDedicatedFSVideoWnd->DestroyWindow();
     }
 
     if (s.iMonitor == 0) {
@@ -18309,9 +18306,9 @@ bool CMainFrame::CreateFullScreenWindow(bool isD3D /* = true */)
     m_bFullScreenWindowIsD3D = isD3D;
 
     // allow the mainframe to keep focus
-    bool ret = !!m_pFullscreenWnd->CreateEx(WS_EX_TOPMOST | WS_EX_TOOLWINDOW, _T(""), ResStr(IDS_MAINFRM_136), WS_POPUP, monitorRect, nullptr, 0);
+    bool ret = !!m_pDedicatedFSVideoWnd->CreateEx(WS_EX_TOPMOST | WS_EX_TOOLWINDOW, _T(""), ResStr(IDS_MAINFRM_136), WS_POPUP, monitorRect, nullptr, 0);
     if (ret) {
-        m_pFullscreenWnd->ShowWindow(SW_SHOWNOACTIVATE);
+        m_pDedicatedFSVideoWnd->ShowWindow(SW_SHOWNOACTIVATE);
     }
     return ret;
 }
@@ -18347,17 +18344,17 @@ bool CMainFrame::IsFullScreenMode() const {
 }
 
 bool CMainFrame::IsFullScreenMainFrame() const {
-    return m_fFullScreen && !HasFullScreenWindow();
+    return m_fFullScreen && !HasDedicatedFSVideoWindow();
 }
 
-bool CMainFrame::HasFullScreenWindow() const {
-    return m_pFullscreenWnd && m_pFullscreenWnd->IsWindow();
+bool CMainFrame::HasDedicatedFSVideoWindow() const {
+    return m_pDedicatedFSVideoWnd && m_pDedicatedFSVideoWnd->IsWindow();
 }
 
 
 bool CMainFrame::IsD3DFullScreenMode() const
 {
-    return HasFullScreenWindow() && m_bFullScreenWindowIsD3D;
+    return HasDedicatedFSVideoWindow() && m_bFullScreenWindowIsD3D;
 };
 
 bool CMainFrame::IsSubresyncBarVisible() const

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -523,7 +523,7 @@ public:
     bool IsInteractiveVideo() const;
     bool IsFullScreenMode() const;
     bool IsFullScreenMainFrame() const;
-    bool HasFullScreenWindow() const;
+    bool HasDedicatedFSVideoWindow() const;
     bool IsD3DFullScreenMode() const;
     bool IsSubresyncBarVisible() const;
 
@@ -1154,7 +1154,7 @@ public:
     HRESULT PreviewWindowShow(REFERENCE_TIME rtCur2);
     bool CanPreviewUse();
 
-    CFullscreenWnd* m_pFullscreenWnd;
+    CFullscreenWnd* m_pDedicatedFSVideoWnd;
     CVMROSD     m_OSD;
     bool        m_bOSDDisplayTime;
     int         m_nCurSubtitle;

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -242,6 +242,7 @@ private:
     friend class CMouse;
     friend class CPlayerSeekBar; // for accessing m_controls.ControlChecked()
     friend class CChildView; // for accessing m_controls.DelayShowNotLoaded()
+    friend class CMouseWndWithArtView; // for accessing m_controls.DelayShowNotLoaded()
     friend class SubtitlesProvider;
 
     // TODO: wrap these graph objects into a class to make it look cleaner
@@ -1229,6 +1230,10 @@ protected:
     void UpdateSkypeHandler();
     void UpdateSeekbarChapterBag();
     void UpdateAudioSwitcher();
+
+    void LoadArtToViews(const CString& imagePath);
+    void LoadArtToViews(std::vector<BYTE> buffer);
+    void ClearArtFromViews();
 
     void UpdateUILanguage();
 

--- a/src/mpc-hc/MouseTouch.cpp
+++ b/src/mpc-hc/MouseTouch.cpp
@@ -186,8 +186,8 @@ CPoint CMouse::GetVideoPoint(const CPoint& point) const
 
 bool CMouse::IsOnFullscreenWindow() const
 {
-    if (m_pMainFrame->HasFullScreenWindow()) {
-        return m_pMainFrame->m_pFullscreenWnd == this; //we are the fullscreen window
+    if (m_pMainFrame->HasDedicatedFSVideoWindow()) {
+        return m_pMainFrame->m_pDedicatedFSVideoWnd == this; //we are the fullscreen window
     } else {
         return &m_pMainFrame->m_wndView == this && m_pMainFrame->IsFullScreenMainFrame(); //we are the view and it is fullscreened
     }
@@ -723,7 +723,7 @@ std::unordered_set<const CWnd*> CMainFrameMouseHook::GetRoots()
     if (pMainFrame) {
         ret.emplace(pMainFrame);
         if (pMainFrame->IsD3DFullScreenMode()) {
-            ret.emplace(pMainFrame->m_pFullscreenWnd);
+            ret.emplace(pMainFrame->m_pDedicatedFSVideoWnd);
         }
     }
     return ret;

--- a/src/mpc-hc/MouseWndWithArtView.cpp
+++ b/src/mpc-hc/MouseWndWithArtView.cpp
@@ -1,0 +1,174 @@
+/*
+ * (C) 2003-2006 Gabest
+ * (C) 2006-2015 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "mplayerc.h"
+#include "MouseWndWithArtView.h"
+#include "MainFrm.h"
+#include "CMPCTheme.h"
+#include "CMPCThemeUtil.h"
+#include "ColorProfileUtil.h"
+
+CMouseWndWithArtView::CMouseWndWithArtView(CMainFrame* pMainFrame, bool bD3DFS/* = false*/)
+    : CMouseWnd(pMainFrame, bD3DFS)
+    , m_pMainFrame(pMainFrame)
+{
+    LoadImg();
+}
+
+CMouseWndWithArtView::~CMouseWndWithArtView()
+{
+}
+
+void CMouseWndWithArtView::LoadImg(const CString& imagePath)
+{
+    CMPCPngImage img;
+
+    if (!imagePath.IsEmpty()) {
+        img.LoadFromFile(imagePath);
+    }
+
+    LoadImgInternal(img.Detach());
+}
+
+void CMouseWndWithArtView::LoadImg(std::vector<BYTE> buffer)
+{
+    CMPCPngImage img;
+
+    if (!buffer.empty()) {
+        img.LoadFromBuffer(buffer.data(), (UINT)buffer.size());
+    }
+
+    LoadImgInternal(img.Detach());
+}
+
+void CMouseWndWithArtView::LoadImgInternal(HGDIOBJ hImg)
+{
+    CAppSettings& s = AfxGetAppSettings();
+    bool bHaveLogo = false;
+
+    m_img.DeleteObject();
+    m_resizedImg.Destroy();
+    m_bCustomImgLoaded = !!m_img.Attach(hImg);
+
+    if (!m_bCustomImgLoaded && s.fLogoExternal) {
+        bHaveLogo = !!m_img.LoadFromFile(s.strLogoFileName);
+    }
+
+    if (!bHaveLogo && !m_bCustomImgLoaded) {
+        s.fLogoExternal = false;               // use the built-in logo instead
+        s.strLogoFileName.Empty();             // clear logo file name
+        int useLogoId = s.nLogoId;
+        if (useLogoId == -1) { // if the user has never chosen a logo, we can try loading a theme default logo
+            if (AppIsThemeLoaded()) {
+                useLogoId = CMPCThemeUtil::defaultLogo();
+            } else {
+                useLogoId = DEF_LOGO;
+            }
+        }
+        if (!m_img.Load(useLogoId)) { // try the latest selected build-in logo
+            s.nLogoId = -1;           // upon failure, use default
+            m_img.Load(DEF_LOGO);
+        }
+    }
+
+    if (m_hWnd) {
+        Invalidate();
+    }
+}
+
+CSize CMouseWndWithArtView::GetLogoSize()
+{
+    return m_img.GetSize();
+}
+
+IMPLEMENT_DYNAMIC(CMouseWndWithArtView, CMouseWnd)
+
+BEGIN_MESSAGE_MAP(CMouseWndWithArtView, CMouseWnd)
+    ON_WM_ERASEBKGND()
+END_MESSAGE_MAP()
+
+BOOL CMouseWndWithArtView::OnEraseBkgnd(CDC* pDC)
+{
+    if (!pDC) {
+        ASSERT(FALSE);
+        return FALSE;
+    }
+
+    CRect r;
+    CImage img;
+    img.Attach(m_img);
+
+    if ((m_pMainFrame->GetLoadState() != MLS::CLOSED || (!m_bFirstMedia && m_pMainFrame->m_controls.DelayShowNotLoaded())) &&
+            !m_pMainFrame->HasDedicatedFSVideoWindow() && !m_pMainFrame->m_fAudioOnly) {
+        pDC->ExcludeClipRect(m_vrect);
+    } else if (!img.IsNull()) {
+        const double dImageAR = double(img.GetWidth()) / img.GetHeight();
+
+        GetClientRect(r);
+        int width = r.Width();
+        int height = r.Height();
+        if (!m_bCustomImgLoaded) {
+            // Limit logo size
+            // TODO: Use vector logo to preserve quality and remove limit.
+            width = std::min(img.GetWidth(), width);
+            height = std::min(img.GetHeight(), height);
+        }
+
+        double dImgWidth = height * dImageAR;
+        double dImgHeight;
+        if (width < dImgWidth) {
+            dImgWidth = width;
+            dImgHeight = dImgWidth / dImageAR;
+        } else {
+            dImgHeight = height;
+        }
+
+        int x = std::lround((r.Width() - dImgWidth) / 2.0);
+        int y = std::lround((r.Height() - dImgHeight) / 2.0);
+
+        r = CRect(CPoint(x, y), CSize(std::lround(dImgWidth), std::lround(dImgHeight)));
+
+        if (!r.IsRectEmpty()) {
+            if (m_resizedImg.IsNull() || r.Width() != m_resizedImg.GetWidth() || r.Height() != m_resizedImg.GetHeight() || img.GetBPP() != m_resizedImg.GetBPP()) {
+                m_resizedImg.Destroy();
+                m_resizedImg.Create(r.Width(), r.Height(), std::max(img.GetBPP(), 24));
+
+                HDC hDC = m_resizedImg.GetDC();
+                SetStretchBltMode(hDC, STRETCH_HALFTONE);
+                img.StretchBlt(hDC, 0, 0, r.Width(), r.Height(), SRCCOPY);
+                m_resizedImg.ReleaseDC();
+                if (AfxGetAppSettings().fLogoColorProfileEnabled) {
+                    ColorProfileUtil::applyColorProfile(m_hWnd, m_resizedImg);
+                }
+            }
+
+            m_resizedImg.BitBlt(*pDC, r.TopLeft());
+            pDC->ExcludeClipRect(r);
+        }
+    }
+    img.Detach();
+
+    GetClientRect(r);
+    pDC->FillSolidRect(r, 0);
+
+    return TRUE;
+}

--- a/src/mpc-hc/MouseWndWithArtView.h
+++ b/src/mpc-hc/MouseWndWithArtView.h
@@ -1,0 +1,55 @@
+/*
+ * (C) 2003-2006 Gabest
+ * (C) 2006-2013, 2015 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "MPCPngImage.h"
+#include "MouseTouch.h"
+
+class CMainFrame;
+
+class CMouseWndWithArtView : public CMouseWnd
+{
+    DECLARE_DYNAMIC(CMouseWndWithArtView)
+
+    CMainFrame* m_pMainFrame;
+public:
+    explicit CMouseWndWithArtView(CMainFrame* pMainFrame, bool bD3DFS = false);
+    ~CMouseWndWithArtView();
+    CSize GetLogoSize();
+    void LoadImg(const CString& imagePath = _T(""));
+    void LoadImg(std::vector<BYTE> buffer);
+    bool IsCustomImgLoaded() const { return m_bCustomImgLoaded; };
+
+protected:
+    CMPCPngImage m_img;
+    CImage m_resizedImg;
+    bool m_bFirstMedia;
+    bool m_bCustomImgLoaded;
+    CRect m_vrect;
+
+    void LoadImgInternal(HGDIOBJ hImg);
+
+    DECLARE_MESSAGE_MAP()
+
+    afx_msg BOOL OnEraseBkgnd(CDC* pDC);
+
+};

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -215,6 +215,7 @@
     <ClCompile Include="ModelessResizableDialog.cpp" />
     <ClCompile Include="Monitors.cpp" />
     <ClCompile Include="MouseTouch.cpp" />
+    <ClCompile Include="MouseWndWithArtView.cpp" />
     <ClCompile Include="MPCPngImage.cpp" />
     <ClCompile Include="Mpeg2SectionData.cpp" />
     <ClCompile Include="mplayerc.cpp" />
@@ -404,6 +405,7 @@
     <ClInclude Include="ModelessResizableDialog.h" />
     <ClInclude Include="Monitors.h" />
     <ClInclude Include="MouseTouch.h" />
+    <ClInclude Include="MouseWndWithArtView.h" />
     <ClInclude Include="MpcApi.h" />
     <ClInclude Include="MPCPngImage.h" />
     <ClInclude Include="Mpeg2SectionData.h" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -597,6 +597,9 @@
     <ClCompile Include="ModelessResizableDialog.cpp">
       <Filter>Modal Dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="MouseWndWithArtView.cpp">
+      <Filter>Main View</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AppSettings.h">
@@ -1132,6 +1135,9 @@
     </ClInclude>
     <ClInclude Include="ModelessResizableDialog.h">
       <Filter>Modal Dialogs</Filter>
+    </ClInclude>
+    <ClInclude Include="MouseWndWithArtView.h">
+      <Filter>Main View</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This seems to fix the issue with bFullscreenSeparateControls and audio.  It seems like a pretty basic solution, and I'm not sure why it couldn't be done all the time (even without bFullscreenSeparateControls).

One thing I noticed is the fs window gets created even for audio files, because it hasn't identified yet that that file is audio-only.  So it has to destroy it for every audio file.