### PR TITLE
DPI Fixes

### DIFF
--- a/src/mpc-hc/CMPCThemeUtil.h
+++ b/src/mpc-hc/CMPCThemeUtil.h
@@ -37,6 +37,7 @@ protected:
     void EnableThemedDialogTooltips(CDialog* wnd);
     void PlaceThemedDialogTooltip(UINT_PTR nID);
     void RelayThemedDialogTooltip(MSG* pMsg);
+    static bool metricsNeedCalculation;
 public:
     static bool getFontByFace(CFont& font, CWnd *wnd, wchar_t* fontName, int size, LONG weight = FW_REGULAR);
     static bool getFixedFont(CFont& font, CDC* pDC, CWnd* wnd);

--- a/src/mpc-hc/DpiHelper.cpp
+++ b/src/mpc-hc/DpiHelper.cpp
@@ -36,6 +36,7 @@ namespace
 
     typedef int (WINAPI* tpGetSystemMetricsForDpi)(int nIndex, UINT dpi);
     HRESULT WINAPI GetDpiForMonitor(HMONITOR hmonitor, MONITOR_DPI_TYPE dpiType, UINT* dpiX, UINT* dpiY);
+    UINT GetDpiForWindow(HWND hwnd);
 }
 
 DpiHelper::DpiHelper()
@@ -46,6 +47,15 @@ DpiHelper::DpiHelper()
     ::ReleaseDC(nullptr, hDC);
     m_dpix = m_sdpix;
     m_dpiy = m_sdpiy;
+}
+
+UINT DpiHelper::GetDPIForWindow(HWND wnd) {
+    const WinapiFunc<decltype(GetDpiForWindow)>
+    fnGetDpiForWindow = { _T("user32.dll"), "GetDpiForWindow" };
+    if (fnGetDpiForWindow) {
+        return fnGetDpiForWindow(wnd);
+    }
+    return 0;
 }
 
 void DpiHelper::Override(HWND hWindow)

--- a/src/mpc-hc/DpiHelper.h
+++ b/src/mpc-hc/DpiHelper.h
@@ -42,9 +42,12 @@ public:
 
     inline int ScaleSystemToOverrideX(int x) const { return MulDiv(x, m_dpix, m_sdpix); }
     inline int ScaleSystemToOverrideY(int y) const { return MulDiv(y, m_dpiy, m_sdpiy); }
+    inline int ScaleArbitraryToOverrideY(int y, int dpi_y) const { return MulDiv(y, m_dpix, dpi_y); }
 
     inline int DPIX() { return m_dpix; }
     inline int DPIY() { return m_dpiy; }
+    inline int SDPIX() const { return m_sdpix; }
+    inline int SDPIY() const { return m_sdpiy; }
     static bool CanUsePerMonitorV2();
     inline void ScaleRect(__inout RECT* pRect) {
         pRect->left = ScaleX(pRect->left);

--- a/src/mpc-hc/DpiHelper.h
+++ b/src/mpc-hc/DpiHelper.h
@@ -29,6 +29,7 @@ public:
     void Override(HWND hWindow);
     void Override(int dpix, int dpiy);
     int GetSystemMetricsDPI(int nIndex);
+    static UINT GetDPIForWindow(HWND wnd);
 
     inline double ScaleFactorX() const { return m_dpix / 96.0; }
     inline double ScaleFactorY() const { return m_dpiy / 96.0; }
@@ -42,7 +43,7 @@ public:
 
     inline int ScaleSystemToOverrideX(int x) const { return MulDiv(x, m_dpix, m_sdpix); }
     inline int ScaleSystemToOverrideY(int y) const { return MulDiv(y, m_dpiy, m_sdpiy); }
-    inline int ScaleArbitraryToOverrideY(int y, int dpi_y) const { return MulDiv(y, m_dpix, dpi_y); }
+    inline int ScaleArbitraryToOverrideY (int y, int dpi_y) const { return MulDiv(y, m_dpix, dpi_y); }
 
     inline int DPIX() { return m_dpix; }
     inline int DPIY() { return m_dpiy; }

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1642,16 +1642,16 @@ void CPlayerPlaylistBar::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasure
     __super::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 
     if (createdWindow) {
-        //after creation, measureitem is called once for every window resize.  we will cache the default before DPI scaling
+        //after creation, measureitem is called once for every window resize.  we will cache the default height before DPI scaling
         if (m_itemHeight == 0) {
             m_itemHeight = lpMeasureItemStruct->itemHeight;
-            m_itemHeightDPI = m_pMainFrame->m_dpi.SDPIY();
         }
-        lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleArbitraryToOverrideY(m_itemHeight, m_itemHeightDPI);
+        lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleArbitraryToOverrideY(m_itemHeight, m_initialWindowDPI); //we must scale by initial DPI, NOT current DPI
     } else { 
         //before creation, we must return a valid DPI scaled value, to prevent visual glitches when icon height has been tweaked.
         //we cannot cache this value as it may be different from that calculated after font has been set
         lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(lpMeasureItemStruct->itemHeight);
+        m_initialWindowDPI = m_pMainFrame->m_dpi.DPIY(); //the initial DPI is always cached by ListCtrl and is never updated for future calculations of OnMeasureItem
     }
 }
 

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1639,19 +1639,20 @@ void CPlayerPlaylistBar::OnNMDblclkList(NMHDR* pNMHDR, LRESULT* pResult)
 
 void CPlayerPlaylistBar::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct)
 {
-	__super::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
+    __super::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
 
-	if (createdWindow) {
-		//after creation, measureitem is called once for every window resize.  we will cache the default before DPI scaling
+    if (createdWindow) {
+        //after creation, measureitem is called once for every window resize.  we will cache the default before DPI scaling
         if (m_itemHeight == 0) {
-			m_itemHeight = lpMeasureItemStruct->itemHeight;
-		}
-		lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(m_itemHeight);
-	} else { 
-		//before creation, we must return a valid DPI scaled value, to prevent visual glitches when icon height has been tweaked.
-		//we cannot cache this value as it may be different from that calculated after font has been set
-		lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(lpMeasureItemStruct->itemHeight);
-	}
+            m_itemHeight = lpMeasureItemStruct->itemHeight;
+            m_itemHeightDPI = m_pMainFrame->m_dpi.SDPIY();
+        }
+        lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleSystemToArbitraryY(m_itemHeight, m_itemHeightDPI);
+    } else { 
+        //before creation, we must return a valid DPI scaled value, to prevent visual glitches when icon height has been tweaked.
+        //we cannot cache this value as it may be different from that calculated after font has been set
+        lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(lpMeasureItemStruct->itemHeight);
+    }
 }
 
 /*

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1647,7 +1647,7 @@ void CPlayerPlaylistBar::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasure
             m_itemHeight = lpMeasureItemStruct->itemHeight;
             m_itemHeightDPI = m_pMainFrame->m_dpi.SDPIY();
         }
-        lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleSystemToArbitraryY(m_itemHeight, m_itemHeightDPI);
+        lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleArbitraryToOverrideY(m_itemHeight, m_itemHeightDPI);
     } else { 
         //before creation, we must return a valid DPI scaled value, to prevent visual glitches when icon height has been tweaked.
         //we cannot cache this value as it may be different from that calculated after font has been set

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -60,10 +60,11 @@ private:
     CImageList m_fakeImageList;
     CMPCThemePlayerListCtrl m_list;
 
-	int m_itemHeight = 0;
-	bool createdWindow;
+    int m_itemHeight = 0;
+    int m_itemHeightDPI = 0;
+    bool createdWindow;
 
-	EventClient m_eventc;
+    EventClient m_eventc;
     void EventCallback(MpcEvent ev);
 
     int m_nTimeColWidth;

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -61,7 +61,7 @@ private:
     CMPCThemePlayerListCtrl m_list;
 
     int m_itemHeight = 0;
-    int m_itemHeightDPI = 0;
+    int m_initialWindowDPI = 0;
     bool createdWindow;
 
     EventClient m_eventc;

--- a/src/mpc-hc/PlayerPreView.cpp
+++ b/src/mpc-hc/PlayerPreView.cpp
@@ -114,7 +114,6 @@ int CPreView::OnCreate(LPCREATESTRUCT lpCreateStruct) {
         return -1;
     }
 
-    ScaleFont();
     SetColor();
 
     return 0;
@@ -181,6 +180,9 @@ void CPreView::OnPaint() {
     rtime.right -= m_border + 2;
 
     // text
+    if (!m_font.m_hObject) {
+        ScaleFont();
+    }
     mdc.SelectObject(&m_font);
     mdc.SetTextColor(m_crText);
     mdc.DrawTextW(m_tooltipstr, m_tooltipstr.GetLength(), &rtime, DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);


### PR DESCRIPTION
Fixes included:

1. Supports menu scaling for mpc-hc started on lower DPI monitors
2. Fix scaling issue for playlist, especially going back and forth between monitors
3. Added win10 api call for window DPI (not used but useful for debugging)