### PR TITLE
DPI utilities, listctrl height calculation

### DIFF
--- a/src/mpc-hc/DpiHelper.h
+++ b/src/mpc-hc/DpiHelper.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include <afxcmn.h>
 
 class DpiHelper final
 {
@@ -29,7 +30,11 @@ public:
     void Override(HWND hWindow);
     void Override(int dpix, int dpiy);
     int GetSystemMetricsDPI(int nIndex);
+    void GetMessageFont(LOGFONT* lf);
+    bool GetNonClientMetrics(PNONCLIENTMETRICSW, bool& dpiCorrected);
+    int GetSystemMetrics(int type);
     static UINT GetDPIForWindow(HWND wnd);
+    int CalculateListCtrlItemHeight(CListCtrl* wnd);
 
     inline double ScaleFactorX() const { return m_dpix / 96.0; }
     inline double ScaleFactorY() const { return m_dpiy / 96.0; }

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1507,8 +1507,8 @@ END_MESSAGE_MAP()
 void CPlayerPlaylistBar::ScaleFont()
 {
     LOGFONT lf;
-    GetMessageFont(&lf);
-    lf.lfHeight = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(lf.lfHeight);
+    m_pMainFrame->m_dpi.GetMessageFont(&lf);
+    //lf.lfHeight = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(lf.lfHeight);
 
     m_font.DeleteObject();
     if (m_font.CreateFontIndirect(&lf)) {
@@ -1640,19 +1640,21 @@ void CPlayerPlaylistBar::OnNMDblclkList(NMHDR* pNMHDR, LRESULT* pResult)
 void CPlayerPlaylistBar::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct)
 {
     __super::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
-
+    lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.CalculateListCtrlItemHeight((CListCtrl*)&m_list);
+#if 0
     if (createdWindow) {
         //after creation, measureitem is called once for every window resize.  we will cache the default height before DPI scaling
         if (m_itemHeight == 0) {
             m_itemHeight = lpMeasureItemStruct->itemHeight;
         }
         lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleArbitraryToOverrideY(m_itemHeight, m_initialWindowDPI); //we must scale by initial DPI, NOT current DPI
-    } else { 
+    } else {
         //before creation, we must return a valid DPI scaled value, to prevent visual glitches when icon height has been tweaked.
         //we cannot cache this value as it may be different from that calculated after font has been set
         lpMeasureItemStruct->itemHeight = m_pMainFrame->m_dpi.ScaleSystemToOverrideY(lpMeasureItemStruct->itemHeight);
         m_initialWindowDPI = m_pMainFrame->m_dpi.DPIY(); //the initial DPI is always cached by ListCtrl and is never updated for future calculations of OnMeasureItem
     }
+#endif
 }
 
 /*


### PR DESCRIPTION
This could use testing, but I wrote this to solve a minor issue: converting between DPIs led to a height of 18 instead of 19 when going from 192dpi to 96dpi.

This function calculates 96dpi and 192dpi the same regardless of starting screen.  Also it solves an issue that sometimes the initial height is incorrectly shrunken (before font is set).