### PR TITLE
derive CPlayerListCtrl from CMPCThemePlayerListCtrl instead of reverse

### DIFF
--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -5,7 +5,7 @@
 #include "mplayerc.h"
 #undef SubclassWindow
 
-CMPCThemePlayerListCtrl::CMPCThemePlayerListCtrl(int tStartEditingDelay) : CPlayerListCtrl(tStartEditingDelay)
+CMPCThemePlayerListCtrl::CMPCThemePlayerListCtrl() : CListCtrl()
 {
     themeGridLines = false;
     fullRowSelect = false;
@@ -43,12 +43,12 @@ void CMPCThemePlayerListCtrl::PreSubclassWindow()
         }
         subclassHeader();
     }
-    CPlayerListCtrl::PreSubclassWindow();
+    CListCtrl::PreSubclassWindow();
 }
 
-IMPLEMENT_DYNAMIC(CMPCThemePlayerListCtrl, CPlayerListCtrl)
+IMPLEMENT_DYNAMIC(CMPCThemePlayerListCtrl, CListCtrl)
 
-BEGIN_MESSAGE_MAP(CMPCThemePlayerListCtrl, CPlayerListCtrl)
+BEGIN_MESSAGE_MAP(CMPCThemePlayerListCtrl, CListCtrl)
     ON_WM_NCPAINT()
     ON_WM_CREATE()
     ON_NOTIFY_REFLECT_EX(LVN_ENDSCROLL, OnLvnEndScroll)

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.h
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "PlayerListCtrl.h"
 #include "CMPCThemeScrollBarHelper.h"
 #include "CMPCThemeToolTipCtrl.h"
 #include "CMPCThemeUtil.h"
@@ -13,10 +12,10 @@ public:
     virtual void GetCustomGridColors(int nItem, COLORREF& horzGridColor, COLORREF& vertGridColor) = 0;
 };
 
-class CMPCThemePlayerListCtrl : public CPlayerListCtrl, CMPCThemeUtil, CMPCThemeScrollable
+class CMPCThemePlayerListCtrl : public CListCtrl, CMPCThemeUtil, CMPCThemeScrollable
 {
 public:
-    CMPCThemePlayerListCtrl(int tStartEditingDelay = 500);
+    CMPCThemePlayerListCtrl();
     virtual ~CMPCThemePlayerListCtrl();
     DECLARE_DYNAMIC(CMPCThemePlayerListCtrl)
 

--- a/src/mpc-hc/PPageAccelTbl.h
+++ b/src/mpc-hc/PPageAccelTbl.h
@@ -27,7 +27,6 @@
 #include "WinHotkeyCtrl.h"
 #include "vkCodes.h"
 #include "CMPCThemePPageBase.h"
-#include "CMPCThemePlayerListCtrl.h"
 #include "CMPCThemeStaticLink.h"
 #include "CMPCThemeEdit.h"
 
@@ -69,7 +68,7 @@ private:
 	};
 	std::vector<std::unique_ptr<ITEMDATA>> m_pItemsData;
 	
-    CMPCThemePlayerListCtrl m_list;
+    CPlayerListCtrl m_list;
     int sortColumn = -1;
     int sortDirection;
     BOOL m_fWinLirc;

--- a/src/mpc-hc/PPageFormats.h
+++ b/src/mpc-hc/PPageFormats.h
@@ -23,7 +23,7 @@
 
 #include <afxwin.h>
 #include "CMPCThemePPageBase.h"
-#include "CMPCThemePlayerListCtrl.h"
+#include "PlayerListCtrl.h"
 #include "CMPCThemeButton.h"
 #include "CMPCThemeGroupBox.h"
 #include "CMPCThemeRadioOrCheck.h"
@@ -38,7 +38,7 @@ class CPPageFormats : public CMPCThemePPageBase
 
 private:
 
-    CMPCThemePlayerListCtrl m_list;
+    CPlayerListCtrl m_list;
     CImageList m_onoff;
     CMPCThemeRadioOrCheck m_fContextDir;
     CMPCThemeRadioOrCheck m_fContextFiles;

--- a/src/mpc-hc/PPageFullscreen.h
+++ b/src/mpc-hc/PPageFullscreen.h
@@ -25,7 +25,6 @@
 #include "PlayerListCtrl.h"
 #include "CMPCThemeComboBox.h"
 #include "CMPCThemeSpinButtonCtrl.h"
-#include "CMPCThemePlayerListCtrl.h"
 
 // CPPageFullscreen dialog
 
@@ -60,7 +59,7 @@ private:
     BOOL m_bAutoChangeFSModeRestoreResAfterProgExit;
     unsigned m_uAutoChangeFullscrResDelay;
 
-    CMPCThemePlayerListCtrl m_list;
+    CPlayerListCtrl m_list;
     enum {
         COL_N,
         COL_FRAMERATE_START,

--- a/src/mpc-hc/PlayerListCtrl.cpp
+++ b/src/mpc-hc/PlayerListCtrl.cpp
@@ -484,7 +484,7 @@ void CInPlaceListBox::OnNcDestroy()
 
 // CPlayerListCtrl
 
-IMPLEMENT_DYNAMIC(CPlayerListCtrl, CListCtrl)
+IMPLEMENT_DYNAMIC(CPlayerListCtrl, CMPCThemePlayerListCtrl)
 CPlayerListCtrl::CPlayerListCtrl(int tStartEditingDelay)
     : m_nItemClicked(-1)
     , m_nSubItemClicked(-1)
@@ -836,7 +836,7 @@ CListBox* CPlayerListCtrl::ShowInPlaceListBox(int nItem, int nCol, CAtlList<CStr
     return pListBox;
 }
 
-BEGIN_MESSAGE_MAP(CPlayerListCtrl, CListCtrl)
+BEGIN_MESSAGE_MAP(CPlayerListCtrl, CMPCThemePlayerListCtrl)
     ON_WM_VSCROLL()
     ON_WM_HSCROLL()
     ON_WM_MOUSEWHEEL()

--- a/src/mpc-hc/PlayerListCtrl.h
+++ b/src/mpc-hc/PlayerListCtrl.h
@@ -23,6 +23,7 @@
 
 #include "WinHotkeyCtrl.h"
 #include "CMPCThemeComboBox.h"
+#include "CMPCThemePlayerListCtrl.h"
 
 #define LVN_DOLABELEDIT (LVN_FIRST+1)
 
@@ -141,7 +142,7 @@ public:
 
 // CPlayerListCtrl
 
-class CPlayerListCtrl : public CListCtrl
+class CPlayerListCtrl : public CMPCThemePlayerListCtrl
 {
     DECLARE_DYNAMIC(CPlayerListCtrl)
 

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -23,7 +23,7 @@
 
 #include <afxcoll.h>
 #include "CMPCThemePlayerBar.h"
-#include "CMPCThemePlayerListCtrl.h"
+#include "PlayerListCtrl.h"
 #include "Playlist.h"
 #include "DropTarget.h"
 #include "../Subtitles/TextFile.h"
@@ -58,7 +58,7 @@ private:
     void ScaleFont();
 
     CImageList m_fakeImageList;
-    CMPCThemePlayerListCtrl m_list;
+    CPlayerListCtrl m_list;
 
     int m_itemHeight = 0;
     int m_initialWindowDPI = 0;

--- a/src/mpc-hc/PlayerSubresyncBar.h
+++ b/src/mpc-hc/PlayerSubresyncBar.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "CMPCThemePlayerBar.h"
-#include "CMPCThemePlayerListCtrl.h"
+#include "PlayerListCtrl.h"
 #include "../Subtitles/STS.h"
 #include "../Subtitles/VobSubFile.h"
 #include <map>
@@ -44,7 +44,7 @@ private:
     CString m_strYes, m_strNo;
     CString m_strYesMenu, m_strNoMenu;
 
-    CMPCThemePlayerListCtrl m_list;
+    CPlayerListCtrl m_list;
 
     CMainFrame* m_pMainFrame;
 


### PR DESCRIPTION
Prior to the dark theme, only the following areas actually used `CPlayerListCtrl`:

![image](https://github.com/clsid2/mpc-hc/assets/3324395/8cf9914a-53a2-4111-9d93-4f29d9c82302)

In order to avoid implementing the themed list control twice, I took all the areas that used a `CListCtrl` and made them use a `CPlayerListctrl`.  It mostly worked without incident.  Today I realized that it was affecting the listctrl in the subtitle download dialog.  Specifically, it moves the focus each time you click on a row, which didn't happen before, and when you click the checkboxes, it causes the row to be highlighted (normally, that only happens if you click elsewhere on the row).

By changing the order of inheritance, those areas that used to use CPlayerListCtrl were changed to again refer to CPlayerListCtrl.  Everything else (that had prior to the dark theme used the stock `CListCtrl`) still uses `CMPCThemePlayerListCtrl`, which no longer contains the expanded functionality of the `CPlayerListCtrl`.

So far, this seems like a pretty simple change without any issues.  It fixes a few things.  Some testing is a good idea, though.