### PR TITLE
Fix incorrect display of subtitle track list when using xySubFilter as subtitle renderer

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -9325,88 +9325,138 @@ void CMainFrame::OnPlaySubtitles(UINT nID)
         }
     }
 
-    if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
-        if (CBDAChannel* pChannel = m_pDVBState->pChannel) {
-            OnNavStreamSelectSubMenu(i, 2);
-            pChannel->SetDefaultSubtitle(i);
-            SetSubtitle(i);
-        }
-    } else if (!m_pSubStreams.IsEmpty()) {
-        // Currently the subtitles menu contains 5 items apart from the actual subtitles list when the ISR is used
-        i -= 5;
+    switch (AfxGetAppSettings().GetSubtitleRenderer())
+    {
+        case CAppSettings::SubtitleRenderer::INTERNAL:
+            if (!m_pSubStreams.IsEmpty()) {
+                // Currently the subtitles menu contains 5 items apart from the actual subtitles list when the ISR is used
+                i -= 5;
 
-        if (i == -5) {
-            // options
-            ShowOptions(CPPageSubtitles::IDD);
-        } else if (i == -4) {
-            // styles
-            int j = 0;
-            SubtitleInput* pSubInput = GetSubtitleInput(j, true);
-            CLSID clsid;
+                if (i == -5) {
+                    // options
+                    ShowOptions(CPPageSubtitles::IDD);
+                }
+                else if (i == -4) {
+                    // styles
+                    int j = 0;
+                    SubtitleInput* pSubInput = GetSubtitleInput(j, true);
+                    CLSID clsid;
 
-            if (pSubInput && SUCCEEDED(pSubInput->pSubStream->GetClassID(&clsid))) {
-                if (clsid == __uuidof(CRenderedTextSubtitle)) {
-                    CRenderedTextSubtitle* pRTS = (CRenderedTextSubtitle*)(ISubStream*)pSubInput->pSubStream;
+                    if (pSubInput && SUCCEEDED(pSubInput->pSubStream->GetClassID(&clsid))) {
+                        if (clsid == __uuidof(CRenderedTextSubtitle)) {
+                            CRenderedTextSubtitle* pRTS = (CRenderedTextSubtitle*)(ISubStream*)pSubInput->pSubStream;
 
-                    CAutoPtrArray<CPPageSubStyle> pages;
-                    CAtlArray<STSStyle*> styles;
+                            CAutoPtrArray<CPPageSubStyle> pages;
+                            CAtlArray<STSStyle*> styles;
 
-                    POSITION pos = pRTS->m_styles.GetStartPosition();
-                    for (int k = 0; pos; k++) {
-                        CString key;
-                        STSStyle* val;
-                        pRTS->m_styles.GetNextAssoc(pos, key, val);
+                            POSITION pos = pRTS->m_styles.GetStartPosition();
+                            for (int k = 0; pos; k++) {
+                                CString key;
+                                STSStyle* val;
+                                pRTS->m_styles.GetNextAssoc(pos, key, val);
 
-                        CAutoPtr<CPPageSubStyle> page(DEBUG_NEW CPPageSubStyle());
-                        page->InitStyle(key, *val);
-                        pages.Add(page);
-                        styles.Add(val);
-                    }
-
-                    CMPCThemePropertySheet dlg(IDS_SUBTITLES_STYLES_CAPTION, GetModalParent());
-                    for (size_t l = 0; l < pages.GetCount(); l++) {
-                        dlg.AddPage(pages[l]);
-                    }
-
-                    if (dlg.DoModal() == IDOK) {
-                        {
-                            CAutoLock cAutoLock(&m_csSubLock);
-
-                            for (size_t l = 0; l < pages.GetCount(); l++) {
-                                pages[l]->GetStyle(*styles[l]);
-                                if (pages[l]->GetStyleName() == L"Default") {
-                                    if (*styles[l] != s.subtitlesDefStyle) {
-                                        pRTS->m_bUsingPlayerDefaultStyle = false;
-                                        pRTS->SetDefaultStyle(*styles[l]);
-                                    }
-                                }
+                                CAutoPtr<CPPageSubStyle> page(DEBUG_NEW CPPageSubStyle());
+                                page->InitStyle(key, *val);
+                                pages.Add(page);
+                                styles.Add(val);
                             }
-                            pRTS->Deinit();
+
+                            CPropertySheet dlg(IDS_SUBTITLES_STYLES_CAPTION, GetModalParent());
+                            for (size_t l = 0; l < pages.GetCount(); l++) {
+                                dlg.AddPage(pages[l]);
+                            }
+
+                            if (dlg.DoModal() == IDOK) {
+                                {
+                                    CAutoLock cAutoLock(&m_csSubLock);
+
+                                    for (size_t l = 0; l < pages.GetCount(); l++) {
+                                        pages[l]->GetStyle(*styles[l]);
+                                    }
+                                    pRTS->Deinit();
+                                }
+                                InvalidateSubtitle();
+                            }
                         }
-                        InvalidateSubtitle();
-                        RepaintVideo();
                     }
                 }
+                else if (i == -3) {
+                    // reload
+                    ReloadSubtitle();
+                }
+                else if (i == -2) {
+                    // enable
+                    ToggleSubtitleOnOff();
+                }
+                else if (i == -1) {
+                    // override default style
+                    // TODO: default subtitles style toggle here
+                    s.fUseDefaultSubtitlesStyle = !s.fUseDefaultSubtitlesStyle;
+                    UpdateSubDefaultStyle();
+                }
+                else if (i >= 0) {
+                    // this is an actual item from the subtitles list
+                    s.fEnableSubtitles = true;
+                    SetSubtitle(i);
+                }
             }
-        } else if (i == -3) {
-            // reload
-            ReloadSubtitle();
-        } else if (i == -2) {
-            // enable
-            ToggleSubtitleOnOff();
-        } else if (i == -1) {
-            // override default style
-            // TODO: default subtitles style toggle here
-            s.fUseDefaultSubtitlesStyle = !s.fUseDefaultSubtitlesStyle;
-            UpdateSubtitleRenderingParameters();
-            RepaintVideo();
-        } else if (i >= 0) {
-            // this is an actual item from the subtitles list
-            s.fEnableSubtitles = true;
-            SetSubtitle(i);
-        }
-    } else if (GetPlaybackMode() == PM_FILE) {
-        OnNavStreamSelectSubMenu(i, 2);
+            break;
+        case CAppSettings::SubtitleRenderer::XY_SUB_FILTER:
+            {
+                auto id = i;
+                auto processStreamSelectFilter = [&](CComPtr<IAMStreamSelect> pSS) {
+                    bool bSelected = false;
+
+                    DWORD cStreams;
+                    if (SUCCEEDED(pSS->Count(&cStreams))) {
+                        for (int i = 0, j = cStreams; i < j; i++) {
+                            DWORD dwFlags, dwGroup;
+                            LCID lcid;
+                            CComHeapPtr<WCHAR> pszName;
+
+                            if (FAILED(pSS->Info(i, nullptr, &dwFlags, &lcid, &dwGroup, &pszName, nullptr, nullptr))
+                                || !pszName) {
+                                continue;
+                            }
+
+                            if (id == 0) {
+                                pSS->Enable(i, AMSTREAMSELECTENABLE_ENABLE);
+                                bSelected = true;
+                                break;
+                            }
+
+                            id--;
+                        }
+                    }
+
+                    return bSelected;
+                };
+
+                CComQIPtr<IAMStreamSelect> pSS;
+
+                BeginEnumFilters(m_pGB, pEF, pBF) {
+                    if (GetCLSID(pBF) == CLSID_XySubFilter_AutoLoader || GetCLSID(pBF) == CLSID_XySubFilter) {
+                        if (pSS = pBF) {
+                            processStreamSelectFilter(pSS);
+                            break;
+                        }
+                    }
+                }
+                EndEnumFilters
+
+            }
+            break;
+        default:
+            if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
+                if (CDVBChannel* pChannel = m_pDVBState->pChannel) {
+                    OnNavStreamSelectSubMenu(i, 2);
+                    pChannel->SetDefaultSubtitle(i);
+                }
+            }
+            else if (GetPlaybackMode() == PM_FILE) {
+                OnNavStreamSelectSubMenu(i, 2);
+            }
+    	    break;
     }
 }
 
@@ -15595,151 +15645,247 @@ void CMainFrame::SetupSubtitlesSubMenu()
         }
     }
 
-    POSITION pos = m_pSubStreams.GetHeadPosition();
-
-    if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
-        DWORD selected = SetupNavStreamSelectSubMenu(subMenu, id, 2);
-        if (selected != -1) {
-            SetSubtitle(selected - ID_SUBTITLES_SUBITEM_START);
-        }
-    } else if (pos) { // Internal subtitles renderer
-        int nItemsBeforeStart = id - ID_SUBTITLES_SUBITEM_START;
-        if (nItemsBeforeStart > 0) {
-            VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
-            nItemsBeforeStart += 2; // Separators
-        }
-
-        // Build the static menu's items
-        bool bTextSubtitles = false;
-        VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_OPTIONS)));
-        VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_STYLES)));
-        VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_RELOAD)));
-        VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
-
-        VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_ENABLE)));
-        VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_DEFAULT_STYLE)));
-        VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
-
-        // Build the dynamic menu's items
-        int i = 0, iSelected = -1;
-        while (pos) {
-            SubtitleInput& subInput = m_pSubStreams.GetNext(pos);
-
-            if (CComQIPtr<IAMStreamSelect> pSSF = subInput.pSourceFilter) {
-                DWORD cStreams;
-                if (FAILED(pSSF->Count(&cStreams))) {
-                    continue;
+    switch (AfxGetAppSettings().GetSubtitleRenderer())
+    {
+        case CAppSettings::SubtitleRenderer::INTERNAL:
+            {
+                POSITION pos = m_pSubStreams.GetHeadPosition();
+                int nItemsBeforeStart = id - ID_SUBTITLES_SUBITEM_START;
+                if (nItemsBeforeStart > 0) {
+                    VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
+                    nItemsBeforeStart += 2; // Separators
                 }
 
-                for (int j = 0, cnt = (int)cStreams; j < cnt; j++) {
-                    DWORD dwFlags, dwGroup;
-                    CComHeapPtr<WCHAR> pszName;
-                    LCID lcid = 0;
-                    if (FAILED(pSSF->Info(j, nullptr, &dwFlags, &lcid, &dwGroup, &pszName, nullptr, nullptr))
-                            || !pszName) {
-                        continue;
-                    }
+                // Build the static menu's items
+                bool bTextSubtitles = false;
+                VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_OPTIONS)));
+                VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_STYLES)));
+                VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_RELOAD)));
+                VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
 
-                    if (dwGroup != 2) {
-                        continue;
-                    }
+                VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_ENABLE)));
+                VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_SUBTITLES_DEFAULT_STYLE)));
+                VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
 
-                    if (subInput.pSubStream == m_pCurrentSubInput.pSubStream
-                            && dwFlags & (AMSTREAMSELECTINFO_ENABLED | AMSTREAMSELECTINFO_EXCLUSIVE)) {
-                        iSelected = i;
-                    }
+                // Build the dynamic menu's items
+                int i = 0, iSelected = -1;
+                while (pos) {
+                    SubtitleInput& subInput = m_pSubStreams.GetNext(pos);
 
-                    CString name(pszName);
-                    /*
-                    CString lcname = CString(name).MakeLower();
-                    if (lcname.Find(_T(" off")) >= 0) {
-                        name.LoadString(IDS_AG_DISABLED);
-                    }
-                    */
-                    if (lcid != 0 && name.Find(L'\t') < 0) {
-                        CString lcidstr;
-                        GetLocaleString(lcid, LOCALE_SENGLANGUAGE, lcidstr);
-                        name.Append(_T("\t") + lcidstr);
-                    }
-
-                    name.Replace(_T("&"), _T("&&"));
-                    VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, name));
-                    i++;
-                }
-            } else {
-                CComPtr<ISubStream> pSubStream = subInput.pSubStream;
-                if (!pSubStream) {
-                    continue;
-                }
-
-                if (subInput.pSubStream == m_pCurrentSubInput.pSubStream) {
-                    iSelected = i + pSubStream->GetStream();
-                }
-
-                for (int j = 0, cnt = pSubStream->GetStreamCount(); j < cnt; j++) {
-                    CComHeapPtr<WCHAR> pName;
-                    LCID lcid = 0;
-                    if (SUCCEEDED(pSubStream->GetStreamInfo(j, &pName, &lcid))) {
-                        CString name(pName);
-                        if (lcid != 0 && name.Find(L'\t') < 0) {
-                            CString lcidstr;
-                            GetLocaleString(lcid, LOCALE_SENGLANGUAGE, lcidstr);
-                            name.Append(_T("\t") + lcidstr);
+                    if (CComQIPtr<IAMStreamSelect> pSSF = subInput.pSourceFilter) {
+                        DWORD cStreams;
+                        if (FAILED(pSSF->Count(&cStreams))) {
+                            continue;
                         }
 
-                        name.Replace(_T("&"), _T("&&"));
-                        VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, name));
-                    } else {
-                        VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_AG_UNKNOWN_STREAM)));
+                        for (int j = 0, cnt = (int)cStreams; j < cnt; j++) {
+                            DWORD dwFlags, dwGroup;
+                            LCID lcid;
+                            WCHAR* pszName = nullptr;
+
+                            if (FAILED(pSSF->Info(j, nullptr, &dwFlags, &lcid, &dwGroup, &pszName, nullptr, nullptr))
+                                || !pszName) {
+                                continue;
+                            }
+
+                            CString name(pszName);
+                            CString lcname = CString(name).MakeLower();
+                            CoTaskMemFree(pszName);
+
+                            if (dwGroup != 2) {
+                                continue;
+                            }
+
+                            if (subInput.pSubStream == m_pCurrentSubInput.pSubStream
+                                && dwFlags & (AMSTREAMSELECTINFO_ENABLED | AMSTREAMSELECTINFO_EXCLUSIVE)) {
+                                iSelected = i;
+                            }
+
+                            CString str;
+
+                            if (lcname.Find(_T(" off")) >= 0) {
+                                str.LoadString(IDS_AG_DISABLED);
+                            }
+                            else {
+                                if (lcid != 0) {
+                                    int len = GetLocaleInfo(lcid, LOCALE_SENGLANGUAGE, str.GetBuffer(64), 64);
+                                    str.ReleaseBufferSetLength(std::max(len - 1, 0));
+                                }
+
+                                CString lcstr = CString(str).MakeLower();
+
+                                if (str.IsEmpty() || lcname.Find(lcstr) >= 0) {
+                                    str = name;
+                                }
+                                else if (!name.IsEmpty()) {
+                                    str = name + _T(" (") + str + _T(")");
+                                }
+                            }
+
+                            str.Replace(_T("&"), _T("&&"));
+                            VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, str));
+                            i++;
+                        }
                     }
-                    i++;
+                    else {
+                        CComPtr<ISubStream> pSubStream = subInput.pSubStream;
+                        if (!pSubStream) {
+                            continue;
+                        }
+
+                        if (subInput.pSubStream == m_pCurrentSubInput.pSubStream) {
+                            iSelected = i + pSubStream->GetStream();
+                        }
+
+                        for (int j = 0, cnt = pSubStream->GetStreamCount(); j < cnt; j++) {
+                            CComHeapPtr<WCHAR> pName;
+                            if (SUCCEEDED(pSubStream->GetStreamInfo(j, &pName, nullptr))) {
+                                CString name(pName);
+                                name.Replace(_T("&"), _T("&&"));
+
+                                VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, name));
+                            }
+                            else {
+                                VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_AG_UNKNOWN_STREAM)));
+                            }
+                            i++;
+                        }
+                    }
+
+                    if (subInput.pSubStream == m_pCurrentSubInput.pSubStream) {
+                        CLSID clsid;
+                        if (SUCCEEDED(subInput.pSubStream->GetClassID(&clsid))
+                            && clsid == __uuidof(CRenderedTextSubtitle)) {
+                            bTextSubtitles = true;
+                        }
+                    }
+
+                    // TODO: find a better way to group these entries
+                    /*if (pos && m_pSubStreams.GetAt(pos).subStream) {
+                        CLSID cur, next;
+                        pSubStream->GetClassID(&cur);
+                        m_pSubStreams.GetAt(pos).subStream->GetClassID(&next);
+
+                        if (cur != next) {
+                            VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
+                        }
+                    }*/
                 }
+
+                // Set the menu's items' state
+                const CAppSettings& s = AfxGetAppSettings();
+                // Style
+                if (!bTextSubtitles) {
+                    subMenu.EnableMenuItem(nItemsBeforeStart + 1, MF_BYPOSITION | MF_DISABLED | MF_GRAYED);
+                }
+                // Enabled
+                if (s.fEnableSubtitles) {
+                    subMenu.CheckMenuItem(nItemsBeforeStart + 4, MF_BYPOSITION | MF_CHECKED);
+                }
+                // Default style
+                // TODO: foxX - default subtitles style toggle here; still wip
+                if (!bTextSubtitles) {
+                    subMenu.EnableMenuItem(nItemsBeforeStart + 5, MF_BYPOSITION | MF_DISABLED | MF_GRAYED);
+                }
+                if (s.fUseDefaultSubtitlesStyle) {
+                    subMenu.CheckMenuItem(nItemsBeforeStart + 5, MF_BYPOSITION | MF_CHECKED);
+                }
+                VERIFY(subMenu.CheckMenuRadioItem(nItemsBeforeStart + 7, nItemsBeforeStart + 7 + i - 1, nItemsBeforeStart + 7 + iSelected, MF_BYPOSITION));
             }
+            break;
+        case CAppSettings::SubtitleRenderer::XY_SUB_FILTER:
+            {
+                //xy_sub_filter.cpp:1093
+                const int FLAG_CMD = 1;
+                const int FLAG_EXTERNAL_SUB = 2;
+                const int FLAG_PICTURE_CMD = 4;
+                const int FLAG_VISIBILITY_CMD = 8;
+                const int GROUP_NUM_BASE = 0x648E40;//random number
 
-            if (subInput.pSubStream == m_pCurrentSubInput.pSubStream) {
-                CLSID clsid;
-                if (SUCCEEDED(subInput.pSubStream->GetClassID(&clsid))
-                        && clsid == __uuidof(CRenderedTextSubtitle)) {
-                    bTextSubtitles = true;
+                auto addStreamSelectFilter = [&](CComPtr<IAMStreamSelect> pSS) {
+                    DWORD cStreams;
+                    if (!pSS || FAILED(pSS->Count(&cStreams))) {
+                        return;
+                    }
+
+                    bool bAdded = false;
+                    for (DWORD i = 0; i < cStreams; i++) {
+                        DWORD dwFlags, dwGroup;
+                        LCID lcid;
+                        CComHeapPtr<WCHAR> pszName;
+
+                        if (FAILED(pSS->Info(i, nullptr, &dwFlags, &lcid, &dwGroup, &pszName, nullptr, nullptr))
+                            || !pszName) {
+                            continue;
+                        }
+
+                        CString suffix;
+                        if (dwGroup == (GROUP_NUM_BASE & ~(FLAG_CMD | FLAG_EXTERNAL_SUB)))
+                        {
+                            suffix = "[Embedded] ";
+                        }
+                        else if(dwGroup == ((GROUP_NUM_BASE & ~FLAG_CMD) | FLAG_EXTERNAL_SUB))
+                        {
+                            suffix = "[External] ";
+                        }
+
+                        CString str;
+                        CString lcname(pszName);
+                        lcname.MakeLower();
+
+                        if (lcname.Find(_T(" off")) >= 0) {
+                            str.LoadString(IDS_AG_DISABLED);
+                        }
+                        else {
+                            if (lcid && lcid != LCID(-1)) {
+                                int len = GetLocaleInfo(lcid, LOCALE_SENGLANGUAGE, str.GetBuffer(64), 64);
+                                str.ReleaseBufferSetLength(std::max(len - 1, 0));
+                            }
+
+                            CString lcstr(str);
+                            lcstr.MakeLower();
+
+                            if (str.IsEmpty() || lcname.Find(lcstr) >= 0) {
+                                str = pszName;
+                            }
+                            else if (wcslen(pszName)) {
+                                str = CString(pszName) + _T(" (") + str + _T(")");
+                            }
+                        }
+
+                        UINT flags = MF_BYCOMMAND | MF_STRING | MF_ENABLED;
+                        if (dwFlags) {
+                            flags |= MF_CHECKED;
+                        }
+
+                        str.Replace(_T("&"), _T("&&"));
+                        if(!suffix.IsEmpty()) str = suffix + str;
+                        VERIFY(subMenu.AppendMenu(flags, id++, str));
+                    }
+
+                };
+
+                CComQIPtr<IAMStreamSelect> pSS;
+
+                BeginEnumFilters(m_pGB, pEF, pBF) {
+                    if (GetCLSID(pBF) == CLSID_XySubFilter_AutoLoader || GetCLSID(pBF) == CLSID_XySubFilter) {
+                        if (pSS = pBF) {
+                            addStreamSelectFilter(pSS);
+                            break;
+                        }
+                    }
                 }
+                EndEnumFilters
             }
-
-            // TODO: find a better way to group these entries
-            /*if (pos && m_pSubStreams.GetAt(pos).subStream) {
-                CLSID cur, next;
-                pSubStream->GetClassID(&cur);
-                m_pSubStreams.GetAt(pos).subStream->GetClassID(&next);
-
-                if (cur != next) {
-                    VERIFY(subMenu.AppendMenu(MF_SEPARATOR));
-                }
-            }*/
-        }
-
-        // Set the menu's items' state
-        const CAppSettings& s = AfxGetAppSettings();
-        // Style
-        if (!bTextSubtitles) {
-            subMenu.EnableMenuItem(nItemsBeforeStart + 1, MF_BYPOSITION | MF_GRAYED);
-        }
-        // Enabled
-        if (s.fEnableSubtitles) {
-            subMenu.CheckMenuItem(nItemsBeforeStart + 4, MF_BYPOSITION | MF_CHECKED);
-        }
-        // Default style
-        // TODO: foxX - default subtitles style toggle here; still wip
-        if (!bTextSubtitles) {
-            subMenu.EnableMenuItem(nItemsBeforeStart + 5, MF_BYPOSITION | MF_GRAYED);
-        }
-        if (s.fUseDefaultSubtitlesStyle) {
-            subMenu.CheckMenuItem(nItemsBeforeStart + 5, MF_BYPOSITION | MF_CHECKED);
-        }
-        if (iSelected >= 0) {
-            VERIFY(subMenu.CheckMenuRadioItem(nItemsBeforeStart + 7, nItemsBeforeStart + 7 + i - 1, nItemsBeforeStart + 7 + iSelected, MF_BYPOSITION));
-        }
-    } else if (GetPlaybackMode() == PM_FILE) {
-        SetupNavStreamSelectSubMenu(subMenu, id, 2);
-    }
+            break;
+        default:
+            if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
+                SetupNavStreamSelectSubMenu(subMenu, id, 2);
+            }
+            else if (GetPlaybackMode() == PM_FILE) {
+                SetupNavStreamSelectSubMenu(subMenu, id, 2);
+            }
+            break;
 }
 
 void CMainFrame::SetupVideoStreamsSubMenu()


### PR DESCRIPTION
If I change `dwGroup` to 2, it lists all available choices like this:
![image](https://github.com/Masaiki/xy-VSFilter/assets/69719051/f00c1083-e32e-4cba-98be-a5b997579ad5)
But it is obvious that some options are duplicated, which should be caused by 'CMainFrame:: SetupNavStreamSelectSubMenu' traversing all 'Filters' in graph. 
I think, since the subtitle output is given to 'xySubFilter', then the player should no longer ask other 'Filters' for subtitles.

I have made some modifications according to my own understanding. Do you think such changes are acceptable?