### PR TITLE
clean up preprocessor defines and add libunibreak

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,7 @@
 [submodule "src/thirdparty/libass/libass"]
 	path = src/thirdparty/libass/libass
 	url = https://github.com/libass/libass.git
+	branch = 0.17.1-branch
 [submodule "src/thirdparty/fontconfig/fontconfig"]
 	path = src/thirdparty/fontconfig/fontconfig
 	url = https://github.com/ShiftMediaProject/fontconfig.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,6 @@
 [submodule "src/thirdparty/libass/libass"]
 	path = src/thirdparty/libass/libass
 	url = https://github.com/libass/libass.git
-	branch = 0.17.1-branch
 [submodule "src/thirdparty/fontconfig/fontconfig"]
 	path = src/thirdparty/fontconfig/fontconfig
 	url = https://github.com/ShiftMediaProject/fontconfig.git
@@ -50,3 +49,6 @@
 [submodule "src/thirdparty/libiconv/libiconv-for-Windows"]
 	path = src/thirdparty/libiconv/libiconv-for-Windows
 	url = https://github.com/pffang/libiconv-for-Windows.git
+[submodule "src/thirdparty/libunibreak/libunibreak"]
+	path = src/thirdparty/libunibreak/libunibreak
+	url = https://github.com/adah1972/libunibreak

--- a/src/Subtitles/LibassContext.cpp
+++ b/src/Subtitles/LibassContext.cpp
@@ -706,6 +706,7 @@ void LibassContext::InitLibASS() {
     m_ass = decltype(m_ass)(ass_library_init());
     ass_set_fonts_dir(m_ass.get(), NULL); //initialize it or we get free() errors in debug mode
     m_renderer = decltype(m_renderer)(ass_renderer_init(m_ass.get()));
+    ass_set_cache_limits(m_renderer.get(), 0, 1024);
     m_track = decltype(m_track)(ass_new_track(m_ass.get()));
 }
 

--- a/src/thirdparty/libass/config.h
+++ b/src/thirdparty/libass/config.h
@@ -6,6 +6,9 @@
 /* ASM enabled */
 #define CONFIG_ASM 1
 
+/* targeting a 32 - or 64 - bit x86 host architecture */
+#define ARCH_X86 1
+
 /* found CoreText in System library */
 /* #undef CONFIG_CORETEXT */
 

--- a/src/thirdparty/libass/config.h
+++ b/src/thirdparty/libass/config.h
@@ -30,6 +30,8 @@
 /* use iconv */
 #define CONFIG_ICONV 1
 
+#define CONFIG_UNIBREAK 1
+
 /* use small tiles */
 /* #undef CONFIG_LARGE_TILES */
 

--- a/src/thirdparty/libass/libass.vcxproj
+++ b/src/thirdparty/libass/libass.vcxproj
@@ -26,29 +26,30 @@
     <ClInclude Include="libass\libass\ass_cache_template.h" />
     <ClInclude Include="libass\libass\ass_compat.h" />
     <ClInclude Include="libass\libass\ass_directwrite.h" />
+    <ClInclude Include="libass\libass\ass_directwrite_info_template.h" />
     <ClInclude Include="libass\libass\ass_drawing.h" />
     <ClInclude Include="libass\libass\ass_filesystem.h" />
     <ClInclude Include="libass\libass\ass_font.h" />
     <ClInclude Include="libass\libass\ass_fontconfig.h" />
     <ClInclude Include="libass\libass\ass_fontselect.h" />
     <ClInclude Include="libass\libass\ass_func_template.h" />
+    <ClInclude Include="libass\libass\ass_library.h" />
     <ClInclude Include="libass\libass\ass_outline.h" />
     <ClInclude Include="libass\libass\ass_parse.h" />
     <ClInclude Include="libass\libass\ass_rasterizer.h" />
-    <ClInclude Include="libass\libass\c\rasterizer_template.h" />
     <ClInclude Include="libass\libass\ass_render.h" />
     <ClInclude Include="libass\libass\ass_shaper.h" />
     <ClInclude Include="libass\libass\ass_string.h" />
     <ClInclude Include="libass\libass\ass_types.h" />
     <ClInclude Include="libass\libass\ass_utils.h" />
     <ClInclude Include="libass\libass\dwrite_c.h" />
+    <ClInclude Include="libass\libass\wyhash.h" />
     <ClInclude Include="libass\libass\x86\cpuid.h" />
     <ClInclude Include="config.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="libass\libass\ass.c" />
     <ClCompile Include="libass\libass\ass_bitmap.c" />
-    <ClCompile Include="libass\libass\ass_bitmap_engine.c" />
     <ClCompile Include="libass\libass\ass_blur.c" />
     <ClCompile Include="libass\libass\ass_cache.c" />
     <ClCompile Include="libass\libass\ass_directwrite.c" />
@@ -61,10 +62,7 @@
     <ClCompile Include="libass\libass\ass_outline.c" />
     <ClCompile Include="libass\libass\ass_parse.c" />
     <ClCompile Include="libass\libass\ass_rasterizer.c" />
-    <ClCompile Include="libass\libass\c\c_rasterizer.c" />
-    <ClCompile Include="libass\libass\c\c_blend_bitmaps.c" />
-    <ClCompile Include="libass\libass\c\c_blur.c" />
-    <ClCompile Include="libass\libass\c\c_be_blur.c" />
+    <ClCompile Include="libass\libass\ass_rasterizer_c.c" />
     <ClCompile Include="libass\libass\ass_render.c" />
     <ClCompile Include="libass\libass\ass_render_api.c" />
     <ClCompile Include="libass\libass\ass_shaper.c" />
@@ -108,7 +106,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PreprocessorDefinitions>CONFIG_ASM;ARCH_X86;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>.;libass\libass;..\fribidi\generated;..\libiconv\libiconv-for-Windows\include;..\dirent;..\freetype2\freetype2\include\freetype;..\fontconfig\fontconfig;..\freetype2\freetype2\include;..\harfbuzz\harfbuzz\src;..\fribidi\fribidi\lib;..\fribidi\fribidi\charset;..\fribidi;..\fribidi\fribidi\SMP\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level2</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/src/thirdparty/libass/libass.vcxproj
+++ b/src/thirdparty/libass/libass.vcxproj
@@ -76,9 +76,7 @@
     <None Include="libass.def" />
   </ItemGroup>
   <ItemGroup>
-    <NASM Include="libass\libass\x86\be_blur.asm">
-      <ExcludedFromBuild Condition="'$(Platform)'=='Win32'">true</ExcludedFromBuild>
-    </NASM>
+    <NASM Include="libass\libass\x86\be_blur.asm" />
     <NASM Include="libass\libass\x86\blend_bitmaps.asm" />
     <NASM Include="libass\libass\x86\blur.asm" />
     <NASM Include="libass\libass\x86\cpuid.asm" />
@@ -110,7 +108,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CONFIG_ASM;ARCH_X86;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>.;libass\libass;..\fribidi\generated;..\libiconv\libiconv-for-Windows\include;..\dirent;..\freetype2\freetype2\include\freetype;..\fontconfig\fontconfig;..\freetype2\freetype2\include;..\harfbuzz\harfbuzz\src;..\fribidi\fribidi\lib;..\fribidi\fribidi\charset;..\fribidi;..\fribidi\fribidi\SMP\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level2</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/src/thirdparty/libass/libass.vcxproj
+++ b/src/thirdparty/libass/libass.vcxproj
@@ -26,30 +26,30 @@
     <ClInclude Include="libass\libass\ass_cache_template.h" />
     <ClInclude Include="libass\libass\ass_compat.h" />
     <ClInclude Include="libass\libass\ass_directwrite.h" />
-    <ClInclude Include="libass\libass\ass_directwrite_info_template.h" />
     <ClInclude Include="libass\libass\ass_drawing.h" />
     <ClInclude Include="libass\libass\ass_filesystem.h" />
     <ClInclude Include="libass\libass\ass_font.h" />
     <ClInclude Include="libass\libass\ass_fontconfig.h" />
     <ClInclude Include="libass\libass\ass_fontselect.h" />
     <ClInclude Include="libass\libass\ass_func_template.h" />
-    <ClInclude Include="libass\libass\ass_library.h" />
     <ClInclude Include="libass\libass\ass_outline.h" />
     <ClInclude Include="libass\libass\ass_parse.h" />
     <ClInclude Include="libass\libass\ass_rasterizer.h" />
+    <ClInclude Include="libass\libass\c\blur_template.h" />
+    <ClInclude Include="libass\libass\c\rasterizer_template.h" />
     <ClInclude Include="libass\libass\ass_render.h" />
     <ClInclude Include="libass\libass\ass_shaper.h" />
     <ClInclude Include="libass\libass\ass_string.h" />
     <ClInclude Include="libass\libass\ass_types.h" />
     <ClInclude Include="libass\libass\ass_utils.h" />
     <ClInclude Include="libass\libass\dwrite_c.h" />
-    <ClInclude Include="libass\libass\wyhash.h" />
     <ClInclude Include="libass\libass\x86\cpuid.h" />
     <ClInclude Include="config.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="libass\libass\ass.c" />
     <ClCompile Include="libass\libass\ass_bitmap.c" />
+    <ClCompile Include="libass\libass\ass_bitmap_engine.c" />
     <ClCompile Include="libass\libass\ass_blur.c" />
     <ClCompile Include="libass\libass\ass_cache.c" />
     <ClCompile Include="libass\libass\ass_directwrite.c" />
@@ -62,7 +62,10 @@
     <ClCompile Include="libass\libass\ass_outline.c" />
     <ClCompile Include="libass\libass\ass_parse.c" />
     <ClCompile Include="libass\libass\ass_rasterizer.c" />
-    <ClCompile Include="libass\libass\ass_rasterizer_c.c" />
+    <ClCompile Include="libass\libass\c\c_rasterizer.c" />
+    <ClCompile Include="libass\libass\c\c_blend_bitmaps.c" />
+    <ClCompile Include="libass\libass\c\c_blur.c" />
+    <ClCompile Include="libass\libass\c\c_be_blur.c" />
     <ClCompile Include="libass\libass\ass_render.c" />
     <ClCompile Include="libass\libass\ass_render_api.c" />
     <ClCompile Include="libass\libass\ass_shaper.c" />
@@ -103,8 +106,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PreprocessorDefinitions>CONFIG_ASM;ARCH_X86;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>.;libass\libass;..\fribidi\generated;..\libiconv\libiconv-for-Windows\include;..\dirent;..\freetype2\freetype2\include\freetype;..\fontconfig\fontconfig;..\freetype2\freetype2\include;..\harfbuzz\harfbuzz\src;..\fribidi\fribidi\lib;..\fribidi\fribidi\charset;..\fribidi;..\fribidi\fribidi\SMP\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.;libass\libass;..\fribidi\generated;..\libiconv\libiconv-for-Windows\include;..\dirent;..\freetype2\freetype2\include\freetype;..\fontconfig\fontconfig;..\freetype2\freetype2\include;..\harfbuzz\harfbuzz\src;..\fribidi\fribidi\lib;..\fribidi\fribidi\charset;..\fribidi;..\fribidi\fribidi\SMP\lib;..\libunibreak\libunibreak\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level2</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <C99Support>true</C99Support>
@@ -112,7 +115,7 @@
       <DisableSpecificWarnings>4005;4244;4267;4018;4334;4101;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>freetype2.lib;libfontconfig.lib;libfribidi.lib;libharfbuzz.lib;libiconv.lib;liblzma.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>freetype2.lib;libfontconfig.lib;libfribidi.lib;libharfbuzz.lib;libiconv.lib;liblzma.lib;zlib.lib;libunibreak.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
     <NASM>
       <IncludePaths>libass\libass;%(IncludePaths)</IncludePaths>

--- a/src/thirdparty/libass/libass.vcxproj.filters
+++ b/src/thirdparty/libass/libass.vcxproj.filters
@@ -87,10 +87,24 @@
     <ClInclude Include="libass\libass\ass_outline.h">
       <Filter>Header Files\libass</Filter>
     </ClInclude>
-    <ClInclude Include="config.h" />
-    <ClInclude Include="libass\libass\ass_bitmap_engine.h" />
-    <ClInclude Include="libass\libass\ass_filesystem.h" />
-    <ClInclude Include="libass\libass\c\rasterizer_template.h" />
+    <ClInclude Include="libass\libass\wyhash.h">
+      <Filter>Header Files\libass</Filter>
+    </ClInclude>
+    <ClInclude Include="libass\libass\ass_bitmap_engine.h">
+      <Filter>Header Files\libass</Filter>
+    </ClInclude>
+    <ClInclude Include="libass\libass\ass_directwrite_info_template.h">
+      <Filter>Header Files\libass</Filter>
+    </ClInclude>
+    <ClInclude Include="libass\libass\ass_filesystem.h">
+      <Filter>Header Files\libass</Filter>
+    </ClInclude>
+    <ClInclude Include="libass\libass\ass_library.h">
+      <Filter>Header Files\libass</Filter>
+    </ClInclude>
+    <ClInclude Include="config.h">
+      <Filter>Header Files\libass</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="libass\libass\ass_fontconfig.c">
@@ -150,12 +164,12 @@
     <ClCompile Include="libass\libass\ass_outline.c">
       <Filter>Source Files\libass</Filter>
     </ClCompile>
-    <ClCompile Include="libass\libass\ass_bitmap_engine.c" />
-    <ClCompile Include="libass\libass\ass_filesystem.c" />
-    <ClCompile Include="libass\libass\c\c_rasterizer.c" />
-    <ClCompile Include="libass\libass\c\c_blend_bitmaps.c" />
-    <ClCompile Include="libass\libass\c\c_blur.c" />
-    <ClCompile Include="libass\libass\c\c_be_blur.c" />
+    <ClCompile Include="libass\libass\ass_filesystem.c">
+      <Filter>Source Files\libass</Filter>
+    </ClCompile>
+    <ClCompile Include="libass\libass\ass_rasterizer_c.c">
+      <Filter>Source Files\libass</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="libass.def">

--- a/src/thirdparty/libass/libass.vcxproj.filters
+++ b/src/thirdparty/libass/libass.vcxproj.filters
@@ -36,9 +36,6 @@
     <ClInclude Include="libass\libass\ass_fontconfig.h">
       <Filter>Header Files\libass</Filter>
     </ClInclude>
-    <ClInclude Include="libass\libass\ass_library.h">
-      <Filter>Header Files\libass</Filter>
-    </ClInclude>
     <ClInclude Include="libass\libass\ass_parse.h">
       <Filter>Header Files\libass</Filter>
     </ClInclude>
@@ -91,6 +88,9 @@
       <Filter>Header Files\libass</Filter>
     </ClInclude>
     <ClInclude Include="config.h" />
+    <ClInclude Include="libass\libass\ass_bitmap_engine.h" />
+    <ClInclude Include="libass\libass\ass_filesystem.h" />
+    <ClInclude Include="libass\libass\c\rasterizer_template.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="libass\libass\ass_fontconfig.c">
@@ -132,9 +132,6 @@
     <ClCompile Include="libass\libass\ass_font.c">
       <Filter>Source Files\libass</Filter>
     </ClCompile>
-    <ClCompile Include="libass\libass\ass_rasterizer_c.c">
-      <Filter>Source Files\libass</Filter>
-    </ClCompile>
     <ClCompile Include="libass\libass\ass_rasterizer.c">
       <Filter>Source Files\libass</Filter>
     </ClCompile>
@@ -153,6 +150,12 @@
     <ClCompile Include="libass\libass\ass_outline.c">
       <Filter>Source Files\libass</Filter>
     </ClCompile>
+    <ClCompile Include="libass\libass\ass_bitmap_engine.c" />
+    <ClCompile Include="libass\libass\ass_filesystem.c" />
+    <ClCompile Include="libass\libass\c\c_rasterizer.c" />
+    <ClCompile Include="libass\libass\c\c_blend_bitmaps.c" />
+    <ClCompile Include="libass\libass\c\c_blur.c" />
+    <ClCompile Include="libass\libass\c\c_be_blur.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="libass.def">

--- a/src/thirdparty/libunibreak/libunibreak.vcxproj
+++ b/src/thirdparty/libunibreak/libunibreak.vcxproj
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{51abbf2b-fb42-4d88-ab50-3ce956014b5c}</ProjectGuid>
+    <RootNamespace>libunibreak</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="..\..\platform.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseOfMfc>Static</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\common.props" />
+    <Import Project="..\..\common-3rd-party.props" />
+  </ImportGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="libunibreak\src\emojidef.h" />
+    <ClInclude Include="libunibreak\src\graphemebreak.h" />
+    <ClInclude Include="libunibreak\src\graphemebreakdef.h" />
+    <ClInclude Include="libunibreak\src\linebreak.h" />
+    <ClInclude Include="libunibreak\src\linebreakdef.h" />
+    <ClInclude Include="libunibreak\src\test_skips.h" />
+    <ClInclude Include="libunibreak\src\unibreakbase.h" />
+    <ClInclude Include="libunibreak\src\unibreakdef.h" />
+    <ClInclude Include="libunibreak\src\wordbreak.h" />
+    <ClInclude Include="libunibreak\src\wordbreakdef.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="libunibreak\src\emojidata.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\emojidef.c" />
+    <ClCompile Include="libunibreak\src\graphemebreak.c" />
+    <ClCompile Include="libunibreak\src\graphemebreakdata.c" />
+    <ClCompile Include="libunibreak\src\linebreak.c" />
+    <ClCompile Include="libunibreak\src\linebreakdata.c" />
+    <ClCompile Include="libunibreak\src\linebreakdef.c" />
+    <ClCompile Include="libunibreak\src\unibreakbase.c" />
+    <ClCompile Include="libunibreak\src\unibreakdef.c" />
+    <ClCompile Include="libunibreak\src\wordbreak.c" />
+    <ClCompile Include="libunibreak\src\wordbreakdata.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/thirdparty/libunibreak/libunibreak.vcxproj.filters
+++ b/src/thirdparty/libunibreak/libunibreak.vcxproj.filters
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="libunibreak\src\emojidef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\graphemebreak.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\graphemebreakdef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\linebreak.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\linebreakdef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\test_skips.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\unibreakbase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\unibreakdef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\wordbreak.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="libunibreak\src\wordbreakdef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="libunibreak\src\emojidata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\emojidef.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\graphemebreak.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\graphemebreakdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\linebreak.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\linebreakdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\linebreakdef.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\unibreakbase.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\unibreakdef.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\wordbreak.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="libunibreak\src\wordbreakdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I found that libass was on an old branch.  The c-path (slow vs. ASM) is mostly removed from 0.17.1.

Updated some things to work with latest libass.

Performance remains high thanks to `ARCH_X86`.