### PR TITLE
support saving paths for additional filedialogs

### DIFF
--- a/src/DSUtil/DSUtil.cpp
+++ b/src/DSUtil/DSUtil.cpp
@@ -2010,3 +2010,10 @@ bool FindStringInList(const CAtlList<CString>& list, CString& value)
     }
     return found;
 }
+
+CStringW ForceTrailingSlash(CStringW folder) {
+    if (folder.Right(1) != L'\\' && folder.GetLength() > 0) {
+        folder += L'\\';
+    }
+    return folder;
+}

--- a/src/DSUtil/DSUtil.h
+++ b/src/DSUtil/DSUtil.h
@@ -131,6 +131,7 @@ extern void SetThreadName(DWORD dwThreadID, LPCSTR szThreadName);
 extern CString FindCoverArt(const CString& path, const CString& author);
 extern CString NormalizeUnicodeStrForSearch(CString srcStr, LANGID langid);
 extern bool FindStringInList(const CAtlList<CString>& list, CString& value);
+extern CStringW ForceTrailingSlash(CStringW folder);
 
 extern inline const LONGLONG GetPerfCounter();
 

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -255,7 +255,8 @@ CAppSettings::CAppSettings()
     , iReloadAfterLongPause(0)
     , bOpenRecPanelWhenOpeningDevice(true)
     , lastQuickOpenPath(L"")
-    , lastSaveImagePath(L"")
+    , lastFileSaveCopyPath(L"")
+    , lastFileOpenDirPath(L"")
     , iRedirectOpenToAppendThreshold(1000)
     , bFullscreenSeparateControls(false)
     , bAlwaysUseShortMenu(false)
@@ -1253,7 +1254,9 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_USE_AUTOMATIC_CAPTIONS, bUseAutomaticCaptions);
 
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_LAST_QUICKOPEN_PATH, lastQuickOpenPath);
-    pApp->WriteProfileString(IDS_R_SETTINGS, IDS_LAST_SAVEIMAGE_PATH, lastSaveImagePath);
+    pApp->WriteProfileString(IDS_R_SETTINGS, IDS_LAST_FILESAVECOPY_PATH, lastFileSaveCopyPath);
+    pApp->WriteProfileString(IDS_R_SETTINGS, IDS_LAST_FILEOPENDIR_PATH, lastFileOpenDirPath);
+
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_REDIRECT_OPEN_TO_APPEND_THRESHOLD, iRedirectOpenToAppendThreshold);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_FULLSCREEN_SEPARATE_CONTROLS, bFullscreenSeparateControls);
@@ -2060,7 +2063,9 @@ void CAppSettings::LoadSettings()
     bUseAutomaticCaptions = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_USE_AUTOMATIC_CAPTIONS, FALSE);
 
     lastQuickOpenPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_LAST_QUICKOPEN_PATH, L"");
-    lastSaveImagePath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_LAST_SAVEIMAGE_PATH, L"");
+    lastFileSaveCopyPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_LAST_FILESAVECOPY_PATH, L"");
+    lastFileOpenDirPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_LAST_FILEOPENDIR_PATH, L"");
+
 
     iRedirectOpenToAppendThreshold = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_REDIRECT_OPEN_TO_APPEND_THRESHOLD, 1000);
     bFullscreenSeparateControls = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_FULLSCREEN_SEPARATE_CONTROLS, FALSE);

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -952,7 +952,8 @@ public:
     CStringA strOpenTypeLangHint;
 
     CStringW lastQuickOpenPath;
-    CStringW lastSaveImagePath;
+    CStringW lastFileSaveCopyPath;
+    CStringW lastFileOpenDirPath;
 
     int iRedirectOpenToAppendThreshold;
     bool bFullscreenSeparateControls;

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -890,6 +890,8 @@ public:
 
     // menu item handlers
 
+    INT_PTR DoFileDialogWithLastFolder(CFileDialog& fd, CStringW& lastPath);
+
     afx_msg void OnFileOpenQuick();
     afx_msg void OnFileOpenmedia();
     afx_msg void OnUpdateFileOpen(CCmdUI* pCmdUI);

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -380,4 +380,6 @@
 #define IDS_RS_ENABLE_CRASH_REPORTER        _T("EnableCrashReporter")
 
 #define IDS_LAST_QUICKOPEN_PATH             _T("LastQuickOpenPath")
-#define IDS_LAST_SAVEIMAGE_PATH             _T("LastSaveImagePath")
+#define IDS_LAST_FILESAVECOPY_PATH          _T("LastFileSaveCopyPath")
+#define IDS_LAST_FILEOPENDIR_PATH          _T("LastFileOpenDirPath")
+


### PR DESCRIPTION
Tries to unify the behavior for remembering last file path.

1. Add convenience function `DoFileDialogWithLastFolder` to wrap `DoModal()` when saving the last path
2. Remove use of `IFileOpenDialog* openDlgPtr` code as it is an unnecessary complication to update the title (which can already be done via `fd.m_ofn.lpstrTitle`.

Cases:

1. File - Quick Open : add `lastQuickOpenPath` to support
2. File - Open File : already relies on `COpenDlg` to load previous paths
3. File - Open DVD: reuse `fUseDVDPath` as default for open dialog
4. File - Open Directory: add `lastFileOpenDirPath` as default for open dialog
5. File - Save a Copy: `lastFileSaveCopyPath` as default for open dialog
6. File - Save Image : already relies on `CSaveImageDialog` and `strSnapshotPath` to load previous path
7. File - Save Thumbnails : already relies on `CSaveThumbnailsDialog` and `strSnapshotPath` to load previous path
8. File - Subtitles - load/save: uses current video folder, which is more appropriate

