### PR TITLE
support saving playlist positions

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -1273,7 +1273,42 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
         }
     }
 
+    size_t maxsize = AfxGetAppSettings().fKeepHistory ? iRecentFilesNumber : 0;
+    CStringW section = L"PlaylistHistory";
+    auto timeToHash = LoadHistoryHashes(section, L"LastUpdated");
+
+    int entries = 0;
+    for (auto iter = timeToHash.rbegin(); iter != timeToHash.rend(); ++iter, ++entries) {
+        CStringW hash = iter->second;
+        if (entries >= maxsize) {
+            PurgeExpiredHash(section, hash);
+        }
+    }
+
     pApp->FlushProfile();
+}
+
+std::multimap<CStringW, CStringW> CAppSettings::LoadHistoryHashes(CStringW section, CStringW dateField) {
+    auto pApp = AfxGetMyApp();
+    auto hashes = pApp->GetSectionSubKeys(section);
+
+    std::multimap<CStringW, CStringW> timeToHash;
+    for (auto const& hash : hashes) {
+        CStringW lastOpened, subSection;
+        subSection.Format(L"%s\\%s", section, static_cast<LPCWSTR>(hash));
+        lastOpened = pApp->GetProfileStringW(subSection, dateField, L"0000-00-00T00:00:00.0Z");
+        if (!lastOpened.IsEmpty()) {
+            timeToHash.insert(std::pair<CStringW, CStringW>(lastOpened, hash));
+        }
+    }
+    return timeToHash;
+}
+
+void CAppSettings::PurgeExpiredHash(CStringW section, CStringW hash) {
+    auto pApp = AfxGetMyApp();
+    CStringW subSection;
+    subSection.Format(L"%s\\%s", section, static_cast<LPCWSTR>(hash));
+    pApp->WriteProfileString(subSection, nullptr, nullptr);
 }
 
 void CAppSettings::LoadExternalFilters(CAutoPtrList<FilterOverride>& filters, LPCTSTR baseKey /*= IDS_R_EXTERNAL_FILTERS*/)
@@ -3136,15 +3171,7 @@ void CAppSettings::CRecentFileListWithMoreInfo::ReadMediaHistory() {
         hashes = pApp->GetSectionSubKeys(m_section);
     }
 
-    std::multimap<CStringW, CStringW> timeToHash;
-    for (auto const& hash : hashes) {
-        CStringW lastOpened, subSection;
-        subSection.Format(L"%s\\%s", m_section, static_cast<LPCWSTR>(hash));
-        lastOpened = pApp->GetProfileStringW(subSection, L"LastOpened");
-        if (!lastOpened.IsEmpty()) {
-            timeToHash.insert(std::pair<CStringW, CStringW>(lastOpened, hash));
-        }
-    }
+    auto timeToHash = CAppSettings::LoadHistoryHashes(m_section, L"LastOpened");
 
     rfe_array.RemoveAll();
     int entries = 0;
@@ -3161,9 +3188,7 @@ void CAppSettings::CRecentFileListWithMoreInfo::ReadMediaHistory() {
             }
         }
         if (purge_rfe) { //purge entry
-            CStringW subSection;
-            subSection.Format(L"%s\\%s", m_section, static_cast<LPCWSTR>(hash));
-            pApp->WriteProfileString(subSection, nullptr, nullptr);
+            CAppSettings::PurgeExpiredHash(m_section, hash);
         }
     }
     rfe_array.FreeExtra();
@@ -3581,6 +3606,11 @@ void CAppSettings::SavePlayListPosition(CStringW playlistPath, UINT position) {
     CStringW subSection, t;
     subSection.Format(L"%s\\%s", L"PlaylistHistory", static_cast<LPCWSTR>(hash));
     pApp->WriteProfileInt(subSection, L"Position", position);
+
+    auto now = std::chrono::system_clock::now();
+    auto nowISO = date::format<wchar_t>(L"%FT%TZ", date::floor<std::chrono::microseconds>(now));
+    CStringW lastUpdated = CStringW(nowISO.c_str());
+    pApp->WriteProfileStringW(subSection, L"LastUpdated", lastUpdated);
 }
 
 UINT CAppSettings::GetSavedPlayListPosition(CStringW playlistPath) {

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -3572,6 +3572,32 @@ CRenderersSettings& GetRenderersSettings() {
     return AfxGetAppSettings().m_RenderersSettings;
 }
 
+void CAppSettings::SavePlayListPosition(CStringW playlistPath, UINT position) {
+    auto pApp = AfxGetMyApp();
+    ASSERT(pApp);
+
+    auto hash = getRFEHash(playlistPath);
+
+    CStringW subSection, t;
+    subSection.Format(L"%s\\%s", L"PlaylistHistory", static_cast<LPCWSTR>(hash));
+    pApp->WriteProfileInt(subSection, L"Position", position);
+}
+
+UINT CAppSettings::GetSavedPlayListPosition(CStringW playlistPath) {
+    auto pApp = AfxGetMyApp();
+    ASSERT(pApp);
+
+    auto hash = getRFEHash(playlistPath);
+
+    CStringW subSection, t;
+    subSection.Format(L"%s\\%s", L"PlaylistHistory", static_cast<LPCWSTR>(hash));
+    UINT position = pApp->GetProfileIntW(subSection, L"Position", -1);
+    if (position != (UINT)-1) {
+        return position;
+    }
+    return 0;
+}
+
 // SubRendererSettings.h
 
 // Todo: move individual members of AppSettings into SubRendererSettings struct and use this function to get a reference to it

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -1014,6 +1014,10 @@ public:
     };
     void            UpdateSettings();
 
+    void SavePlayListPosition(CStringW playlistPath, UINT position);
+
+    UINT GetSavedPlayListPosition(CStringW playlistPath);
+
     void            SetAsUninitialized() {
         bInitialized = false;
     };

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -1006,6 +1006,8 @@ public:
     CAppSettings& operator = (const CAppSettings&) = delete;
 
     void            SaveSettings(bool write_full_history = false);
+    static std::multimap<CStringW, CStringW> LoadHistoryHashes(CStringW section, CStringW dateField);
+    static void PurgeExpiredHash(CStringW section, CStringW hash);
     void            LoadSettings();
     void            SaveExternalFilters() {
         if (bInitialized) {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -4701,7 +4701,9 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
                 }
 
                 applyRandomizeSwitch();
-                m_wndPlaylistBar.SetFirst();
+                if (sl.GetCount() != 1 || !IsPlaylistFile(sl.GetHead())) { //playlists already set first pos (or saved pos)
+                    m_wndPlaylistBar.SetFirst();
+                }
                 OpenCurPlaylistItem((s.nCLSwitches & CLSW_STARTVALID) ? s.rtStart : 0, false, s.abRepeat);
 
                 s.nCLSwitches &= ~CLSW_STARTVALID;
@@ -4917,6 +4919,12 @@ bool CMainFrame::IsImageFileExt(CStringW ext) {
         ext == _T(".jpg") || ext == _T(".jpeg") || ext == _T(".png") || ext == _T(".gif") || ext == _T(".bmp")
         || ext == _T(".tiff") || ext == _T(".jpe") || ext == _T(".tga") || ext == _T(".heic") || ext == _T(".avif")
     );
+}
+
+bool CMainFrame::IsPlaylistFile(CStringW fn) {
+    CPath path(fn);
+    CStringW ext(path.GetExtension());
+    return IsPlaylistFileExt(ext);
 }
 
 bool CMainFrame::IsPlaylistFileExt(CStringW ext) {
@@ -13022,6 +13030,10 @@ void CMainFrame::OpenFile(OpenFileData* pOFD)
                 }
 
                 pMRU->Add(r, true);
+                CStringW playListName;
+                if (m_wndPlaylistBar.IsExternalPlayListActive(playListName)) {
+                    s.SavePlayListPosition(playListName, m_wndPlaylistBar.GetSelIdx());
+                }
             }
             else {
                 if (!pli || !pli->m_bYoutubeDL) {

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1285,6 +1285,7 @@ protected:
     bool IsPlayableFormatExt(CStringW ext);
     bool IsAudioFileExt(CStringW ext);
     bool IsImageFileExt(CStringW ext);
+    bool IsPlaylistFile(CStringW fn);
     bool IsPlaylistFileExt(CStringW ext);
     bool IsAudioOrVideoFileExt(CStringW ext);
     bool CanSkipToExt(CStringW ext, CStringW curExt);

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -442,7 +442,9 @@ void CPlayerPlaylistBar::ParsePlayList(CAtlList<CString>& fns, CAtlList<CString>
         ParseCUESheet(fns.GetHead());
         return;
     } else if (ct == _T("audio/x-mpegurl") || ct == _T("audio/mpegurl")) {
-        if (ParseM3UPlayList(fns.GetHead())) {
+        auto fn = fns.GetHead();
+        if (ParseM3UPlayList(fn)) {
+            ExternalPlayListLoaded(fn);
             /* We have handled this one. If parsing fails it should fall through to AddItem below.
                It returns false for HLS playlists, since we want those to be handled directly by LAV Splitter.
             */

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -377,8 +377,13 @@ bool CPlayerPlaylistBar::AddItemsInFolder(CString pathname, bool insertAtCurrent
 }
 
 void CPlayerPlaylistBar::ExternalPlayListLoaded(CStringW fn) {
-    m_ExternalPlayListPath = fn;
-    m_ExternalPlayListFNCopy = m_pl.GetIDs();
+    if (!PathUtils::IsURL(fn)) {
+        m_ExternalPlayListPath = fn;
+        m_ExternalPlayListFNCopy = m_pl.GetIDs();
+    } else {
+        m_ExternalPlayListPath = L"";
+        m_ExternalPlayListFNCopy.clear();
+    }
 }
 
 bool CPlayerPlaylistBar::IsExternalPlayListActive(CStringW& playlistPath) {

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -63,6 +63,10 @@ private:
     int m_itemHeight = 0;
     int m_initialWindowDPI = 0;
     bool createdWindow;
+    CStringW m_ExternalPlayListPath;
+    CPlaylistIDs m_ExternalPlayListFNCopy;
+    void ExternalPlayListLoaded(CStringW fn);
+
 
     EventClient m_eventc;
     void EventCallback(MpcEvent ev);
@@ -152,6 +156,7 @@ public:
     void UpdateLabel(CString in);
 
     void Refresh();
+    void PlayListChanged();
     bool Empty();
 
     void Open(CAtlList<CString>& fns, bool fMulti, CAtlList<CString>* subs = nullptr, CString label = _T(""), CString ydl_src = _T(""), CString cue = _T(""));
@@ -169,6 +174,7 @@ public:
 
     bool SelectFileInPlaylist(LPCTSTR filename);
     bool DeleteFileInPlaylist(POSITION pos, bool recycle = true);
+    bool IsExternalPlayListActive(CStringW& playlistPath);
 
 protected:
     virtual BOOL PreCreateWindow(CREATESTRUCT& cs);

--- a/src/mpc-hc/Playlist.cpp
+++ b/src/mpc-hc/Playlist.cpp
@@ -453,6 +453,16 @@ void CPlaylist::SetShuffle(bool bEnable)
     }
 }
 
+CPlaylistIDs CPlaylist::GetIDs() {
+    CPlaylistIDs ids;
+    POSITION pos = GetHeadPosition();
+    for (size_t i = 0; pos; i++, GetNext(pos)) {
+        CPlaylistItem& pli = GetAt(pos);
+        ids.push_back(pli.m_id);
+    }
+    return ids;
+}
+
 // This will reshuffle if the shuffled list size
 // does not match the playlist size.
 bool CPlaylist::ReshuffleIfNeeded()

--- a/src/mpc-hc/Playlist.h
+++ b/src/mpc-hc/Playlist.h
@@ -66,6 +66,11 @@ public:
     CString GetLabel(int i = 0);
 };
 
+
+class CPlaylistIDs : public std::vector<UINT> {
+
+};
+
 class CPlaylist : protected CAtlList<CPlaylistItem>
 {
 protected:
@@ -113,4 +118,5 @@ public:
     CPlaylistItem& GetPrevWrap(POSITION& pos);
 
     void SetShuffle(bool bEnable);
+    CPlaylistIDs GetIDs();
 };


### PR DESCRIPTION
This is a starting point for saving playlist positions.  It works like this:

1. When a playlist is loaded, if it replaces the currently active playlist, it is considered "active."
2. Active playlist save a list of sequences to record the unique ids known by the playlist
3. The next time a file in the playlist is opened, if the list of unique ids is the same (nothing has been added, removed, or shuffled), the originally loaded playlist is considered to still be active.  Otherwise, it clears the playlist state and no playlist is considered active anymore.
4. If the playlist _is_ active, then it stores the current position within the playlist under PlaylistHistory/<hash of playlist file>
5. The next time a playlist with identical hash is loaded, it will jump to that sequence.

Limitations:
1. Need to clear history at some point, maybe 100 playlists
2. If the playlist is not the same as it was the last time it was loaded, the position is no longer valid.  It does not store the filename of the current position.  Might be worth comparing the position/filename to work better, but playlists can also contain the same filename multiple times.  Another option is to record last modified date or file content hash and refuse to load position if its changed.
3. Only supports mpcpl and m3u, but it's easy to support others. I didn't have others to test so I left them off for now.

