### PR TITLE
improve scrollbarhelper to redraw areas after changing draw region due to resize

### DIFF
--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -61,7 +61,7 @@ BEGIN_MESSAGE_MAP(CMPCThemePlayerListCtrl, CListCtrl)
     ON_NOTIFY(HDN_ENDTRACKA, 0, &OnHdnEndtrack)
     ON_NOTIFY(HDN_ENDTRACKW, 0, &OnHdnEndtrack)
     ON_NOTIFY_REFLECT_EX(LVN_ITEMCHANGED, &OnLvnItemchanged)
-    ON_MESSAGE(PLAYER_PLAYLIST_LVN_ITEMCHANGED, OnDelayed_updateListCtrl)
+    ON_MESSAGE(PLAYER_PLAYLIST_UPDATE_SCROLLBAR, OnDelayed_UpdateScrollbar)
 END_MESSAGE_MAP()
 
 void CMPCThemePlayerListCtrl::subclassHeader()
@@ -270,6 +270,7 @@ void CMPCThemePlayerListCtrl::OnNcCalcSize(BOOL bCalcValidRects, NCCALCSIZE_PARA
         if (GetStyle() & WS_HSCROLL && nullptr == themedSBHelper) {
             themedSBHelper = DEBUG_NEW CMPCThemeScrollBarHelper(this);
         }
+        ::PostMessage(m_hWnd, PLAYER_PLAYLIST_UPDATE_SCROLLBAR, (WPARAM)0, (LPARAM)0);
     }
 }
 
@@ -592,7 +593,7 @@ void CMPCThemePlayerListCtrl::OnHdnEndtrack(NMHDR* pNMHDR, LRESULT* pResult)
     *pResult = 0;
 }
 
-LRESULT CMPCThemePlayerListCtrl::OnDelayed_updateListCtrl(WPARAM, LPARAM)
+LRESULT CMPCThemePlayerListCtrl::OnDelayed_UpdateScrollbar(WPARAM, LPARAM)
 {
     updateScrollInfo();
     return 0;
@@ -602,7 +603,7 @@ BOOL CMPCThemePlayerListCtrl::OnLvnItemchanged(NMHDR* pNMHDR, LRESULT* pResult)
 {
     //LPNMLISTVIEW pNMLV = reinterpret_cast<LPNMLISTVIEW>(pNMHDR);
     if (AppNeedsThemedControls()) {
-        ::PostMessage(m_hWnd, PLAYER_PLAYLIST_LVN_ITEMCHANGED, (WPARAM)0, (LPARAM)0);
+        ::PostMessage(m_hWnd, PLAYER_PLAYLIST_UPDATE_SCROLLBAR, (WPARAM)0, (LPARAM)0);
     }
     *pResult = 0;
     return FALSE;

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.h
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.h
@@ -66,7 +66,7 @@ protected:
 public:
     void doDefault() { Default(); };
     afx_msg void OnHdnEndtrack(NMHDR* pNMHDR, LRESULT* pResult);
-    afx_msg LRESULT OnDelayed_updateListCtrl(WPARAM, LPARAM);
+    afx_msg LRESULT OnDelayed_UpdateScrollbar(WPARAM, LPARAM);
     afx_msg BOOL OnLvnItemchanged(NMHDR* pNMHDR, LRESULT* pResult);
 };
 

--- a/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
@@ -7,6 +7,7 @@ CMPCThemeScrollBarHelper::CMPCThemeScrollBarHelper(CWnd* scrollWindow)
 {
     window = scrollWindow;
     pParent = nullptr;
+    currentlyClipped = false;
 }
 
 
@@ -80,10 +81,32 @@ void CMPCThemeScrollBarHelper::setDrawingArea(CRect& cr, CRect& wr, bool clippin
                 horzSB.ShowWindow(SW_HIDE);
             }
         }
-    }
+        bool wasClipped = currentlyClipped;
 
-    HRGN iehrgn = CreateRectRgn(wr.left, wr.top, wr.right, wr.bottom);
-    window->SetWindowRgn(iehrgn, false);
+        if (wr != realWR) {
+            HRGN iehrgn = CreateRectRgn(wr.left, wr.top, wr.right, wr.bottom);
+            window->SetWindowRgn(iehrgn, false);
+            currentlyClipped = true;
+        } else {
+            window->SetWindowRgn(NULL, false);
+            currentlyClipped = false;
+        }
+        if (wasClipped && currentClipRegion != wr) { //we do not repaint during SetWindowRgn, but we need to invalidate areas that were previously clipped
+            if (currentClipRegion.right < wr.right) {
+                CRect rightRedraw;
+                window->GetClientRect(rightRedraw);
+                rightRedraw.left = rightRedraw.right - (wr.right - currentClipRegion.right);
+                window->InvalidateRect(rightRedraw);
+            }
+            if (currentClipRegion.bottom < wr.bottom) {
+                CRect bottomRedraw = wr;
+                window->GetClientRect(bottomRedraw);
+                bottomRedraw.top = bottomRedraw.bottom - (wr.bottom - currentClipRegion.bottom);
+                window->InvalidateRect(bottomRedraw);
+            }
+        }
+        currentClipRegion = wr;
+    }
 }
 
 void CMPCThemeScrollBarHelper::hideSB()

--- a/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
@@ -106,6 +106,8 @@ void CMPCThemeScrollBarHelper::setDrawingArea(CRect& cr, CRect& wr, bool clippin
             }
         }
         currentClipRegion = wr;
+    } else {
+        window->SetWindowRgn(NULL, false);
     }
 }
 

--- a/src/mpc-hc/CMPCThemeScrollBarHelper.h
+++ b/src/mpc-hc/CMPCThemeScrollBarHelper.h
@@ -15,6 +15,8 @@ class CMPCThemeScrollBarHelper
 protected:
     CWnd* window, *pParent;
     CMPCThemeScrollBar vertSB, horzSB;
+    CRect currentClipRegion;
+    bool currentlyClipped;
     bool hasVSB;
     bool hasHSB;
     static void doNcPaint(CWnd* window);

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -740,7 +740,7 @@
 #define ID_FILE_RECYCLE                 24044
 #define ID_VIEW_MPCTHEME                24045
 #define IDS_AG_TOGGLE_MPCTHEME          24046
-#define PLAYER_PLAYLIST_LVN_ITEMCHANGED 24048
+#define PLAYER_PLAYLIST_UPDATE_SCROLLBAR 24048
 #define IDF_LOGO4                       24050
 #define ID_SUBTITLES_DEFAULT_STYLE      24051
 #define ID_SUB_POS_DOWN                 24052


### PR DESCRIPTION
Could use some testing for things with themed scrollbars.

Found a bug where resized windows and themed scrollbars created glitches due to window region changing.  Win32 does not automatically invalidate areas when the region is updated.