### PR TITLE
fix cursor flicker from inplaceedit on listctrl; fix fullrowselect bug in customdraw listctrl

### DIFF
--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -395,7 +395,7 @@ void CMPCThemePlayerListCtrl::drawItem(CDC* pDC, int nItem, int nSubItem)
             }
 
             if (IsWindowEnabled()) {
-                if (GetItemState(nItem, LVIS_SELECTED) == LVIS_SELECTED && (nSubItem == 0 || fullRowSelect)) {
+                if (GetItemState(nItem, LVIS_SELECTED) == LVIS_SELECTED && (nSubItem == 0 || fullRowSelect) && (GetStyle() & LVS_SHOWSELALWAYS || GetFocus() == this)) {
                     bgColor = selectedBGColor;
                     if (LVS_REPORT != dwStyle) { //in list mode we don't fill the "whole" column
                         CRect tmp = rText;

--- a/src/mpc-hc/PlayerListCtrl.cpp
+++ b/src/mpc-hc/PlayerListCtrl.cpp
@@ -491,6 +491,7 @@ CPlayerListCtrl::CPlayerListCtrl(int tStartEditingDelay)
     , m_tStartEditingDelay(tStartEditingDelay)
     , m_nTimerID(0)
     , m_fInPlaceDirty(false)
+    , inPlaceControl(true)
 {
 }
 
@@ -699,7 +700,7 @@ bool CPlayerListCtrl::PrepareInPlaceControl(int nRow, int nCol, CRect& rect)
     rect &= rcClient;
 
     rect.DeflateRect(1, 0, 0, 1);
-
+    inPlaceControl = true;
     return true;
 }
 
@@ -857,6 +858,8 @@ BEGIN_MESSAGE_MAP(CPlayerListCtrl, CMPCThemePlayerListCtrl)
     ON_WM_XBUTTONDOWN()
     ON_WM_XBUTTONUP()
     ON_WM_XBUTTONDBLCLK()
+    ON_WM_SETCURSOR()
+    ON_NOTIFY_REFLECT(LVN_ENDLABELEDIT, &CPlayerListCtrl::OnLvnEndlabeledit)
 END_MESSAGE_MAP()
 
 // CPlayerListCtrl message handlers
@@ -1109,4 +1112,19 @@ void CPlayerListCtrl::OnXButtonDblClk(UINT nFlags, UINT nButton, CPoint point)
         MapWindowPoints(pParent, &point, 1);
         pParent->SendMessage(WM_XBUTTONDBLCLK, MAKEWPARAM(nFlags, nButton), MAKELPARAM(point.x, point.y));
     }
+}
+
+BOOL CPlayerListCtrl::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message) {
+    if (inPlaceControl) {
+        return FALSE;
+    } else {
+        return CListCtrl::OnSetCursor(pWnd, nHitTest, message);
+    }
+}
+
+
+void CPlayerListCtrl::OnLvnEndlabeledit(NMHDR* pNMHDR, LRESULT* pResult) {
+    NMLVDISPINFO* pDispInfo = reinterpret_cast<NMLVDISPINFO*>(pNMHDR);
+    inPlaceControl = false;
+    *pResult = 0;
 }

--- a/src/mpc-hc/PlayerListCtrl.h
+++ b/src/mpc-hc/PlayerListCtrl.h
@@ -149,6 +149,7 @@ class CPlayerListCtrl : public CMPCThemePlayerListCtrl
 private:
     int m_nItemClicked, m_nSubItemClicked;
     int m_tStartEditingDelay;
+    bool inPlaceControl;
     UINT_PTR m_nTimerID;
 
     bool PrepareInPlaceControl(int nRow, int nCol, CRect& rect);
@@ -196,4 +197,6 @@ public:
     afx_msg void OnXButtonDown(UINT nFlags, UINT nButton, CPoint point);
     afx_msg void OnXButtonUp(UINT nFlags, UINT nButton, CPoint point);
     afx_msg void OnXButtonDblClk(UINT nFlags, UINT nButton, CPoint point);
+    afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
+    afx_msg void OnLvnEndlabeledit(NMHDR* pNMHDR, LRESULT* pResult);
 };


### PR DESCRIPTION
Two issues causing flicker in ListCtrl

1. In Classic mode, ListCtrl was still updating cursor even when in place edit was hovered.  This caused a flicker when the mouse hit the edge of the edits.  Added logic to disable that when in-place edit is there.
2. In themed mode, there was a bug that LVS_SHOWSELALWAYS wasn't being honored and the fullrow was still showing selected even when in place edit was focused.  Fixed this.

There is still a slight flicker in both classic and themed mode as the selected text in the edit is redrawn when the mouse hover changes.  It's worse in themed mode, but it's present in both.  Additionally, had LVS_SHOWSELALWAYS been set, the flicker corrected by # 2 above would probably return.