### PR TITLE
allow ANSI codepages to be used for libass files

### DIFF
--- a/src/Subtitles/RTS.cpp
+++ b/src/Subtitles/RTS.cpp
@@ -1842,6 +1842,7 @@ void CRenderedTextSubtitle::Empty()
 }
 
 void CRenderedTextSubtitle::SetOverride(bool bOverride, const STSStyle& styleOverride) {
+    ApplyANSICP(styleOverride.charSet);
     bool changed = (m_bOverrideStyle != bOverride) || bOverride && (m_styleOverride != styleOverride);
     if (changed) {
         m_bOverrideStyle = bOverride;

--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -2688,11 +2688,13 @@ STSStyle* CSimpleTextSubtitle::CreateDefaultStyle(int CharSet)
 }
 
 void CSimpleTextSubtitle::ApplyANSICP(int CharSet) {
-    POSITION pos = m_styles.GetStartPosition();
-    while (pos) {
-        CStringW key = m_styles.GetNextKey(pos);
-        if (m_styles[key]->charSet == DEFAULT_CHARSET || m_styles[key]->charSet == ANSI_CHARSET) {
-            m_styles[key]->charSet = CharSet;
+    if (CharSet != DEFAULT_CHARSET && CharSet != ANSI_CHARSET) { //don't bother
+        POSITION pos = m_styles.GetStartPosition();
+        while (pos) {
+            CStringW key = m_styles.GetNextKey(pos);
+            if (m_styles[key]->charSet == DEFAULT_CHARSET || m_styles[key]->charSet == ANSI_CHARSET) {
+                m_styles[key]->charSet = CharSet;
+            }
         }
     }
 }

--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -2687,6 +2687,16 @@ STSStyle* CSimpleTextSubtitle::CreateDefaultStyle(int CharSet)
     return ret;
 }
 
+void CSimpleTextSubtitle::ApplyANSICP(int CharSet) {
+    POSITION pos = m_styles.GetStartPosition();
+    while (pos) {
+        CStringW key = m_styles.GetNextKey(pos);
+        if (m_styles[key]->charSet == DEFAULT_CHARSET || m_styles[key]->charSet == ANSI_CHARSET) {
+            m_styles[key]->charSet = CharSet;
+        }
+    }
+}
+
 void CSimpleTextSubtitle::ChangeUnknownStylesToDefault()
 {
     CAtlMap<CString, STSStyle*, CStringElementTraits<CString>> unknown;

--- a/src/Subtitles/STS.h
+++ b/src/Subtitles/STS.h
@@ -150,6 +150,7 @@ public:
 
     void Add(CStringW str, bool fUnicode, REFERENCE_TIME start, REFERENCE_TIME end, CString style = _T("Default"), CString actor = _T(""), CString effect = _T(""), const CRect& marginRect = CRect(0, 0, 0, 0), int layer = 0, int readorder = -1);
     STSStyle* CreateDefaultStyle(int CharSet);
+    void ApplyANSICP(int CharSet);
     void ChangeUnknownStylesToDefault();
     void AddStyle(CString name, STSStyle* style); // style will be stored and freed in Empty() later
     bool CopyStyles(const CSTSStyleMap& styles, bool fAppend = false);


### PR DESCRIPTION
This is a minimal patch to allow the selected ANSI codepage to be used in place of default (and ANSI=0) for non-UTF8 SSA/ASS files.

The theory here is:

1. DEFAULT_CHARSET means to use the windows ANSI codepage.  Changing the ANSI codepage is still possible in windows, but generally a lot less common (and it is a system default requiring a reboot, and breaks various applications).  Yet, in MPC-HC we supply the option to choose the codepage at the application level.
2. SRT subtitles in MPC-HC honor the codepage setting.  An ANSI encoded SRT file will display correctly if the correct codepage is chosen in MPC-HC.
3. SSA/ASS subtitles in the same situtation as # 2 do not work, but it is fairly trivial to substitute DEFAULT_CHARSET (and ANSI) with the chosen charset in MPC-HC.  If the user is not overriding this ANSI charset, they will see no changes, and if they are, they probably prefer to see this change.
4. This is less complex and does not change the build time, compared to trying to analyze using uchardet, for example.

If the WRONG charset is used, MPC-HC should not be changing it, though an advanced option could be supplied to do just that.  But if the DEFAULT charset is used, being able to override it makes sense, IMO. 