### PR TITLE
support dynamically change ANSI charset

### DIFF
--- a/src/Subtitles/RTS.cpp
+++ b/src/Subtitles/RTS.cpp
@@ -1842,7 +1842,7 @@ void CRenderedTextSubtitle::Empty()
 }
 
 void CRenderedTextSubtitle::SetOverride(bool bOverride, const STSStyle& styleOverride) {
-    ApplyANSICP(styleOverride.charSet);
+    overrideANSICharset = styleOverride.charSet;
     bool changed = (m_bOverrideStyle != bOverride) || bOverride && (m_styleOverride != styleOverride);
     if (changed) {
         m_bOverrideStyle = bOverride;

--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -2398,6 +2398,7 @@ CSimpleTextSubtitle::CSimpleTextSubtitle()
     , m_ePARCompensationType(EPCTDisabled)
     , m_dPARCompensation(1.0)
     , m_SubRendererSettings(GetSubRendererSettings())
+    , overrideANSICharset(0)
 #if USE_LIBASS
     , m_LibassContext(this)
 #endif
@@ -2685,18 +2686,6 @@ STSStyle* CSimpleTextSubtitle::CreateDefaultStyle(int CharSet)
     m_originalDefaultStyle = *ret;
 
     return ret;
-}
-
-void CSimpleTextSubtitle::ApplyANSICP(int CharSet) {
-    if (CharSet != DEFAULT_CHARSET && CharSet != ANSI_CHARSET) { //don't bother
-        POSITION pos = m_styles.GetStartPosition();
-        while (pos) {
-            CStringW key = m_styles.GetNextKey(pos);
-            if (m_styles[key]->charSet == DEFAULT_CHARSET || m_styles[key]->charSet == ANSI_CHARSET) {
-                m_styles[key]->charSet = CharSet;
-            }
-        }
-    }
 }
 
 void CSimpleTextSubtitle::ChangeUnknownStylesToDefault()
@@ -3066,7 +3055,11 @@ bool CSimpleTextSubtitle::GetStyle(CString styleName, STSStyle& stss)
 int CSimpleTextSubtitle::GetCharSet(int i)
 {
     const STSStyle* stss = GetStyle(i);
-    return stss ? stss->charSet : DEFAULT_CHARSET;
+    int stssCharset = stss ? stss->charSet : DEFAULT_CHARSET;
+    if (overrideANSICharset > DEFAULT_CHARSET && (stssCharset == DEFAULT_CHARSET || stssCharset == ANSI_CHARSET)) {
+        return overrideANSICharset;
+    }
+    return stssCharset;
 }
 
 bool CSimpleTextSubtitle::IsEntryUnicode(int i)

--- a/src/Subtitles/STS.h
+++ b/src/Subtitles/STS.h
@@ -115,6 +115,7 @@ public:
     bool m_bUsingPlayerDefaultStyle;
 
     CSTSStyleMap m_styles;
+    int overrideANSICharset;
 
     enum EPARCompensationType {
         EPCTDisabled,
@@ -150,7 +151,6 @@ public:
 
     void Add(CStringW str, bool fUnicode, REFERENCE_TIME start, REFERENCE_TIME end, CString style = _T("Default"), CString actor = _T(""), CString effect = _T(""), const CRect& marginRect = CRect(0, 0, 0, 0), int layer = 0, int readorder = -1);
     STSStyle* CreateDefaultStyle(int CharSet);
-    void ApplyANSICP(int CharSet);
     void ChangeUnknownStylesToDefault();
     void AddStyle(CString name, STSStyle* style); // style will be stored and freed in Empty() later
     bool CopyStyles(const CSTSStyleMap& styles, bool fAppend = false);


### PR DESCRIPTION
Instead of destructively changing the styles, this uses an override charset.  That way, if codepage is changed, it still can update it from DEFAULT.