### PR TITLE
convert ansi stylenames to unicode for style tabs

### DIFF
--- a/src/DSUtil/text.cpp
+++ b/src/DSUtil/text.cpp
@@ -356,3 +356,31 @@ bool IsNameSimilar(const CString& title, const CString& fileName) {
     if (fileName.Find(title.Left(25)) > -1) return true;
     return false;
 }
+
+CStringW ToUnicode(CStringW str, DWORD CharSet) {
+    CStringW ret;
+    DWORD cp = CharSetToCodePage(CharSet);
+
+    for (int i = 0, j = str.GetLength(); i < j; i++) {
+        WCHAR wc = str.GetAt(i);
+        char c = wc & 0xff;
+
+        if (IsDBCSLeadByteEx(cp, (BYTE)wc)) {
+            i++;
+
+            if (i < j) {
+                char cc[2];
+                cc[0] = c;
+                cc[1] = (char)str.GetAt(i);
+
+                MultiByteToWideChar(cp, 0, cc, 2, &wc, 1);
+            }
+        } else {
+            MultiByteToWideChar(cp, 0, &c, 1, &wc, 1);
+        }
+
+        ret += wc;
+    }
+
+    return ret;
+}

--- a/src/DSUtil/text.h
+++ b/src/DSUtil/text.h
@@ -162,6 +162,7 @@ extern CAtlList<CString>& MakeLower(CAtlList<CString>& sl);
 extern CAtlList<CString>& MakeUpper(CAtlList<CString>& sl);
 extern int LastIndexOfCString(const CString& text, const CString& pattern);
 extern bool IsNameSimilar(const CString& title, const CString& fileName);
+extern CStringW ToUnicode(CStringW str, DWORD CharSet);
 
 CString FormatNumber(CString szNumber, bool bNoFractionalDigits = true);
 void GetLocaleString(LCID lcid, LCTYPE type, CString& output);

--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -379,35 +379,6 @@ static CStringW UnicodeSSAToMBCS(CStringW str, DWORD CharSet)
     return ret;
 }
 
-static CStringW ToUnicode(CStringW str, DWORD CharSet)
-{
-    CStringW ret;
-    DWORD cp = CharSetToCodePage(CharSet);
-
-    for (int i = 0, j = str.GetLength(); i < j; i++) {
-        WCHAR wc = str.GetAt(i);
-        char c = wc & 0xff;
-
-        if (IsDBCSLeadByteEx(cp, (BYTE)wc)) {
-            i++;
-
-            if (i < j) {
-                char cc[2];
-                cc[0] = c;
-                cc[1] = (char)str.GetAt(i);
-
-                MultiByteToWideChar(cp, 0, cc, 2, &wc, 1);
-            }
-        } else {
-            MultiByteToWideChar(cp, 0, &c, 1, &wc, 1);
-        }
-
-        ret += wc;
-    }
-
-    return ret;
-}
-
 static CStringW MBCSSSAToUnicode(CStringW str, int CharSet)
 {
     CStringW ret;
@@ -1959,6 +1930,7 @@ bool OpenSubStationAlpha(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
 
                 styleName.TrimLeft(_T('*'));
 
+                style->fromUnicode = file->IsUnicode();
                 ret.AddStyle(styleName, style);
             } catch (...) {
                 delete style;
@@ -3052,14 +3024,18 @@ bool CSimpleTextSubtitle::GetStyle(CString styleName, STSStyle& stss)
     return true;
 }
 
-int CSimpleTextSubtitle::GetCharSet(int i)
+int CSimpleTextSubtitle::GetCharSet(int charSet)
 {
-    const STSStyle* stss = GetStyle(i);
-    int stssCharset = stss ? stss->charSet : DEFAULT_CHARSET;
-    if (overrideANSICharset > DEFAULT_CHARSET && (stssCharset == DEFAULT_CHARSET || stssCharset == ANSI_CHARSET)) {
+    if (overrideANSICharset > DEFAULT_CHARSET && (charSet == DEFAULT_CHARSET || charSet == ANSI_CHARSET)) {
         return overrideANSICharset;
     }
-    return stssCharset;
+    return charSet;
+}
+
+int CSimpleTextSubtitle::GetStyleCharSet(int i)
+{
+    const STSStyle* stss = GetStyle(i);
+    return GetCharSet(stss ? stss->charSet : DEFAULT_CHARSET);
 }
 
 bool CSimpleTextSubtitle::IsEntryUnicode(int i)
@@ -3072,7 +3048,7 @@ void CSimpleTextSubtitle::ConvertUnicode(int i, bool fUnicode)
     STSEntry& stse = GetAt(i);
 
     if (stse.fUnicode ^ fUnicode) {
-        int CharSet = GetCharSet(i);
+        int CharSet = GetStyleCharSet(i);
 
         stse.str = fUnicode
                    ? MBCSSSAToUnicode(stse.str, CharSet)
@@ -3090,7 +3066,7 @@ CStringA CSimpleTextSubtitle::GetStrA(int i, bool fSSA)
 CStringW CSimpleTextSubtitle::GetStrW(int i, bool fSSA)
 {
     STSEntry const& stse = GetAt(i);
-    int CharSet = GetCharSet(i);
+    int CharSet = GetStyleCharSet(i);
 
     CStringW str = stse.str;
 
@@ -3108,7 +3084,7 @@ CStringW CSimpleTextSubtitle::GetStrW(int i, bool fSSA)
 CStringW CSimpleTextSubtitle::GetStrWA(int i, bool fSSA)
 {
     STSEntry const& stse = GetAt(i);
-    int CharSet = GetCharSet(i);
+    int CharSet = GetStyleCharSet(i);
 
     CStringW str = stse.str;
 
@@ -3135,9 +3111,9 @@ void CSimpleTextSubtitle::SetStr(int i, CStringW str, bool fUnicode)
     str.Replace(L"\n", L"\\N");
 
     if (stse.fUnicode && !fUnicode) {
-        stse.str = MBCSSSAToUnicode(str, GetCharSet(i));
+        stse.str = MBCSSSAToUnicode(str, GetStyleCharSet(i));
     } else if (!stse.fUnicode && fUnicode) {
-        stse.str = UnicodeSSAToMBCS(str, GetCharSet(i));
+        stse.str = UnicodeSSAToMBCS(str, GetStyleCharSet(i));
     } else {
         stse.str = str;
     }
@@ -3719,6 +3695,7 @@ void STSStyle::SetDefault()
     fGaussianBlur = 0;
     fontShiftX = fontShiftY = fontAngleZ = fontAngleX = fontAngleY = 0;
     relativeTo = STSStyle::AUTO;
+    fromUnicode = false;
 }
 
 bool STSStyle::operator == (const STSStyle& s) const

--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -1930,7 +1930,7 @@ bool OpenSubStationAlpha(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
 
                 styleName.TrimLeft(_T('*'));
 
-                style->fromUnicode = file->IsUnicode();
+                style->hasAnsiStyleName = !file->IsUnicode();
                 ret.AddStyle(styleName, style);
             } catch (...) {
                 delete style;
@@ -3695,7 +3695,7 @@ void STSStyle::SetDefault()
     fGaussianBlur = 0;
     fontShiftX = fontShiftY = fontAngleZ = fontAngleX = fontAngleY = 0;
     relativeTo = STSStyle::AUTO;
-    fromUnicode = false;
+    hasAnsiStyleName = false;
 }
 
 bool STSStyle::operator == (const STSStyle& s) const

--- a/src/Subtitles/STS.h
+++ b/src/Subtitles/STS.h
@@ -175,7 +175,8 @@ public:
     STSStyle* GetStyle(int i);
     bool GetStyle(int i, STSStyle& stss);
     bool GetStyle(CString styleName, STSStyle& stss);
-    int GetCharSet(int i);
+    int GetCharSet(int charSet);
+    int GetStyleCharSet(int i);
     bool IsEntryUnicode(int i);
     void ConvertUnicode(int i, bool fUnicode);
 

--- a/src/Subtitles/STSStyle.h
+++ b/src/Subtitles/STSStyle.h
@@ -55,7 +55,7 @@ public:
     double     fontShiftX, fontShiftY;
 
     RelativeTo relativeTo;
-    bool fromUnicode;
+    bool hasAnsiStyleName;
 
 #if USE_LIBASS
     // libass stuff

--- a/src/Subtitles/STSStyle.h
+++ b/src/Subtitles/STSStyle.h
@@ -55,6 +55,7 @@ public:
     double     fontShiftX, fontShiftY;
 
     RelativeTo relativeTo;
+    bool fromUnicode;
 
 #if USE_LIBASS
     // libass stuff

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -9399,14 +9399,17 @@ void CMainFrame::OnPlaySubtitles(UINT nID)
 
                     POSITION pos = pRTS->m_styles.GetStartPosition();
                     for (int k = 0; pos; k++) {
-                        CString key;
-                        STSStyle* val;
-                        pRTS->m_styles.GetNextAssoc(pos, key, val);
+                        CString styleName;
+                        STSStyle* style;
+                        pRTS->m_styles.GetNextAssoc(pos, styleName, style);
 
                         CAutoPtr<CPPageSubStyle> page(DEBUG_NEW CPPageSubStyle());
-                        page->InitStyle(key, *val);
+                        if (!style->fromUnicode) {
+                            styleName = ToUnicode(styleName, pRTS->GetCharSet(style->charSet));
+                        }
+                        page->InitStyle(styleName, *style);
                         pages.Add(page);
-                        styles.Add(val);
+                        styles.Add(style);
                     }
 
                     CMPCThemePropertySheet dlg(IDS_SUBTITLES_STYLES_CAPTION, GetModalParent());

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -9404,7 +9404,7 @@ void CMainFrame::OnPlaySubtitles(UINT nID)
                         pRTS->m_styles.GetNextAssoc(pos, styleName, style);
 
                         CAutoPtr<CPPageSubStyle> page(DEBUG_NEW CPPageSubStyle());
-                        if (!style->fromUnicode) {
+                        if (style->hasAnsiStyleName) {
                             styleName = ToUnicode(styleName, pRTS->GetCharSet(style->charSet));
                         }
                         page->InitStyle(styleName, *style);


### PR DESCRIPTION
This is a minor change that makes ANSI stylenames show correctly as Unicode in the style override pages.  It does not touch the actual style names in the subtitle.

1. Move `ToUnicode()` utility to text.cpp.
2. Record if styles came from unicode (utf) data. Technically this can change as the file is loading.
3. Rename `GetCharSet()` to `GetStyleCharSet()` (it loads charset for a single style)
4. Move charset override logic to new `GetCharSet()`
5. Update style page names before displaying

