### PR TITLE
Auto add containing folder on file open

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -77,6 +77,7 @@ CAppSettings::CAppSettings()
     , fSavePnSZoom(false)
     , dZoomX(1.0)
     , dZoomY(1.0)
+    , bAutoAddContainingFolder(false)
     , fAssociatedWithIcons(true)
     , hAccel(nullptr)
     , fWinLirc(false)
@@ -894,6 +895,7 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOFITFACTOR_MIN, nAutoFitFactorMin);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOFITFACTOR_MAX, nAutoFitFactorMax);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_AFTER_PLAYBACK, static_cast<int>(eAfterPlayback));
+    pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOADDFOLDER, bAutoAddContainingFolder);
 
     VERIFY(pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_HIDE_FULLSCREEN_CONTROLS, bHideFullscreenControls));
     VERIFY(pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_HIDE_FULLSCREEN_CONTROLS_POLICY,
@@ -1641,6 +1643,7 @@ void CAppSettings::LoadSettings()
     fSnapToDesktopEdges = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_SNAPTODESKTOPEDGES, FALSE);
     sizeAspectRatio.cx = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_ASPECTRATIO_X, 0);
     sizeAspectRatio.cy = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_ASPECTRATIO_Y, 0);
+    bAutoAddContainingFolder = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOADDFOLDER, FALSE);
 
     fKeepHistory = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_KEEPHISTORY, TRUE);
     fileAssoc.SetNoRecentDocs(!fKeepHistory);

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -609,6 +609,7 @@ public:
     bool            fSavePnSZoom;
     double          dZoomX;
     double          dZoomY;
+    bool            bAutoAddContainingFolder;
 
     // Formats
     CMediaFormats   m_Formats;

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -183,6 +183,7 @@ void CPPageAdvanced::InitSettings()
     addBoolItem(USE_FREETYPE, IDS_RS_USE_FREETYPE, false, s.bUseFreeType, StrRes(IDS_PPAGEADVANCED_USE_FREETYPE));
     addBoolItem(USE_MEDIAINFO_LOAD_FILE_DURATION, IDS_RS_USE_MEDIAINFO_LOAD_FILE_DURATION, false, s.bUseMediainfoLoadFileDuration, StrRes(IDS_PPAGEADVANCED_USE_MEDIAINFO_LOAD_FILE_DURATION));
     addBoolItem(CAPTURE_DEINTERLACE, IDS_RS_CAPTURE_DEINTERLACE, false, s.bCaptureDeinterlace, _T("Insert deinterlace filter (blend) in capture mode"));
+    addBoolItem(AUTO_ADD_CONTAINING_FOLDER, IDS_RS_AUTOADDFOLDER, false, s.bAutoAddContainingFolder, _T("Auto add containing folder to playlist on file open"));
 }
 
 BOOL CPPageAdvanced::OnApply()

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -230,6 +230,7 @@ private:
         USE_FREETYPE,
         USE_MEDIAINFO_LOAD_FILE_DURATION,
         CAPTURE_DEINTERLACE,
+        AUTO_ADD_CONTAINING_FOLDER,
     };
 
     enum {

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -386,6 +386,22 @@ void CPlayerPlaylistBar::ExternalPlayListLoaded(CStringW fn) {
     }
 }
 
+bool CPlayerPlaylistBar::AddContainingFolder() {
+    if (GetCount() == 0) {
+        return false;
+    }
+
+    CPlaylistItem* currentItem = GetCur();
+    if (currentItem) {
+        const CString dirName = PathUtils::DirName(currentItem->m_fns.GetHead());
+        if (PathUtils::IsDir(dirName)) {
+            return AddItemsInFolder(dirName, false);
+        }
+    }
+
+    return false;
+}
+
 bool CPlayerPlaylistBar::IsExternalPlayListActive(CStringW& playlistPath) {
     if (!m_ExternalPlayListPath.IsEmpty() && m_pl.GetIDs() == m_ExternalPlayListFNCopy) {
         playlistPath = m_ExternalPlayListPath;
@@ -2313,13 +2329,9 @@ void CPlayerPlaylistBar::OnContextMenu(CWnd* /*pWnd*/, CPoint point)
             break;
         case M_ADDFOLDER: {
             // add all media files in current playlist item folder that are not yet in the playlist
-            const CString dirName = PathUtils::DirName(m_pl.GetAt(pos).m_fns.GetHead());
-            if (PathUtils::IsDir(dirName)) {
-                m_insertingPos = pos;
-                if (AddItemsInFolder(dirName, true)) {
-                    Refresh();
-                    SavePlaylist();
-                }
+            if (AddContainingFolder()) {
+                Refresh();
+                SavePlaylist();
             }
             break;
         }

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -163,6 +163,7 @@ public:
     void Append(CAtlList<CString>& fns, bool fMulti, CAtlList<CString>* subs = nullptr, CString label = _T(""), CString ydl_src = _T(""), CString cue = _T(""), CAtlList<CYoutubeDLInstance::YDLSubInfo>* ydl_subs = nullptr);
     void ReplaceCurrentItem(CAtlList<CString>& fns, CAtlList<CString>* subs = nullptr, CString label = _T(""), CString ydl_src = _T(""), CString cue = _T(""), CAtlList<CYoutubeDLInstance::YDLSubInfo>* ydl_subs = nullptr);
     void AddSubtitleToCurrent(CString fn);
+    bool AddContainingFolder();
 
     void Open(CStringW vdn, CStringW adn, int vinput, int vchannel, int ainput);
     void Append(CStringW vdn, CStringW adn, int vinput, int vchannel, int ainput);

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -113,6 +113,7 @@
 #define IDS_RS_USE_FREETYPE                 _T("UseFreetype")
 #define IDS_RS_USE_MEDIAINFO_LOAD_FILE_DURATION _T("UseMediainfoLoadFileDuration")
 #define IDS_RS_CAPTURE_DEINTERLACE          _T("CaptureDeinterlace")
+#define IDS_RS_AUTOADDFOLDER                _T("AutoAddContainingFolder")
 
 // Audio
 #define IDS_RS_VOLUME                       _T("Volume")


### PR DESCRIPTION
This PR adds feature to auto add containing folder on file open to the playlist and sort by name, and toggled by advanced setting `AutoAddContainingFolder`, defaults to `False`.

I have only tested this feature with local files and playlists, not tested with any stream/yt related playbacks.