### PR TITLE
do not reload recent file menu unless necessary

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -3226,6 +3226,7 @@ void CAppSettings::CRecentFileListWithMoreInfo::ReadMediaHistory() {
     if (lastAddedStored != 0 && lastAddedStored == rfe_last_added || rfe_last_added == 1) {
         return;
     }
+    listModifySequence++;
 
     size_t maxsize = AfxGetAppSettings().fKeepHistory ? m_maxSize : 0;
 
@@ -3401,6 +3402,7 @@ void CAppSettings::CRecentFileListWithMoreInfo::WriteMediaHistoryEntry(RecentFil
             pApp->WriteProfileInt(m_section, L"LastAdded", rfe_last_added);
         }
     }
+    listModifySequence++;
 }
 
 void CAppSettings::CRecentFileListWithMoreInfo::SaveMediaHistory() {

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -511,6 +511,7 @@ class CAppSettings
         REFERENCE_TIME persistedFilePosition = 0;
         CString current_rfe_hash;
         int rfe_last_added = 0;
+        int listModifySequence = 0;
 
         int GetSize() {
             return (int)rfe_array.GetCount();

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -906,6 +906,7 @@ CMainFrame::CMainFrame()
     , lastSeekFinish(0)
     , defaultVideoAngle(0)
     , m_media_trans_control()
+    , recentFilesMenuFromMRUSequence(-1)
 {
     // Don't let CFrameWnd handle automatically the state of the menu items.
     // This means that menu items without handlers won't be automatically
@@ -16239,18 +16240,22 @@ CString CMainFrame::GetStreamOSDString(CString name, LCID lcid, DWORD dwSelGroup
 
 void CMainFrame::SetupRecentFilesSubMenu()
 {
+    auto& s = AfxGetAppSettings();
+    auto& MRU = s.MRU;
+    MRU.ReadMediaHistory();
+
+    if (MRU.listModifySequence == recentFilesMenuFromMRUSequence) {
+        return;
+    }
+    recentFilesMenuFromMRUSequence = MRU.listModifySequence;
+
     CMenu& subMenu = m_recentFilesMenu;
     // Empty the menu
     while (subMenu.RemoveMenu(0, MF_BYPOSITION));
-
-    auto& s = AfxGetAppSettings();
    
     if (!s.fKeepHistory) {
         return;
     }
-
-    auto& MRU = s.MRU;
-    MRU.ReadMediaHistory();
 
     if (MRU.GetSize() > 0) {
         VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, ID_RECENT_FILES_CLEAR, ResStr(IDS_RECENT_FILES_CLEAR)));

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -388,6 +388,7 @@ private:
     CMPCThemeMenu m_favoritesMenu;
     CMPCThemeMenu m_shadersMenu;
     CMPCThemeMenu m_recentFilesMenu;
+    int recentFilesMenuFromMRUSequence;
 
     UINT m_nJumpToSubMenusCount;
 


### PR DESCRIPTION
It only rebuilds the menu if the MRU has:
1. Had a new entry written by the process
2. Had to be reread (presumably because another process added a recent entry)

