### PR TITLE
support resizing PGS subs for images

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "src/thirdparty/libunibreak/libunibreak"]
 	path = src/thirdparty/libunibreak/libunibreak
 	url = https://github.com/adah1972/libunibreak
+[submodule "src/thirdparty/stb"]
+	path = src/thirdparty/stb
+	url = https://github.com/nothings/stb.git

--- a/src/SubPic/MemSubPic.h
+++ b/src/SubPic/MemSubPic.h
@@ -53,6 +53,8 @@ public:
     CMemSubPic(const SubPicDesc& spd, CMemSubPicAllocator* pAllocator);
     virtual ~CMemSubPic();
 
+    HRESULT UnlockARGB();
+
     // ISubPic
     STDMETHODIMP GetDesc(SubPicDesc& spd);
     STDMETHODIMP CopyTo(ISubPic* pSubPic);

--- a/src/Subtitles/PGSSub.cpp
+++ b/src/Subtitles/PGSSub.cpp
@@ -232,6 +232,20 @@ void CPGSSub::AllocSegment(size_t nSize)
     m_nSegSize = nSize;
 }
 
+HRESULT CPGSSub::GetPresentationSegmentTextureSize(REFERENCE_TIME rt, CSize& size) {
+    POSITION posPresentationSegment = FindPresentationSegment(rt);
+
+    if (posPresentationSegment) {
+        const auto& pPresentationSegment = m_pPresentationSegments.GetAt(posPresentationSegment);
+        if (pPresentationSegment->video_descriptor.nVideoWidth > 0) {
+            size.cx = pPresentationSegment->video_descriptor.nVideoWidth;
+            size.cy = pPresentationSegment->video_descriptor.nVideoHeight;
+            return S_OK;
+        }
+    }
+    return E_FAIL;
+}
+
 HRESULT CPGSSub::Render(SubPicDesc& spd, REFERENCE_TIME rt, RECT& bbox, bool bRemoveOldSegments)
 {
     CAutoLock cAutoLock(&m_csCritSec);

--- a/src/Subtitles/PGSSub.h
+++ b/src/Subtitles/PGSSub.h
@@ -47,6 +47,7 @@ public:
     virtual HRESULT ParseSample(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, BYTE* pData, size_t nLen);
     virtual void    EndOfStream() { /* Nothing to do */ };
     virtual void    Reset();
+    HRESULT GetPresentationSegmentTextureSize(REFERENCE_TIME rt, CSize& size);
 
 protected:
     HRESULT Render(SubPicDesc& spd, REFERENCE_TIME rt, RECT& bbox, bool bRemoveOldSegments);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -5519,15 +5519,6 @@ HRESULT CMainFrame::RenderCurrentSubtitles(BYTE* pData) {
         const int width = bih->biWidth;
         const int height = bih->biHeight;
 
-        SubPicDesc spdRender;
-        spdRender.type = MSP_RGB32;
-        spdRender.w = width;
-        spdRender.h = abs(height);
-        spdRender.bpp = 32;
-        spdRender.pitch = width * 4;
-        spdRender.vidrect = { 0, 0, width, height };
-        spdRender.bits = DEBUG_NEW BYTE[spdRender.pitch * spdRender.h];
-
         REFERENCE_TIME rtNow = 0;
         m_pMS->GetCurrentPosition(&rtNow);
 
@@ -5540,6 +5531,28 @@ HRESULT CMainFrame::RenderCurrentSubtitles(BYTE* pData) {
             }
         }
 
+        int subWidth = width;
+        int subHeight = height;
+        bool needsResize = false;
+        if (CPGSSub* pgsSub = dynamic_cast<CPGSSub*>(pSubPicProvider.p)) {
+            CSize sz;
+            if (SUCCEEDED(pgsSub->GetPresentationSegmentTextureSize(rtNow, sz))) {
+                subWidth = sz.cx;
+                subHeight = sz.cy;
+                needsResize = true;
+            }
+        }
+
+        SubPicDesc spdRender;
+        
+        spdRender.type = MSP_RGB32;
+        spdRender.w = subWidth;
+        spdRender.h = abs(subHeight);
+        spdRender.bpp = 32;
+        spdRender.pitch = subWidth * 4;
+        spdRender.vidrect = { 0, 0, width, height };
+        spdRender.bits = DEBUG_NEW BYTE[spdRender.pitch * spdRender.h];
+        
         CComPtr<CMemSubPicAllocator> pSubPicAllocator = DEBUG_NEW CMemSubPicAllocator(spdRender.type, CSize(spdRender.w, spdRender.h));
 
         CMemSubPic memSubPic(spdRender, pSubPicAllocator);
@@ -5548,9 +5561,13 @@ HRESULT CMainFrame::RenderCurrentSubtitles(BYTE* pData) {
 
         RECT bbox = {};
         hr = pSubPicProvider->Render(spdRender, rtNow, m_pCAP->GetFPS(), bbox);
+        if (needsResize) {
+            memSubPic.UnlockARGB();
+        }
+
         if (S_OK == hr) {
             SubPicDesc spdTarget;
-			spdTarget.type    = MSP_RGB32;
+            spdTarget.type = MSP_RGB32;
             spdTarget.w = width;
             spdTarget.h = height;
             spdTarget.bpp = 32;

--- a/src/mpc-hc/STB_Image.cpp
+++ b/src/mpc-hc/STB_Image.cpp
@@ -1,0 +1,7 @@
+#include "stdafx.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb/stb_image.h"
+
+#define STB_IMAGE_RESIZE_IMPLEMENTATION
+#include "stb/stb_image_resize2.h"

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -282,6 +282,7 @@
     <ClCompile Include="ShockwaveGraph.cpp" />
     <ClCompile Include="SkypeMoodMsgHandler.cpp" />
     <ClCompile Include="MediaTransControls.cpp" />
+    <ClCompile Include="STB_Image.cpp" />
     <ClCompile Include="SVGImage.cpp" />
     <ClCompile Include="Translations.cpp" />
     <ClCompile Include="StaticLink.cpp" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -605,6 +605,9 @@
     <ClCompile Include="CMPCThemePropPageButton.cpp">
       <Filter>MPCTheme</Filter>
     </ClCompile>
+    <ClCompile Include="STB_Image.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AppSettings.h">


### PR DESCRIPTION
1. Add stb library (a header-only library which only compiles \#define-specified code.
2. Add code to grab the pgs native frame resolution
3. If pgs sub, call a variant of `MemSubPic::Unlock` (original is no good because it uses `VDPixmapResample` which can't handle alpha correctly.  This resizes to the target video frame.

The additional methods do not support the underlying subpic interface, but they are only used here.  MemSubPic itself is not used elsewhere in Mainfrm, so it's probably hardly worth maintaining other than this use.  With some work it could be made more abstract and handle resizes for different bit depths.

