### PR TITLE
remove unsed mediainfo include

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -159,10 +159,6 @@ static bool EnsureDirectory(CString directory)
     return result;
 }
 
-
-#include "MediaInfo/MediaInfoDLL.h"
-using namespace MediaInfoDLL;
-
 class CSubClock : public CUnknown, public ISubClock
 {
     STDMETHODIMP NonDelegatingQueryInterface(REFIID riid, void** ppv) {


### PR DESCRIPTION
These lines are from commit d4c6b8a0a2 and 174efb1a40, but they don't seem to be used anymore.  The include is also oddly placed after some code.