### PR TITLE
rewrite CMPCThemeScrollBarHelper logic to update region whenever window is changed

### DIFF
--- a/src/mpc-hc/CMPCThemeEdit.cpp
+++ b/src/mpc-hc/CMPCThemeEdit.cpp
@@ -30,8 +30,17 @@ BEGIN_MESSAGE_MAP(CMPCThemeEdit, CEdit)
     ON_WM_VSCROLL()
     ON_WM_HSCROLL()
     ON_WM_KEYDOWN()
+    ON_WM_WINDOWPOSCHANGED()
 END_MESSAGE_MAP()
 
+void CMPCThemeEdit::OnWindowPosChanged(WINDOWPOS* lpwndpos) {
+    if (AppNeedsThemedControls()) {
+        if (themedSBHelper && 0 != (GetStyle() & (WS_VSCROLL | WS_HSCROLL))) {
+            themedSBHelper->OnWindowPosChanged();
+        }
+    }
+    return __super::OnWindowPosChanged(lpwndpos);
+}
 
 void CMPCThemeEdit::PreSubclassWindow()
 {

--- a/src/mpc-hc/CMPCThemeEdit.h
+++ b/src/mpc-hc/CMPCThemeEdit.h
@@ -20,6 +20,8 @@ protected:
     bool isFileDialogChild;
 
     DECLARE_MESSAGE_MAP()
+    
+    afx_msg void OnWindowPosChanged(WINDOWPOS* lpwndpos);
     afx_msg void OnNcPaint();
     afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
     afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -62,7 +62,18 @@ BEGIN_MESSAGE_MAP(CMPCThemePlayerListCtrl, CListCtrl)
     ON_NOTIFY(HDN_ENDTRACKW, 0, &OnHdnEndtrack)
     ON_NOTIFY_REFLECT_EX(LVN_ITEMCHANGED, &OnLvnItemchanged)
     ON_MESSAGE(PLAYER_PLAYLIST_UPDATE_SCROLLBAR, OnDelayed_UpdateScrollbar)
+    ON_WM_WINDOWPOSCHANGED()
 END_MESSAGE_MAP()
+
+void CMPCThemePlayerListCtrl::OnWindowPosChanged(WINDOWPOS* lpwndpos) {
+    if (AppNeedsThemedControls()) {
+        if (themedSBHelper && 0 != (GetStyle() & (WS_VSCROLL | WS_HSCROLL))) {
+            themedSBHelper->OnWindowPosChanged();
+        }
+    }
+    return __super::OnWindowPosChanged(lpwndpos);
+}
+
 
 void CMPCThemePlayerListCtrl::subclassHeader()
 {
@@ -198,7 +209,7 @@ BOOL CMPCThemePlayerListCtrl::OnLvnEndScroll(NMHDR* pNMHDR, LRESULT* pResult)
 void CMPCThemePlayerListCtrl::updateSB()
 {
     if (nullptr != themedSBHelper) {
-        themedSBHelper->hideSB();
+        themedSBHelper->hideNativeScrollBars();
     }
 }
 

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.h
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.h
@@ -39,6 +39,7 @@ public:
     void DoDPIChanged();
 
     DECLARE_MESSAGE_MAP()
+    afx_msg void OnWindowPosChanged(WINDOWPOS* lpwndpos);
     afx_msg void OnNcPaint();
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
     afx_msg BOOL OnLvnEndScroll(NMHDR* pNMHDR, LRESULT* pResult);

--- a/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
@@ -4,10 +4,11 @@
 #include "CMPCThemeUtil.h"
 
 CMPCThemeScrollBarHelper::CMPCThemeScrollBarHelper(CWnd* scrollWindow)
+    :helperInfo(nullptr)
+    ,setWindowRegionActive(false)
 {
     window = scrollWindow;
     pParent = nullptr;
-    currentlyClipped = false;
 }
 
 
@@ -15,120 +16,117 @@ CMPCThemeScrollBarHelper::~CMPCThemeScrollBarHelper()
 {
 }
 
-void CMPCThemeScrollBarHelper::createSB()
+void CMPCThemeScrollBarHelper::createThemedScrollBars()
 {
     pParent = window->GetParent();
-    hasVSB = 0 != (window->GetStyle() & WS_VSCROLL); //we have to draw vertical scrollbar because ncpaint is overridden to handle horizontal scrollbar
-    hasHSB = 0 != (window->GetStyle() & WS_HSCROLL); //windows dark theme horizontal scrollbar is broken
+    ScrollBarHelperInfo i(window);
     if (nullptr != pParent && IsWindow(pParent->m_hWnd)) {
-        if (hasVSB && !IsWindow(vertSB.m_hWnd)) {
+        if (i.canVSB && !IsWindow(vertSB.m_hWnd)) {
             VERIFY(vertSB.Create(SBS_VERT | WS_CHILD |
                                  WS_VISIBLE, CRect(0, 0, 0, 0), pParent, 0));
             vertSB.setScrollWindow(window); //we want messages from this SB
         }
 
-        if (hasHSB && !IsWindow(horzSB.m_hWnd)) {
+        if (i.canHSB && !IsWindow(horzSB.m_hWnd)) {
             VERIFY(horzSB.Create(SBS_HORZ | WS_CHILD |
                                  WS_VISIBLE, CRect(0, 0, 0, 0), pParent, 0));
             horzSB.setScrollWindow(window); //we want messages from this SB
         }
     }
+    hideNativeScrollBars();
 }
 
-void CMPCThemeScrollBarHelper::setDrawingArea(CRect& cr, CRect& wr, bool clipping)
-{
-    window->GetClientRect(&cr);
-    window->ClientToScreen(&cr);
-    window->GetWindowRect(&wr);
-
-    CRect wrOnParent = wr;
-    pParent = window->GetParent();
-    if (nullptr != pParent) {
-        pParent->ScreenToClient(wrOnParent);
+void CMPCThemeScrollBarHelper::OnWindowPosChanged() {
+    {
+        std::lock_guard<std::recursive_mutex> lck(helperMutex);
+        //this is to prevent recursive calls to OnWindowPos due to SetWindowRgn
+        if (!setWindowRegionActive) {
+            hideNativeScrollBars();
+        }
     }
+}
 
-    cr.OffsetRect(-wr.left, -wr.top);
-    wr.OffsetRect(-wr.left, -wr.top);
+void CMPCThemeScrollBarHelper::setWindowRegionExclusive(HRGN h) {
+    {
+        std::lock_guard<std::recursive_mutex> lck(helperMutex);
+        setWindowRegionActive = true;
+    }
+    window->SetWindowRgn(h, false);
+    {
+        std::lock_guard<std::recursive_mutex> lck(helperMutex);
+        setWindowRegionActive = false;
+    }
+}
 
-    if (clipping) {
-        //system metrics doesn't consider other border sizes--client-window works better in all cases so far
-        int borderWidth = cr.left - wr.left; //GetSystemMetrics(SM_CXSIZEFRAME) + 1;
-        int sbThickness = GetSystemMetrics(SM_CXVSCROLL);
-        CRect realWR = wr;
-        bool canVSB = sbThickness < wr.Width() - borderWidth * 2; //SB simply disappears if window is that small
-        bool canHSB = sbThickness < wr.Height() - borderWidth * 2; //SB simply disappears if window is that small
+void CMPCThemeScrollBarHelper::hideNativeScrollBars()
+{
 
-        if (IsWindow(vertSB.m_hWnd)) {
-            if (hasVSB && canVSB) {
-                int width = sbThickness, height = realWR.bottom - realWR.top - 2 * borderWidth - (hasHSB ? sbThickness : 0);
-                wr.right -= sbThickness + borderWidth; //clip whole SB plus border
+    bool windowChanged = helperInfo.UpdateHelperInfo(window);
 
-                vertSB.MoveWindow(wrOnParent.right - width - borderWidth, wrOnParent.top + borderWidth, width, height);
-                vertSB.ShowWindow(SW_SHOW);
-                updateScrollInfo();
-            } else {
-                if (vertSB.IsWindowVisible()) {
-                    CRect sbWR;
-                    vertSB.GetWindowRect(sbWR);
-                    vertSB.ShowWindow(SW_HIDE);
-                    window->ScreenToClient(sbWR);
-                    window->RedrawWindow(sbWR, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
-                }
-            }
-        }
+    ScrollBarHelperInfo& i = helperInfo;
+    CRect wr = i.wr; 
+    CRect horzRect, vertRect;
+    bool needsRegion = false;
 
-        if (IsWindow(horzSB.m_hWnd)) {
-            if (hasHSB && canHSB) {
-                int height = sbThickness, width = realWR.right - realWR.left - 2 * borderWidth - (hasVSB ? sbThickness : 0);
-                wr.bottom -= sbThickness + borderWidth; //clip whole SB plus border
+    if (IsWindow(vertSB.m_hWnd)) {
+        if (i.canVSB) {
+            int width = i.sbThickness, height = wr.bottom - wr.top - 2 * i.borderThickness - (i.canHSB ? i.sbThickness : 0);
+            needsRegion = true;
 
-                horzSB.MoveWindow(wrOnParent.left + borderWidth, wrOnParent.bottom - height - borderWidth, width, height);
-                horzSB.ShowWindow(SW_SHOW);
-                updateScrollInfo();
-            } else {
-                if (horzSB.IsWindowVisible()) {
-                    CRect sbWR;
-                    horzSB.GetWindowRect(sbWR);
-                    horzSB.ShowWindow(SW_HIDE);
-                    window->ScreenToClient(sbWR);
-                    window->RedrawWindow(sbWR, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
-                }
-            }
-        }
-        bool wasClipped = currentlyClipped;
-
-        if (wr != realWR) {
-            HRGN iehrgn = CreateRectRgn(wr.left, wr.top, wr.right, wr.bottom);
-            window->SetWindowRgn(iehrgn, false);
-            currentlyClipped = true;
+            vertRect = CRect(CPoint(i.wrOnParent.right - width - i.borderThickness, i.wrOnParent.top + i.borderThickness), CSize(width, height));
+            vertSB.MoveWindow(vertRect);
+            vertSB.ShowWindow(SW_SHOW);
+            updateScrollInfo();
         } else {
-            window->SetWindowRgn(NULL, false);
-            currentlyClipped = false;
-        }
-        if (wasClipped && currentClipRegion != wr) { //we do not repaint during SetWindowRgn, but we need to invalidate areas that were previously clipped
-            if (currentClipRegion.right < wr.right) {
-                CRect rightRedraw;
-                window->GetClientRect(rightRedraw);
-                rightRedraw.left = rightRedraw.right - (wr.right - currentClipRegion.right);
-                window->RedrawWindow(rightRedraw, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
-            }
-            if (currentClipRegion.bottom < wr.bottom) {
-                CRect bottomRedraw = wr;
-                window->GetClientRect(bottomRedraw);
-                bottomRedraw.top = bottomRedraw.bottom - (wr.bottom - currentClipRegion.bottom);
-                window->RedrawWindow(bottomRedraw, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
+            if (vertSB.IsWindowVisible()) {
+                CRect sbWR;
+                vertSB.GetWindowRect(sbWR);
+                vertSB.ShowWindow(SW_HIDE);
+                window->ScreenToClient(sbWR);
+                window->RedrawWindow(sbWR, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
             }
         }
-        currentClipRegion = wr;
-    } else {
-        window->SetWindowRgn(NULL, false);
     }
-}
 
-void CMPCThemeScrollBarHelper::hideSB()
-{
-    CRect wr, cr;
-    setDrawingArea(cr, wr, true);
+    if (IsWindow(horzSB.m_hWnd)) {
+        if (i.canHSB) {
+            int height = i.sbThickness, width = wr.right - wr.left - 2 * i.borderThickness - (i.canVSB ? i.sbThickness : 0);
+            needsRegion = true;
+
+            horzRect = CRect(CPoint(i.wrOnParent.left + i.borderThickness, i.wrOnParent.bottom - height - i.borderThickness), CSize(width, height));
+            horzSB.MoveWindow(horzRect);
+            horzSB.ShowWindow(SW_SHOW);
+            updateScrollInfo();
+        } else {
+            if (horzSB.IsWindowVisible()) {
+                CRect sbWR;
+                horzSB.GetWindowRect(sbWR);
+                horzSB.ShowWindow(SW_HIDE);
+                window->ScreenToClient(sbWR);
+                window->RedrawWindow(sbWR, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
+            }
+        }
+    }
+    if (needsRegion) {
+        if (windowChanged) {
+            HRGN contentRgn = CreateRectRgn(wr.left, wr.top, wr.right, wr.bottom);
+            if (!vertRect.IsRectEmpty()) {
+                ::MapWindowPoints(pParent->GetSafeHwnd(), window->GetSafeHwnd(), (LPPOINT)&vertRect, 2);
+                vertRect += helperInfo.clientOffset;
+                HRGN vertRgn = CreateRectRgnIndirect(vertRect);
+                CombineRgn(contentRgn, contentRgn, vertRgn, RGN_DIFF);
+            }
+            if (!horzRect.IsRectEmpty()) {
+                ::MapWindowPoints(pParent->GetSafeHwnd(), window->GetSafeHwnd(), (LPPOINT)&horzRect, 2);
+                horzRect += helperInfo.clientOffset;
+                HRGN horzRgn = CreateRectRgnIndirect(horzRect);
+                CombineRgn(contentRgn, contentRgn, horzRgn, RGN_DIFF);
+            }
+            setWindowRegionExclusive(contentRgn);
+        }
+    } else {
+        setWindowRegionExclusive(NULL);
+    }
 }
 
 void CMPCThemeScrollBarHelper::updateScrollInfo(bool invalidate /*=false*/)
@@ -244,17 +242,8 @@ bool CMPCThemeScrollBarHelper::WindowProc(CTreeCtrl* tree, UINT message, WPARAM 
 
 void CMPCThemeScrollBarHelper::themedNcPaintWithSB()
 {
-    createSB();
-    if (IsWindow(vertSB.m_hWnd) || IsWindow(horzSB.m_hWnd)) {
-        CRect wr, cr;
-        CWindowDC dc(window);
-        setDrawingArea(cr, wr, false); //temporarily allow full clipping window
-        dc.ExcludeClipRect(&cr);
-    }
-
+    createThemedScrollBars();
     doNcPaint(window);
-
-    hideSB(); //set back scrollbar clipping window
 }
 
 void CMPCThemeScrollBarHelper::themedNcPaint(CWnd* window, CMPCThemeScrollable* swindow)
@@ -274,34 +263,82 @@ void CMPCThemeScrollBarHelper::themedNcPaint(CWnd* window, CMPCThemeScrollable* 
     }
 }
 
+ScrollBarHelperInfo::ScrollBarHelperInfo(CWnd* w):
+    wr(), corner(), wrOnParent()
+    ,sbThickness(0), borderThickness(0)
+    ,canVSB(false), canHSB(false), needsSBCorner(false)
+{
+    if (w && w->m_hWnd && IsWindow(w->m_hWnd)) {
+        w->GetWindowRect(wr);
+
+        wrOnParent = wr;
+        CWnd* pParent = w->GetParent();
+        if (nullptr != pParent) {
+            pParent->ScreenToClient(wrOnParent);
+        }
+
+        wr.OffsetRect(-wr.left, -wr.top);
+
+        sbThickness = GetSystemMetrics(SM_CXVSCROLL);
+        clientOffset = CMPCThemeUtil::GetRegionOffset(w);
+        borderThickness = clientOffset.x;
+        bool visible = w->IsWindowVisible();
+        auto style = w->GetStyle();
+        //we have to draw vertical scrollbar because ncpaint is overridden to handle horizontal scrollbar
+        //windows dark theme horizontal scrollbar is broken
+        //exceptions: SB simply disappears if window is less than border thickness
+        canVSB = 0 != (style & WS_VSCROLL) && sbThickness < wr.Width() - borderThickness * 2;
+        canHSB = 0 != (style & WS_HSCROLL) && sbThickness < wr.Height() - borderThickness * 2;
+        needsSBCorner = (style & (WS_VSCROLL | WS_HSCROLL)) == (WS_VSCROLL | WS_HSCROLL) && canVSB && canHSB;
+        corner = { wr.right - sbThickness - borderThickness, wr.bottom - sbThickness - borderThickness,  wr.right - borderThickness, wr.bottom - borderThickness };
+    }
+}
+
+bool ScrollBarHelperInfo::UpdateHelperInfo(CWnd* w) {
+    ScrollBarHelperInfo tmp(w);
+    if (tmp == *this) {
+        return false;
+    }
+    *this = tmp;
+    return true;
+}
+
+bool ScrollBarHelperInfo::operator==(ScrollBarHelperInfo& other) {
+    return other.borderThickness == borderThickness && other.sbThickness == sbThickness //dimensions
+        && other.wr == wr && other.wrOnParent == wrOnParent && other.corner == corner //rects
+        && other.clientOffset == clientOffset
+        && other.canHSB == canHSB && other.canVSB == canVSB && other.needsSBCorner == needsSBCorner //bools
+        ;
+}
+
 void CMPCThemeScrollBarHelper::doNcPaint(CWnd* window)
 {
+    HRGN currentRgn = CreateRectRgn(0, 0, 0, 0);
+    int rType = window->GetWindowRgn(currentRgn);
+    window->SetWindowRgn(NULL, false);
+
     CWindowDC dc(window);
     int oldDC = dc.SaveDC();
 
-    CRect wr, cr, clip, corner;
-    window->GetWindowRect(wr);
-    window->ScreenToClient(wr);
+    CRect clip;
+    ScrollBarHelperInfo i(window);
 
-    int sbThickness = GetSystemMetrics(SM_CXVSCROLL);
-    int borderWidth = cr.left - wr.left; //GetSystemMetrics(SM_CXSIZEFRAME) + 1;
-    bool canVSB = sbThickness < wr.Width() - borderWidth * 2; //SB simply disappears if window is that small
-    bool canHSB = sbThickness < wr.Height() - borderWidth * 2; //SB simply disappears if window is that small
-    
-    window->GetClientRect(&cr);
-    int borderThickness = cr.left - wr.left;
-    wr.OffsetRect(-wr.left, -wr.top);
+    CRect &wr = i.wr;
+
     clip = wr; //client rect is insufficient to clip scrollbars
-    clip.DeflateRect(borderThickness, borderThickness);
+    clip.DeflateRect(i.borderThickness, i.borderThickness);
     dc.ExcludeClipRect(clip);
     CBrush brush(CMPCTheme::WindowBorderColorLight); //color used for column sep in explorer
     dc.FillSolidRect(wr, CMPCTheme::ContentBGColor);
     dc.FrameRect(wr, &brush);
 
     dc.RestoreDC(oldDC);
-    if ((window->GetStyle() & (WS_VSCROLL | WS_HSCROLL)) == (WS_VSCROLL | WS_HSCROLL) && canVSB && canHSB) {
-        corner = { wr.right - sbThickness - borderThickness, wr.bottom - sbThickness - borderThickness,  wr.right - borderThickness, wr.bottom - borderThickness};
-        dc.FillSolidRect(corner, CMPCTheme::ContentBGColor);
+    if (i.needsSBCorner) {
+        dc.FillSolidRect(i.corner, CMPCTheme::ContentBGColor);
+    }
+
+    if (rType == COMPLEXREGION || rType == SIMPLEREGION) {
+        window->SetWindowRgn(currentRgn, false);
     }
 }
 

--- a/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarHelper.cpp
@@ -282,7 +282,7 @@ ScrollBarHelperInfo::ScrollBarHelperInfo(CWnd* w):
         sbThickness = GetSystemMetrics(SM_CXVSCROLL);
         clientOffset = CMPCThemeUtil::GetRegionOffset(w);
         borderThickness = clientOffset.x;
-        bool visible = w->IsWindowVisible();
+
         auto style = w->GetStyle();
         //we have to draw vertical scrollbar because ncpaint is overridden to handle horizontal scrollbar
         //windows dark theme horizontal scrollbar is broken

--- a/src/mpc-hc/CMPCThemeScrollBarHelper.h
+++ b/src/mpc-hc/CMPCThemeScrollBarHelper.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CMPCThemeScrollBar.h"
+#include <mutex>
 class CMPCThemeTreeCtrl;
 
 class CMPCThemeScrollable
@@ -10,22 +11,37 @@ public:
     virtual void doDefault() {};
 };
 
+class ScrollBarHelperInfo {
+public:
+    ScrollBarHelperInfo(CWnd* w);
+    bool UpdateHelperInfo(CWnd* w);
+    bool operator==(ScrollBarHelperInfo& lhs);
+    bool operator!=(ScrollBarHelperInfo& lhs) { return !operator==(lhs); }
+    CRect wr, corner, wrOnParent;
+    CPoint clientOffset;
+    int sbThickness;
+    int borderThickness;
+    bool canVSB;
+    bool canHSB;
+    bool needsSBCorner;
+};
+
 class CMPCThemeScrollBarHelper
 {
 protected:
     CWnd* window, *pParent;
     CMPCThemeScrollBar vertSB, horzSB;
-    CRect currentClipRegion;
-    bool currentlyClipped;
-    bool hasVSB;
-    bool hasHSB;
+    ScrollBarHelperInfo helperInfo;
+    std::recursive_mutex helperMutex;
+    bool setWindowRegionActive;
     static void doNcPaint(CWnd* window);
 public:
     CMPCThemeScrollBarHelper(CWnd* scrollWindow);
     ~CMPCThemeScrollBarHelper();
-    void createSB();
-    void setDrawingArea(CRect& cr, CRect& wr, bool clipping);
-    void hideSB();
+    void createThemedScrollBars();
+    void OnWindowPosChanged();
+    void setWindowRegionExclusive(HRGN h);
+    void hideNativeScrollBars();
     void updateScrollInfo(bool invalidate = false);
     bool WindowProc(CListCtrl* list, UINT message, WPARAM wParam, LPARAM lParam);
     bool WindowProc(CTreeCtrl* tree, UINT message, WPARAM wParam, LPARAM lParam);

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1052,3 +1052,13 @@ void CMPCThemeUtil::PreDoModalRTL(LPPROPSHEETHEADERW m_psh) {
     m_psh->dwFlags |= PSH_USECALLBACK;
     m_psh->pfnCallback = PropSheetCallBackRTL;
 }
+
+//Regions are relative to upper left of WINDOW rect (not client)
+CPoint CMPCThemeUtil::GetRegionOffset(CWnd* window) {
+    CRect twr, tcr;
+    window->GetWindowRect(twr);
+    window->GetClientRect(tcr);
+    ::MapWindowPoints(window->GetSafeHwnd(), nullptr, (LPPOINT)&tcr, 2);
+    CPoint offset = tcr.TopLeft() - twr.TopLeft();
+    return offset;
+}

--- a/src/mpc-hc/CMPCThemeUtil.h
+++ b/src/mpc-hc/CMPCThemeUtil.h
@@ -88,6 +88,8 @@ public:
 
     void PreDoModalRTL(LPPROPSHEETHEADERW m_psh);
 
+    static CPoint GetRegionOffset(CWnd* window);
+
     enum CheckBoxStyle {
         CheckBoxRegular = 0,
         CheckBoxHover = 1,


### PR DESCRIPTION
This hopefully works as well as the previous code while also updating draw regions even when no painting is being done.  This is important for the resizable lib which depends on those regions to decide where to erase during a resize.

I did not observe the resize issue with any current windows (although these fixes are perhaps a more elegant approach to the other resize fixes I did recently).  However, for resizable property pages they do seem to solve problems, perhaps due to the multiple levels of resizing.