### PR TITLE
reuse GetInvisibleBorderSize() instead of redundant calc

### DIFF
--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -2007,9 +2007,7 @@ BOOL CMPlayerCApp::InitInstance()
     if (AfxGetAppSettings().HasFixedWindowSize() && IsWindows8OrGreater()) {//make adjustments for drop shadow frame
         CRect rect, frame;
         pFrame->GetWindowRect(&rect);
-        DwmGetWindowAttribute(pFrame->GetSafeHwnd(), DWMWA_EXTENDED_FRAME_BOUNDS, &frame, sizeof(RECT));
-
-        CRect diff(CPoint(frame.TopLeft() - rect.TopLeft()), CPoint(rect.BottomRight() - frame.BottomRight()));
+        CRect diff = pFrame->GetInvisibleBorderSize();
         rect.InflateRect(diff);
 
         pFrame->SetWindowPos(nullptr, rect.left, rect.top, rect.Width(), rect.Height(), SWP_NOZORDER | SWP_NOACTIVATE);

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -2008,9 +2008,10 @@ BOOL CMPlayerCApp::InitInstance()
         CRect rect, frame;
         pFrame->GetWindowRect(&rect);
         CRect diff = pFrame->GetInvisibleBorderSize();
-        rect.InflateRect(diff);
-
-        pFrame->SetWindowPos(nullptr, rect.left, rect.top, rect.Width(), rect.Height(), SWP_NOZORDER | SWP_NOACTIVATE);
+        if (!diff.IsRectNull()) {
+            rect.InflateRect(diff);
+            pFrame->SetWindowPos(nullptr, rect.left, rect.top, rect.Width(), rect.Height(), SWP_NOZORDER | SWP_NOACTIVATE);
+        }
     }
 
     /* adipose 2019-11-12:


### PR DESCRIPTION
I overlooked we already had a function that calculated the invisible border.  