### PR TITLE
dynamic resizing for translations

### DIFF
--- a/src/DSUtil/MFCHelper.cpp
+++ b/src/DSUtil/MFCHelper.cpp
@@ -41,10 +41,10 @@ void SetCursor(HWND m_hWnd, UINT nID, LPCWSTR lpCursorName)
 	SetCursor(::GetDlgItem(m_hWnd, nID), lpCursorName);
 }
 
-void CorrectComboListWidth(CComboBox& ComboBox)
+int CorrectComboListWidth(CComboBox& ComboBox, bool dryRun /*= false*/)
 {
 	if (ComboBox.GetCount() <= 0)
-		return;
+		return CB_ERR;
 
 	CString    str;
 	CSize      sz;
@@ -83,7 +83,10 @@ void CorrectComboListWidth(CComboBox& ComboBox)
 	dx += scroll_width + 2*::GetSystemMetrics(SM_CXEDGE);
 
 	// Set the width of the list box so that every item is completely visible.
-	ComboBox.SetDroppedWidth(dx);
+    if (!dryRun) {
+        ComboBox.SetDroppedWidth(dx);
+    }
+    return dx; //the min width -- may be less than actual width
 }
 
 void CorrectCWndWidth(CWnd* pWnd)

--- a/src/DSUtil/MFCHelper.h
+++ b/src/DSUtil/MFCHelper.h
@@ -25,7 +25,7 @@ extern CString ResStr(UINT nID);
 extern void SetCursor(HWND m_hWnd, LPCWSTR lpCursorName);
 extern void SetCursor(HWND m_hWnd, UINT nID, LPCWSTR lpCursorName);
 
-extern void CorrectComboListWidth(CComboBox& ComboBox);
+extern int CorrectComboListWidth(CComboBox& ComboBox, bool dryRun = false);
 extern void CorrectComboBoxHeaderWidth(CWnd* pComboBox);
 extern void CorrectCWndWidth(CWnd* pWnd);
 

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1062,3 +1062,66 @@ CPoint CMPCThemeUtil::GetRegionOffset(CWnd* window) {
     CPoint offset = tcr.TopLeft() - twr.TopLeft();
     return offset;
 }
+
+void CMPCThemeUtil::AdjustDynamicWidth(CWnd* window, int leftWidget, int rightWidget, DynamicAlignWindowType lType, DynamicAlignWindowType rType) {
+    if (window && IsWindow(window->m_hWnd)) {
+        DpiHelper dpiWindow;
+        dpiWindow.Override(window->GetSafeHwnd());
+
+        CWnd* leftW = window->GetDlgItem(leftWidget);
+        CWnd* rightW = window->GetDlgItem(rightWidget);
+        if (leftW && rightW && IsWindow(leftW->m_hWnd) && IsWindow(rightW->m_hWnd)) {
+            CRect l, r;
+            int leftWantsRight, rightWantsLeft;
+
+            leftW->GetWindowRect(l);
+            leftW->GetOwner()->ScreenToClient(l);
+            rightW->GetWindowRect(r);
+            rightW->GetOwner()->ScreenToClient(r);
+            CDC* lpDC = leftW->GetDC();
+            CFont* pFont = leftW->GetFont();
+            leftWantsRight = l.right;
+            rightWantsLeft = r.left;
+            {
+                int left = l.left;
+                if (lType == DynamicAlignCheckBox) {
+                    left += dpiWindow.GetSystemMetricsDPI(SM_CXMENUCHECK) + 2;
+                }
+
+                CFont* pOldFont = lpDC->SelectObject(pFont);
+                TEXTMETRIC tm;
+                lpDC->GetTextMetricsW(&tm);
+
+                CString str;
+                leftW->GetWindowTextW(str);
+                CSize szText = lpDC->GetTextExtent(str);
+                lpDC->SelectObject(pOldFont);
+
+                leftWantsRight = left + szText.cx + tm.tmAveCharWidth;
+                leftW->ReleaseDC(lpDC);
+            }
+
+            {
+                if (rType == DynamicAlignCombo) {
+                    //int wantWidth = (int)::SendMessage(rightW->m_hWnd, CB_GETDROPPEDWIDTH, 0, 0);
+                    CComboBox *cb = DYNAMIC_DOWNCAST(CComboBox, rightW);
+                    if (cb) {
+                        int wantWidth = CorrectComboListWidth(*cb);
+                        if (wantWidth != CB_ERR) {
+                            rightWantsLeft = r.right - wantWidth - GetSystemMetrics(SM_CXVSCROLL);
+                        }
+                    }
+                }
+            }
+            if (leftWantsRight > rightWantsLeft - dpiWindow.ScaleX(5) //overlaps; we will assume defaults are best
+                || (leftWantsRight < l.right && rightWantsLeft > r.left)) { // there is no need to resize
+                return;
+            } else {
+                l.right = leftWantsRight;
+                leftW->MoveWindow(l);
+                r.left = rightWantsLeft;
+                rightW->MoveWindow(r);
+            }
+        }
+    }
+}

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1067,12 +1067,13 @@ void CMPCThemeUtil::AdjustDynamicWidth(CWnd* window, int leftWidget, int rightWi
     if (window && IsWindow(window->m_hWnd)) {
         DpiHelper dpiWindow;
         dpiWindow.Override(window->GetSafeHwnd());
+        LONG dynamicSpace = dpiWindow.ScaleX(5);
 
         CWnd* leftW = window->GetDlgItem(leftWidget);
         CWnd* rightW = window->GetDlgItem(rightWidget);
         if (leftW && rightW && IsWindow(leftW->m_hWnd) && IsWindow(rightW->m_hWnd)) {
             CRect l, r;
-            int leftWantsRight, rightWantsLeft;
+            LONG leftWantsRight, rightWantsLeft;
 
             leftW->GetWindowRect(l);
             leftW->GetOwner()->ScreenToClient(l);
@@ -1113,13 +1114,16 @@ void CMPCThemeUtil::AdjustDynamicWidth(CWnd* window, int leftWidget, int rightWi
                     }
                 }
             }
-            if (leftWantsRight > rightWantsLeft - dpiWindow.ScaleX(5) //overlaps; we will assume defaults are best
+            if (leftWantsRight > rightWantsLeft - dynamicSpace //overlaps; we will assume defaults are best
                 || (leftWantsRight < l.right && rightWantsLeft > r.left)) { // there is no need to resize
                 return;
             } else {
                 l.right = leftWantsRight;
+                //if necessary space would shrink the right widget, instead get as close to original size as possible
+                //this minimizes noticeable layout changes
+                r.left = std::min(rightWantsLeft, std::max(l.right + dynamicSpace, r.left));
+
                 leftW->MoveWindow(l);
-                r.left = rightWantsLeft;
                 rightW->MoveWindow(r);
             }
         }

--- a/src/mpc-hc/CMPCThemeUtil.h
+++ b/src/mpc-hc/CMPCThemeUtil.h
@@ -18,6 +18,13 @@ public:
         ExternalPropertyPageWithDefaultButton,
     };
 
+    enum DynamicAlignWindowType {
+        DynamicAlignCheckBox = 0
+        , DynamicAlignCombo
+        , DynamicAlignText
+    };
+
+
     CMPCThemeUtil();
     virtual ~CMPCThemeUtil();
 
@@ -85,6 +92,7 @@ public:
     static void drawParentDialogBGClr(CWnd* wnd, CDC* pDC, CRect r, bool fill = true);
     static void fulfillThemeReqs(CProgressCtrl* ctl);
     static void enableWindows10DarkFrame(CWnd* window);
+    static void AdjustDynamicWidth(CWnd* window, int left, int right, DynamicAlignWindowType lType, DynamicAlignWindowType rType);
 
     void PreDoModalRTL(LPPROPSHEETHEADERW m_psh);
 

--- a/src/mpc-hc/PPageTheme.cpp
+++ b/src/mpc-hc/PPageTheme.cpp
@@ -172,6 +172,7 @@ BOOL CPPageTheme::OnInitDialog()
     m_HoverPosition.AddString(ResStr(IDS_TIME_TOOLTIP_ABOVE));
     m_HoverPosition.AddString(ResStr(IDS_TIME_TOOLTIP_BELOW));
     m_HoverPosition.SetCurSel(s.nHoverPosition);
+    AdjustDynamicWidth(this, IDC_CHECK8, IDC_COMBO3, DynamicAlignCheckBox, DynamicAlignCombo);
     CorrectComboListWidth(m_HoverPosition);
 
     m_nOSDSize = s.nOSDSize;


### PR DESCRIPTION
Dynamic layout option allows more translations to fit in the tight space.  Currently implements text/checkbox with a combobox, but we can add more as needed.

![image](https://github.com/clsid2/mpc-hc/assets/3324395/7a02e98f-6b80-4eb4-99d6-b048c65ba85c)

![image](https://github.com/clsid2/mpc-hc/assets/3324395/9916a7a9-326d-484d-a8c2-3c44387ebefd)

![image](https://github.com/clsid2/mpc-hc/assets/3324395/cea282f5-4e7c-47df-967b-75b3f7f5df8e)

