### PR TITLE
allow zoom past monitor size

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -7849,7 +7849,7 @@ void CMainFrame::OnViewModifySize(UINT nID) {
 
     CRect newRect;
     CRect work;
-    //if old rect was constrained to a single monitor, so we zoom incrementally
+    //if old rect was constrained to a single monitor, we zoom incrementally
     if (GetWorkAreaRect(work) && work.PtInRect(rect.TopLeft()) && work.PtInRect(rect.BottomRight())) {
         newRect = GetZoomWindowRect(cs, true);
     } else {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -7847,7 +7847,17 @@ void CMainFrame::OnViewModifySize(UINT nID) {
 
     CSize cs = rect.Size() + CSize(newWidth - videoRect.Width(), newHeight - videoRect.Height());
 
-    MoveWindow(GetZoomWindowRect(cs, true));
+    CRect newRect;
+    CRect work;
+    //if old rect was constrained to a single monitor, so we zoom incrementally
+    if (GetWorkAreaRect(work) && work.PtInRect(rect.TopLeft()) && work.PtInRect(rect.BottomRight())) {
+        newRect = GetZoomWindowRect(cs, true);
+    } else {
+        newRect = CRect(rect.TopLeft(), cs);
+    }
+
+
+    MoveWindow(newRect);
 }
 
 void CMainFrame::OnViewDefaultVideoFrame(UINT nID)
@@ -12169,21 +12179,28 @@ CSize CMainFrame::GetZoomWindowSize(double dScale)
     return ret;
 }
 
+bool CMainFrame::GetWorkAreaRect(CRect& work) {
+    MONITORINFO mi = { sizeof(mi) };
+    if (GetMonitorInfo(MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST), &mi)) {
+        work = mi.rcWork;
+        // account for invisible borders on Windows 10 by allowing
+        // the window to go out of screen a bit
+        if (IsWindows10OrGreater()) {
+            work.InflateRect(GetInvisibleBorderSize());
+        }
+        return true;
+    }
+    return false;
+}
+
 CRect CMainFrame::GetZoomWindowRect(const CSize& size, bool ignoreSavedPosition /*= false*/)
 {
     const auto& s = AfxGetAppSettings();
     CRect ret;
     GetWindowRect(ret);
 
-    MONITORINFO mi = { sizeof(mi) };
-    if (GetMonitorInfo(MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST), &mi)) {
-        CRect rcWork = mi.rcWork;
-        // account for invisible borders on Windows 10 by allowing
-        // the window to go out of screen a bit
-        if (IsWindows10OrGreater()) {
-            rcWork.InflateRect(GetInvisibleBorderSize());
-        }
-
+    CRect rcWork;
+    if (GetWorkAreaRect(rcWork)) {
         CSize windowSize(size);
 
         // don't go larger than the current monitor working area

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -361,6 +361,7 @@ private:
     void RestoreDefaultWindowRect();
     CRect GetInvisibleBorderSize() const;
     CSize GetZoomWindowSize(double dScale);
+    bool GetWorkAreaRect(CRect& work);
     CRect GetZoomWindowRect(const CSize& size, bool ignoreSavedPosition = false);
     void ZoomVideoWindow(double dScale = ZOOM_DEFAULT_LEVEL);
     double GetZoomAutoFitScale();


### PR DESCRIPTION
This solves one or more of the zoom issues.  Namely, it will zoom past the monitor size by changing back to bottom right growth once it is out of monitor.  I chose that option somewhat arbitrarily, but if the window has already zoomed to its max size within the monitor, it keeps the upper left on that monitor, which is helpful for accessing the menus etc.