### PR TITLE
simple fill for OSD

### DIFF
--- a/src/mpc-hc/OSD.cpp
+++ b/src/mpc-hc/OSD.cpp
@@ -1131,11 +1131,8 @@ bool COSD::UpdateButtonImages()
 
 void COSD::SimpleFill(CDC* pDc, CRect* rc)
 {
-    const CAppSettings& s = AfxGetAppSettings();
-
     pDc->SelectObject(m_brushBack);
     pDc->SelectObject(m_penBorder);
-
     pDc->Rectangle(rc);
 }
 

--- a/src/mpc-hc/OSD.cpp
+++ b/src/mpc-hc/OSD.cpp
@@ -60,7 +60,7 @@ COSD::COSD(CMainFrame* pMainFrame)
     m_colors[OSD_TRANSPARENT] = RGB(0, 0, 0);
     if (AppIsThemeLoaded()) {
         m_colors[OSD_BACKGROUND] = CMPCTheme::ContentBGColor;
-        m_colors[OSD_BORDER] = CMPCTheme::WindowBorderColorDim;
+        m_colors[OSD_BORDER] = CMPCTheme::EditBorderColor;
         m_colors[OSD_TEXT] = CMPCTheme::TextFGColor;
         m_colors[OSD_BAR] = CMPCTheme::ScrollProgressColor;
         m_colors[OSD_CURSOR] = CMPCTheme::ScrollThumbDragColor;
@@ -468,7 +468,7 @@ void COSD::DrawMessage()
         //m_MemDC.EndPath();
         //m_MemDC.SelectClipPath(RGN_COPY);
 
-        GradientFill(&m_MemDC, &rectMessages);
+        SimpleFill(&m_MemDC, &rectMessages);
 
         UINT uFormat = DT_LEFT|DT_VCENTER|DT_NOPREFIX;
 
@@ -1127,6 +1127,16 @@ bool COSD::UpdateButtonImages()
     }
     */
     return false;
+}
+
+void COSD::SimpleFill(CDC* pDc, CRect* rc)
+{
+    const CAppSettings& s = AfxGetAppSettings();
+
+    pDc->SelectObject(m_brushBack);
+    pDc->SelectObject(m_penBorder);
+
+    pDc->Rectangle(rc);
 }
 
 void COSD::GradientFill(CDC* pDc, CRect* rc)

--- a/src/mpc-hc/OSD.h
+++ b/src/mpc-hc/OSD.h
@@ -218,6 +218,7 @@ private:
     void DrawWnd();
 
     void GradientFill(CDC* pDc, CRect* rc);
+    void SimpleFill(CDC* pDc, CRect* rc);
 
     void CreateFontInternal();
 


### PR DESCRIPTION
If we won't support transparency, this code is simpler to control the border and fill.