### PR TITLE
fix popup menu on autohiding dockbars

### DIFF
--- a/src/mpc-hc/PlayerBar.cpp
+++ b/src/mpc-hc/PlayerBar.cpp
@@ -190,5 +190,5 @@ bool CPlayerBar::IsAutohidden() const
 
 bool CPlayerBar::HasActivePopup() const
 {
-    return m_bAutohidden;
+    return m_bHasActivePopup;
 }

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -2252,8 +2252,11 @@ void CPlayerPlaylistBar::OnContextMenu(CWnd* /*pWnd*/, CPoint point)
         m.fulfillThemeReqs();
     }
 
+    m_bHasActivePopup = true;
     //use mainframe as parent to take advantage of measure redirect (was 'this' but text was not printed)
+    //adipose: note this will bypass CPlayerBar::OnEnterMenuLoop, so we set m_bHasActivePopup directly here
     int nID = (int)m.TrackPopupMenu(TPM_LEFTBUTTON | TPM_RETURNCMD, point.x, point.y, m_pMainFrame);
+    m_bHasActivePopup = false;
     switch (nID) {
         case M_OPEN:
             m_pl.SetPos(pos);

--- a/src/mpc-hc/PlayerSubresyncBar.cpp
+++ b/src/mpc-hc/PlayerSubresyncBar.cpp
@@ -947,7 +947,7 @@ void CPlayerSubresyncBar::OnRclickList(NMHDR* pNMHDR, LRESULT* pResult)
         CStringArray actors;
         CStringArray effects;
 
-        CMenu m;
+        CMPCThemeMenu m;
         m.CreatePopupMenu();
 
         if (m_mode == VOBSUB || m_mode == TEXTSUB) {
@@ -1072,6 +1072,9 @@ void CPlayerSubresyncBar::OnRclickList(NMHDR* pNMHDR, LRESULT* pResult)
         CPoint p = lpnmlv->ptAction;
         ::MapWindowPoints(pNMHDR->hwndFrom, HWND_DESKTOP, &p, 1);
 
+        if (AppNeedsThemedControls()) {
+            m.fulfillThemeReqs();
+        }
         UINT id = m.TrackPopupMenu(TPM_LEFTBUTTON | TPM_RETURNCMD, p.x, p.y, this);
 
         bool bNeedsUpdate = false;


### PR DESCRIPTION
Fixes second issue here: https://github.com/clsid2/mpc-hc/issues/1675

Note, `HasActivePopup` appears to have been returning wrong variable for 11 years.  Due to the popup menu being tied to mainframe, it probably never could be set to true.