### PR TITLE
remember current external playlist when closing

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -266,6 +266,7 @@ CAppSettings::CAppSettings()
     , lastQuickOpenPath(L"")
     , lastFileSaveCopyPath(L"")
     , lastFileOpenDirPath(L"")
+    , externalPlayListPath(L"")
     , iRedirectOpenToAppendThreshold(1000)
     , bFullscreenSeparateControls(true)
     , bAlwaysUseShortMenu(false)
@@ -1290,7 +1291,8 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_LAST_QUICKOPEN_PATH, lastQuickOpenPath);
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_LAST_FILESAVECOPY_PATH, lastFileSaveCopyPath);
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_LAST_FILEOPENDIR_PATH, lastFileOpenDirPath);
-
+    pApp->WriteProfileString(IDS_R_SETTINGS, IDS_EXTERNAL_PLAYLIST_PATH, externalPlayListPath);
+    
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_REDIRECT_OPEN_TO_APPEND_THRESHOLD, iRedirectOpenToAppendThreshold);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_FULLSCREEN_SEPARATE_CONTROLS, bFullscreenSeparateControls);
@@ -2175,7 +2177,7 @@ void CAppSettings::LoadSettings()
     lastQuickOpenPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_LAST_QUICKOPEN_PATH, L"");
     lastFileSaveCopyPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_LAST_FILESAVECOPY_PATH, L"");
     lastFileOpenDirPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_LAST_FILEOPENDIR_PATH, L"");
-
+    externalPlayListPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_EXTERNAL_PLAYLIST_PATH, L"");
 
     iRedirectOpenToAppendThreshold = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_REDIRECT_OPEN_TO_APPEND_THRESHOLD, 1000);
     bFullscreenSeparateControls = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_FULLSCREEN_SEPARATE_CONTROLS, TRUE);

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -964,6 +964,7 @@ public:
     CStringW lastQuickOpenPath;
     CStringW lastFileSaveCopyPath;
     CStringW lastFileOpenDirPath;
+    CStringW externalPlayListPath;
 
     int iRedirectOpenToAppendThreshold;
     bool bFullscreenSeparateControls;
@@ -972,7 +973,6 @@ public:
     int iMouseLeftUpDelay;
 
     bool bCaptureDeinterlace;
-
 private:
     struct FilterKey {
         CString name;

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1246,6 +1246,8 @@ void CMainFrame::OnClose()
         CloseMedia();
     }
 
+    m_wndPlaylistBar.ClearExternalPlaylistIfInvalid();
+
     s.WinLircClient.DisConnect();
     s.UIceClient.DisConnect();
 

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -63,7 +63,6 @@ private:
     int m_itemHeight = 0;
     int m_initialWindowDPI = 0;
     bool createdWindow;
-    CStringW m_ExternalPlayListPath;
     CPlaylistIDs m_ExternalPlayListFNCopy;
     void ExternalPlayListLoaded(CStringW fn);
 
@@ -175,6 +174,7 @@ public:
     bool SelectFileInPlaylist(LPCTSTR filename);
     bool DeleteFileInPlaylist(POSITION pos, bool recycle = true);
     bool IsExternalPlayListActive(CStringW& playlistPath);
+    void ClearExternalPlaylistIfInvalid();
 
 protected:
     virtual BOOL PreCreateWindow(CREATESTRUCT& cs);

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -390,5 +390,6 @@
 
 #define IDS_LAST_QUICKOPEN_PATH             _T("LastQuickOpenPath")
 #define IDS_LAST_FILESAVECOPY_PATH          _T("LastFileSaveCopyPath")
-#define IDS_LAST_FILEOPENDIR_PATH          _T("LastFileOpenDirPath")
+#define IDS_LAST_FILEOPENDIR_PATH           _T("LastFileOpenDirPath")
+#define IDS_EXTERNAL_PLAYLIST_PATH          _T("ExternalPlayListPath")
 


### PR DESCRIPTION
Fixed a few things here:

1. Current playlist is stored as a setting instead of being temporary
2. When opening, it loads the "default" playlist, but treats it as an external playlist if one was remembered.
3. It doesn't highlight/select the active item in the playlist, just makes it active.  This is more consistent with how the default playlist behaves.
