### PR TITLE
fix for window moving during intial zoom

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -12433,7 +12433,7 @@ void CMainFrame::ZoomVideoWindow(double dScale/* = ZOOM_DEFAULT_LEVEL*/)
             ASSERT(FALSE);
             return;
         }
-        MoveWindow(GetZoomWindowRect(GetZoomWindowSize(dScale), true));
+        MoveWindow(GetZoomWindowRect(GetZoomWindowSize(dScale), !s.fRememberWindowPos));
     }
 }
 


### PR DESCRIPTION
I think this should fix the problem.  The issue began after https://github.com/clsid2/mpc-hc/commit/8d282d092e131c1f76b0903aeb83618ecb638f7c.  I don't recall why the code was updated to have "true" in this location, but it seems more logical to have it use the value of "remember position."  

When testing snap sizing and incremental zoom, it all still seems to work fine.  But more testing is probably a good idea since I am not sure why this line was like this.