### PR TITLE
Fix DVB subtitles

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -16599,7 +16599,10 @@ DWORD CMainFrame::SetupNavStreamSelectSubMenu(CMenu& subMenu, UINT id, DWORD dwS
     if (!streams_found && m_pOtherSS[1]) {
         addStreamSelectFilter(m_pOtherSS[1]);
     }
-
+    if (CComQIPtr<IAMStreamSelect> pSS = m_pGB) {
+        //ASSERT(false);
+        addStreamSelectFilter(pSS);
+    }
     return selected;
 }
 


### PR DESCRIPTION
This seems to solve the problem.

CFGManagerBDA supports interface IAMStreamSelect.  But when enumerating filters in `OpenBDAGraph`, none of the filters seem to support that interface.

Not sure if I'm missing something, here.