### PR TITLE
port VMR9AlphaBitmap support from VMROSD

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -11814,8 +11814,8 @@ void CMainFrame::ToggleD3DFullscreen(bool fSwitchScreenResWhenHasTo)
             pD3DFS->SetD3DFullscreen(true);
 
             if (s.fShowOSD || s.fShowDebugInfo) {
-                if (m_pMFVMB) {
-                    m_OSD.Start(m_pVideoWnd, m_pMFVMB, true);
+                if (m_pVMB || m_pMFVMB) {
+                    m_OSD.Start(m_pVideoWnd, m_pVMB, m_pMFVMB, true);
                 }
             }
 
@@ -15006,6 +15006,7 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
     m_pVMRWC = nullptr;
     m_pVMRMC = nullptr;
     m_pMFVDC = nullptr;
+    m_pVMB = nullptr;
     m_pMFVMB = nullptr;
     m_pMFVP = nullptr;
     m_pMVRC = nullptr;
@@ -15068,7 +15069,6 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
             throw (UINT)IDS_MAINFRM_88;
         }
 
-        CComPtr<IVMRMixerBitmap9>    pVMB   = nullptr;
         CComPtr<IMadVRTextOsd>       pMVTO  = nullptr;
 
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP), TRUE);
@@ -15076,7 +15076,7 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP3), TRUE);
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRWC), FALSE); // might have IVMRMixerBitmap9, but not IVMRWindowlessControl9
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRMC), TRUE);
-        m_pGB->FindInterface(IID_PPV_ARGS(&pVMB), TRUE);
+        m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMB), TRUE);
         m_pGB->FindInterface(IID_PPV_ARGS(&m_pMFVMB), TRUE);
 
         m_pMVRC = m_pCAP;
@@ -15090,8 +15090,8 @@ bool CMainFrame::OpenMediaPrivate(CAutoPtr<OpenMediaData> pOMD)
             m_OSD.Stop();
 
             if (IsD3DFullScreenMode() && !m_fAudioOnly) {
-                if (m_pMFVMB) {
-                    m_OSD.Start(m_pVideoWnd, m_pMFVMB, true);
+                if (m_pVMB || m_pMFVMB) {
+                    m_OSD.Start(m_pVideoWnd, m_pVMB, m_pMFVMB, true);
                 }
             } else {
                 if (pMVTO) {
@@ -15384,6 +15384,7 @@ void CMainFrame::CloseMediaPrivate()
     m_pCAP.Release();
     m_pVMRWC.Release();
     m_pVMRMC.Release();
+    m_pVMB.Release();
     m_pMFVMB.Release();
     m_pMFVP.Release();
     m_pMFVDC.Release();
@@ -18149,7 +18150,6 @@ bool CMainFrame::BuildGraphVideoAudio(int fVPreview, bool fVCapture, int fAPrevi
         }
 
         if (fVidPrev) {
-            CComPtr<IVMRMixerBitmap9>    pVMB;
             CComPtr<IMadVRTextOsd>       pMVTO;
 
             m_pMVRS.Release();
@@ -18162,6 +18162,7 @@ bool CMainFrame::BuildGraphVideoAudio(int fVPreview, bool fVCapture, int fAPrevi
             m_pCAP.Release();
             m_pVMRWC.Release();
             m_pVMRMC.Release();
+            m_pVMB.Release();
             m_pMFVMB.Release();
             m_pMFVP.Release();
             m_pMFVDC.Release();
@@ -18174,7 +18175,7 @@ bool CMainFrame::BuildGraphVideoAudio(int fVPreview, bool fVCapture, int fAPrevi
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pCAP3), TRUE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRWC), FALSE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMRMC), TRUE);
-            m_pGB->FindInterface(IID_PPV_ARGS(&pVMB), TRUE);
+            m_pGB->FindInterface(IID_PPV_ARGS(&m_pVMB), TRUE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pMFVMB), TRUE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pMFVDC), TRUE);
             m_pGB->FindInterface(IID_PPV_ARGS(&m_pMFVP), TRUE);
@@ -18196,8 +18197,8 @@ bool CMainFrame::BuildGraphVideoAudio(int fVPreview, bool fVCapture, int fAPrevi
                 m_OSD.Stop();
 
                 if (IsD3DFullScreenMode() && !m_fAudioOnly) {
-                    if (m_pMFVMB) {
-                        m_OSD.Start(m_pVideoWnd, m_pMFVMB, true);
+                    if (m_pVMB || m_pMFVMB) {
+                        m_OSD.Start(m_pVideoWnd, m_pVMB, m_pMFVMB, true);
                     }
                 } else {
                     if (pMVTO) {

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -286,6 +286,7 @@ private:
     CComPtr<IVMRMixerControl9> m_pVMRMC;
     CComPtr<IMFVideoDisplayControl> m_pMFVDC;
     CComPtr<IMFVideoProcessor> m_pMFVP;
+    CComPtr<IVMRMixerBitmap9>    m_pVMB;
     CComPtr<IMFVideoMixerBitmap>    m_pMFVMB;
     CComPtr<IVMRWindowlessControl9> m_pVMRWC;
 

--- a/src/mpc-hc/OSD.cpp
+++ b/src/mpc-hc/OSD.cpp
@@ -199,7 +199,15 @@ void COSD::UpdateBitmap()
         hbmpRender = CreateDIBSection(m_MemDC, &bmi, DIB_RGB_COLORS, nullptr, nullptr, 0);
         m_MemDC.SelectObject(hbmpRender);
         if (::GetObjectW(hbmpRender, sizeof(BITMAP), &m_BitmapInfo) != 0) {
-            if (m_pMFVMB) {
+            if (m_pVMB) {
+                ZeroMemory(&m_VMR9AlphaBitmap, sizeof(m_VMR9AlphaBitmap));
+                m_VMR9AlphaBitmap.dwFlags = VMRBITMAP_HDC | VMRBITMAP_SRCCOLORKEY;
+                m_VMR9AlphaBitmap.hdc = m_MemDC;
+                m_VMR9AlphaBitmap.clrSrcKey = m_colors[OSD_TRANSPARENT];
+                m_VMR9AlphaBitmap.rSrc = m_rectWnd;
+                m_VMR9AlphaBitmap.rDest = { 0, 0, 1, 1 };
+                m_VMR9AlphaBitmap.fAlpha = 1.0;
+            } else if (m_pMFVMB) {
                 ZeroMemory(&m_MFVAlphaBitmap, sizeof(m_MFVAlphaBitmap));
                 m_MFVAlphaBitmap.GetBitmapFromDC  = TRUE;
                 m_MFVAlphaBitmap.bitmap.hdc       = m_MemDC;
@@ -232,8 +240,9 @@ void COSD::Reset()
     CalcFlybar();
 }
 
-void COSD::Start(CWnd* pWnd, CComPtr<IMFVideoMixerBitmap> pMFVMB, bool bShowSeekBar)
+void COSD::Start(CWnd* pWnd, CComPtr<IVMRMixerBitmap9> pVMB, CComPtr<IMFVideoMixerBitmap> pMFVMB, bool bShowSeekBar)
 {
+    m_pVMB         = pVMB;
     m_pMFVMB       = pMFVMB;
     m_pMVTO        = nullptr;
     m_pWnd         = pWnd;
@@ -547,7 +556,11 @@ void COSD::InvalidateBitmapOSD()
     DrawMessage();
     DrawDebug();
 
-    m_pMFVMB->SetAlphaBitmap(&m_MFVAlphaBitmap);
+    if (m_pVMB) {
+        m_pVMB->SetAlphaBitmap(&m_VMR9AlphaBitmap);
+    } else if (m_pMFVMB) {
+        m_pMFVMB->SetAlphaBitmap(&m_MFVAlphaBitmap);
+    }
 
     m_pMainFrame->RepaintVideo(m_llSeekPos == m_llSeekStop);
 }

--- a/src/mpc-hc/OSD.h
+++ b/src/mpc-hc/OSD.h
@@ -63,6 +63,7 @@ class COSD : public CWnd
         IMG_CLOSE_A = 24,
     };
 
+    CComPtr<IVMRMixerBitmap9>    m_pVMB;
     CComPtr<IMFVideoMixerBitmap> m_pMFVMB;
     CComPtr<IMadVRTextOsd>       m_pMVTO;
 
@@ -72,6 +73,7 @@ class COSD : public CWnd
 
     CCritSec            m_Lock;
     CDC                 m_MemDC;
+    VMR9AlphaBitmap    m_VMR9AlphaBitmap = {};
     MFVideoAlphaBitmap  m_MFVAlphaBitmap = {};
     BITMAP              m_BitmapInfo;
 
@@ -152,7 +154,7 @@ public:
 
     HRESULT Create(CWnd* pWnd);
 
-    void Start(CWnd* pWnd, CComPtr<IMFVideoMixerBitmap> pMFVMB, bool bShowSeekBar);
+    void Start(CWnd* pWnd, CComPtr<IVMRMixerBitmap9> pVMB, CComPtr<IMFVideoMixerBitmap> pMFVMB, bool bShowSeekBar);
     void Start(CWnd* pWnd, IMadVRTextOsd* pMVTO);
     void Start(CWnd* pWnd);
     void Stop();


### PR DESCRIPTION
Sync Renderer does not work well with the current OSD.  There is one open ticket for it not showing the OSD sometimes.  I personally discovered that a paused Sync Renderer video when entering D3D crashes the whole process (due to OSD).

In VMROSD we supported `VMR9AlphaBitmap`, which SyncAP actually implements.  I tried implementing `IMFVideoMixerBitmap` in SyncAP, but I don't quite understand how it works, and it doesn't find the interface to the SyncAP implementation (it finds the EVR one, but that one seems to be the cause of the crashes...).  But maybe it could be made to work.

Anyway, restoring the functionality we had before seems to make Sync Renderer work without the bugs.  So this is probably good enough.  MPC-BE doesn't support D3D for Sync Renderer, so the lack of support is a non-issue there.