### PR TITLE
simpler fix for mousewheel on filter dialogs

### DIFF
--- a/src/mpc-hc/CMPCThemeDialog.cpp
+++ b/src/mpc-hc/CMPCThemeDialog.cpp
@@ -53,8 +53,6 @@ BOOL CMPCThemeDialog::PreTranslateMessage(MSG* pMsg) {
 void CMPCThemeDialog::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar) {
     __super::OnHScroll(nSBCode, nPos, pScrollBar);
     if (ExternalPropertyPageWithAnalogCaptureSliders == specialCase && nSBCode == TB_THUMBPOSITION) {
-        if (CSliderCtrl* slider = DYNAMIC_DOWNCAST(CSliderCtrl, pScrollBar)) {
-            UpdateAnalogCaptureDeviceEdit(slider, this, nPos);
-        }
+        UpdateAnalogCaptureDeviceEdit(pScrollBar);
     }
 }

--- a/src/mpc-hc/CMPCThemeDialog.cpp
+++ b/src/mpc-hc/CMPCThemeDialog.cpp
@@ -53,6 +53,6 @@ BOOL CMPCThemeDialog::PreTranslateMessage(MSG* pMsg) {
 void CMPCThemeDialog::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar) {
     __super::OnHScroll(nSBCode, nPos, pScrollBar);
     if (ExternalPropertyPageWithAnalogCaptureSliders == specialCase && nSBCode == TB_THUMBPOSITION) {
-        UpdateAnalogCaptureDeviceEdit(pScrollBar);
+        UpdateAnalogCaptureDeviceSlider(pScrollBar);
     }
 }

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1255,10 +1255,10 @@ void CMPCThemeUtil::AdjustDynamicWidgetPair(CWnd* window, int leftWidget, int ri
     }
 }
 
-void CMPCThemeUtil::UpdateAnalogCaptureDeviceEdit(CScrollBar* pScrollBar) {
+void CMPCThemeUtil::UpdateAnalogCaptureDeviceSlider(CScrollBar* pScrollBar) {
     if (pScrollBar && ::IsWindow(pScrollBar->m_hWnd)) {
         if (CSliderCtrl* slider = DYNAMIC_DOWNCAST(CSliderCtrl, pScrollBar)) {
-            slider->SendMessage(WM_KEYUP, VK_LEFT, 1);
+            slider->SendMessage(WM_KEYUP, VK_LEFT, 1); //does not move the slider, only forces current position to be registered
         }
     }
 }

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1255,35 +1255,10 @@ void CMPCThemeUtil::AdjustDynamicWidgetPair(CWnd* window, int leftWidget, int ri
     }
 }
 
-std::map<int, int> CMPCThemeUtil::AnalogCaptureDevice_SliderIDToEditID = {
-    { 0x3EA, 0x3F1 },
-    { 0x3E8, 0x3F2 },
-    { 0x3E9, 0x3F3 },
-    { 0x3EB, 0x3F4 },
-    { 0x3EC, 0x3F5 },
-    { 0x3ED, 0x3F6 },
-    { 0x3EF, 0x3F7 },
-    { 0x3F0, 0x3F8 },
-    { 0x7D0, 0x403 },
-    { 0x402, 0x406 },
-    { 0x400, 0x404 },
-    { 0x401, 0x405 },
-    { 0x3F8, 0x3F9 },
-    { 0x3FB, 0x3FC },
-    { 0x3FE, 0x3FF },
-};
-
-void CMPCThemeUtil::UpdateAnalogCaptureDeviceEdit(CSliderCtrl* slider, CDialog* parent, UINT nPos) {
-    if (slider && ::IsWindow(slider->m_hWnd) && parent && ::IsWindow(parent->m_hWnd)) {
-        int sliderID = GetDlgCtrlID(slider->m_hWnd);
-        if (AnalogCaptureDevice_SliderIDToEditID.count(sliderID)) {
-            CEdit* edit = DYNAMIC_DOWNCAST(CEdit, parent->GetDlgItem(AnalogCaptureDevice_SliderIDToEditID[sliderID]));
-            if (edit) {
-                CStringW editText;
-                editText.Format(L"%d", nPos);
-                edit->SetWindowTextW(editText);
-                slider->SetPos(nPos);
-            }
+void CMPCThemeUtil::UpdateAnalogCaptureDeviceEdit(CScrollBar* pScrollBar) {
+    if (pScrollBar && ::IsWindow(pScrollBar->m_hWnd)) {
+        if (CSliderCtrl* slider = DYNAMIC_DOWNCAST(CSliderCtrl, pScrollBar)) {
+            slider->SendMessage(WM_KEYUP, VK_LEFT, 1);
         }
     }
 }

--- a/src/mpc-hc/CMPCThemeUtil.h
+++ b/src/mpc-hc/CMPCThemeUtil.h
@@ -110,7 +110,7 @@ public:
     static void fulfillThemeReqs(CProgressCtrl* ctl);
     static void enableWindows10DarkFrame(CWnd* window);
     static void AdjustDynamicWidgetPair(CWnd* window, int left, int right, WidgetPairType lType = WidgetPairAuto, WidgetPairType rType = WidgetPairAuto);
-    static void UpdateAnalogCaptureDeviceEdit(CScrollBar* pScrollBar);
+    static void UpdateAnalogCaptureDeviceSlider(CScrollBar* pScrollBar);
     static bool IsWindowVisibleAndRendered(CWnd* window);
 
     void PreDoModalRTL(LPPROPSHEETHEADERW m_psh);

--- a/src/mpc-hc/CMPCThemeUtil.h
+++ b/src/mpc-hc/CMPCThemeUtil.h
@@ -28,8 +28,6 @@ public:
         , WidgetPairEdit
     };
 
-    static std::map<int, int> AnalogCaptureDevice_SliderIDToEditID;
-
     CMPCThemeUtil();
     virtual ~CMPCThemeUtil();
 
@@ -112,7 +110,7 @@ public:
     static void fulfillThemeReqs(CProgressCtrl* ctl);
     static void enableWindows10DarkFrame(CWnd* window);
     static void AdjustDynamicWidgetPair(CWnd* window, int left, int right, WidgetPairType lType = WidgetPairAuto, WidgetPairType rType = WidgetPairAuto);
-    static void UpdateAnalogCaptureDeviceEdit(CSliderCtrl* slider, CDialog* parent, UINT nPos);
+    static void UpdateAnalogCaptureDeviceEdit(CScrollBar* pScrollBar);
     static bool IsWindowVisibleAndRendered(CWnd* window);
 
     void PreDoModalRTL(LPPROPSHEETHEADERW m_psh);


### PR DESCRIPTION
The old fix updated the edit, but the internal value was still not changed.  This is a simpler fix that works by triggering the internal update code.