### PR TITLE
open disc to behave like open DVD

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -4972,6 +4972,20 @@ int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData)
     return 0;
 }
 
+void CMainFrame::OpenDVDOrBD(CStringW path) {
+    if (!path.IsEmpty()) {
+        AfxGetAppSettings().strDVDPath = path;
+        if (!OpenBD(path)) {
+            CAutoPtr<OpenDVDData> p(DEBUG_NEW OpenDVDData());
+            p->path = path;
+            p->path.Replace(_T('/'), _T('\\'));
+            p->path = ForceTrailingSlash(p->path);
+
+            OpenMedia(p);
+        }
+    }
+}
+
 void CMainFrame::OnFileOpendvd()
 {
     if ((GetLoadState() == MLS::LOADING) || IsD3DFullScreenMode()) {
@@ -4997,18 +5011,7 @@ void CMainFrame::OnFileOpendvd()
             return;
         }
     }
-
-    if (!path.IsEmpty()) {
-        s.strDVDPath = path;
-        if (!OpenBD(path)) {
-            CAutoPtr<OpenDVDData> p(DEBUG_NEW OpenDVDData());
-            p->path = path;
-            p->path.Replace(_T('/'), _T('\\'));
-            p->path = ForceTrailingSlash(p->path);
-
-            OpenMedia(p);
-        }
-    }
+    OpenDVDOrBD(path);
 }
 
 void CMainFrame::OnFileOpendevice()
@@ -5044,7 +5047,8 @@ void CMainFrame::OnFileOpenOpticalDisk(UINT nID)
     for (TCHAR drive = _T('A'); drive <= _T('Z'); drive++) {
         CAtlList<CString> sl;
 
-        switch (GetOpticalDiskType(drive, sl)) {
+        OpticalDiskType_t discType = GetOpticalDiskType(drive, sl);
+        switch (discType) {
             case OpticalDisk_Audio:
             case OpticalDisk_VideoCD:
             case OpticalDisk_DVDVideo:
@@ -5056,16 +5060,19 @@ void CMainFrame::OnFileOpenOpticalDisk(UINT nID)
         }
 
         if (nID == 0) {
-            SendMessage(WM_COMMAND, ID_FILE_CLOSEMEDIA);
-            SetForegroundWindow();
+            if (OpticalDisk_BD == discType || OpticalDisk_DVDVideo == discType) {
+                OpenDVDOrBD(CStringW(drive) + L":\\");
+            } else {
+                SendMessage(WM_COMMAND, ID_FILE_CLOSEMEDIA);
+                SetForegroundWindow();
 
-            if (IsIconic()) {
-                ShowWindow(SW_RESTORE);
+                if (IsIconic()) {
+                    ShowWindow(SW_RESTORE);
+                }
+
+                m_wndPlaylistBar.Open(sl, true);
+                OpenCurPlaylistItem();
             }
-
-            m_wndPlaylistBar.Open(sl, true);
-            OpenCurPlaylistItem();
-
             break;
         }
     }

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -915,6 +915,7 @@ public:
     // menu item handlers
 
     INT_PTR DoFileDialogWithLastFolder(CFileDialog& fd, CStringW& lastPath);
+    void OpenDVDOrBD(CStringW path);
 
     afx_msg void OnFileOpenQuick();
     afx_msg void OnFileOpenmedia();


### PR DESCRIPTION
I cannot really see the value of the division between open disc and open DVD, at least today.  They both seem to work similarly, but at least in the case of BD, it now skips a code block which enables playlists.

There seems to be some overlap in the capabilities of `GetOpticalDiskType` and `OpenBD`, but the latter is far more sophisticated.  Given that open DVD simply looks for the root path of a BD/DVD, it seems that open disc can leverage the same code based on the drive letter.

Open Disc also supports VideoCD and CDROM Audio, so it still has its uses.

It also would be reasonable to expect "Open Disc" to behave the same as choosing the root drive of a "disc" when choosing Open DVD.