### PR TITLE
fix wrong parameter size in CSaveDlg::OnGraphNotify

### DIFF
--- a/src/mpc-hc/SaveDlg.cpp
+++ b/src/mpc-hc/SaveDlg.cpp
@@ -221,8 +221,9 @@ void CSaveDlg::OnBnClickedCancel()
 
 LRESULT CSaveDlg::OnGraphNotify(WPARAM wParam, LPARAM lParam)
 {
-    LONG evCode, evParam1, evParam2;
-    while (pME && SUCCEEDED(pME->GetEvent(&evCode, (LONG_PTR*)&evParam1, (LONG_PTR*)&evParam2, 0))) {
+    LONG evCode = 0;
+    LONG_PTR evParam1 = 0, evParam2 = 0;
+    while (pME && SUCCEEDED(pME->GetEvent(&evCode, &evParam1, &evParam2, 0))) {
         HRESULT hr = pME->FreeEventParams(evCode, evParam1, evParam2);
         UNREFERENCED_PARAMETER(hr);
 


### PR DESCRIPTION
This code was casting a LONG* to LONG_PTR* which caused stack corruption.  It seems like it didn't cause a crash but in debug, it throws an error.