### PR TITLE
handle libass subrendering outside the frame

### DIFF
--- a/src/Subtitles/LibassContext.cpp
+++ b/src/Subtitles/LibassContext.cpp
@@ -916,9 +916,9 @@ STDMETHODIMP LibassContext::Render(REFERENCE_TIME rt, SubPicDesc& spd, RECT& bbo
     return E_POINTER;
 }
 
-void AlphaBlendToInverted(const BYTE* src, int w, int h, int pitch, BYTE* dst, int dst_pitch) {
+void AlphaBlendToInverted(const BYTE* src, int w, int h, int pitch, int srcOffset, BYTE* dst, int dst_pitch) {
     for (int i = 0; i < h; i++, src += pitch, dst += dst_pitch) {
-        const BYTE* s2 = src;
+        const BYTE* s2 = src + srcOffset;
         const BYTE* s2end = s2 + w * 4;
         DWORD* d2 = (DWORD*)dst;
         for (; s2 < s2end; s2 += 4, d2++) {
@@ -942,6 +942,7 @@ bool LibassContext::RenderFrame(long long now, SubPicDesc& spd, CRect& rcDirty) 
     CRect curSPDRect = CRect(0, 0, spd.w, spd.h);
     if (changed || curSPDRect != lastSPDRect) {
         AssFlattenSSE2(image, spd, rcDirty);
+        lastUncroppedDirty = rcDirty;
         rcDirty.IntersectRect(rcDirty, curSPDRect);
 
         lastDirty = rcDirty;
@@ -951,7 +952,7 @@ bool LibassContext::RenderFrame(long long now, SubPicDesc& spd, CRect& rcDirty) 
     }
 
     BYTE* pixelBytes = (BYTE*)(spd.bits + spd.pitch * rcDirty.top + rcDirty.left * 4);
-    AlphaBlendToInverted(reinterpret_cast<uint8_t*>(m_pixels.get()), rcDirty.Width(), rcDirty.Height(), 4 * rcDirty.Width(), pixelBytes, spd.pitch);
+    AlphaBlendToInverted(reinterpret_cast<uint8_t*>(m_pixels.get()), rcDirty.Width(), rcDirty.Height(), 4 * lastUncroppedDirty.Width(), 4 * (rcDirty.left - lastUncroppedDirty.left), pixelBytes, spd.pitch);
     return true;
 }
 

--- a/src/Subtitles/LibassContext.cpp
+++ b/src/Subtitles/LibassContext.cpp
@@ -916,9 +916,10 @@ STDMETHODIMP LibassContext::Render(REFERENCE_TIME rt, SubPicDesc& spd, RECT& bbo
     return E_POINTER;
 }
 
-void AlphaBlendToInverted(const BYTE* src, int w, int h, int pitch, int srcOffset, BYTE* dst, int dst_pitch) {
+void AlphaBlendToInverted(const BYTE* src, int w, int h, int pitch, int srcXOffset, int srcYOffset, BYTE* dst, int dst_pitch) {
+    src += srcYOffset * pitch;
     for (int i = 0; i < h; i++, src += pitch, dst += dst_pitch) {
-        const BYTE* s2 = src + srcOffset;
+        const BYTE* s2 = src + srcXOffset;
         const BYTE* s2end = s2 + w * 4;
         DWORD* d2 = (DWORD*)dst;
         for (; s2 < s2end; s2 += 4, d2++) {
@@ -952,7 +953,7 @@ bool LibassContext::RenderFrame(long long now, SubPicDesc& spd, CRect& rcDirty) 
     }
 
     BYTE* pixelBytes = (BYTE*)(spd.bits + spd.pitch * rcDirty.top + rcDirty.left * 4);
-    AlphaBlendToInverted(reinterpret_cast<uint8_t*>(m_pixels.get()), rcDirty.Width(), rcDirty.Height(), 4 * lastUncroppedDirty.Width(), 4 * (rcDirty.left - lastUncroppedDirty.left), pixelBytes, spd.pitch);
+    AlphaBlendToInverted(reinterpret_cast<uint8_t*>(m_pixels.get()), rcDirty.Width(), rcDirty.Height(), 4 * lastUncroppedDirty.Width(), 4 * (rcDirty.left - lastUncroppedDirty.left), rcDirty.top - lastUncroppedDirty.top, pixelBytes, spd.pitch);
     return true;
 }
 

--- a/src/Subtitles/LibassContext.h
+++ b/src/Subtitles/LibassContext.h
@@ -136,7 +136,7 @@ protected:
     CSimpleTextSubtitle* m_STS;
     IPin* m_pPin;
     std::unique_ptr<uint32_t[]> m_pixels;
-    CRect lastDirty;
+    CRect lastDirty, lastUncroppedDirty;
     CRect lastSPDRect;
     REFERENCE_TIME rtCurrent;
     bool curTimeInitialized;


### PR DESCRIPTION
Problem was the pitch of the source images was no longer matching the cropped frame.  Once cropped, it needs an x offset as well.

~For vertical offset, I didn't observe any problem.  But that shouldn't affect the pitch anyway.  Still...if the subs were tall enough, it might be an issue.~