### PR TITLE
Add application/x-font-otf to font mimetypes

### DIFF
--- a/src/Subtitles/LibassContext.cpp
+++ b/src/Subtitles/LibassContext.cpp
@@ -838,6 +838,7 @@ void LibassContext::LoadASSFont() {
             if (SUCCEEDED(bag->ResGet(i, &name.GetBSTR(), &desc.GetBSTR(), &mime.GetBSTR(), &pData, &len, nullptr))) {
                 if (wcscmp(mime.GetBSTR(), L"application/x-truetype-font") == 0 // see https://gitlab.com/mbunkus/mkvtoolnix/-/issues/3137
                     || wcscmp(mime.GetBSTR(), L"application/vnd.ms-opentype") == 0
+                    || wcscmp(mime.GetBSTR(), L"application/x-font-otf") == 0
                     || wcscmp(mime.GetBSTR(), L"application/x-font-ttf") == 0
                     || wcscmp(mime.GetBSTR(), L"application/font-sfnt") == 0
                     || wcscmp(mime.GetBSTR(), L"font/otf") == 0


### PR DESCRIPTION
As per commit https://github.com/mpv-player/mpv/commit/a283f66ede58e0182ac8cd4c930238144427fa74 seems like application/x-font-otf added to mime types,
so this PR is just to keep the files in sync