### PR TITLE
Add Option: Combine Play/Pause buttons into one

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -228,6 +228,7 @@ CAppSettings::CAppSettings()
     , hMasterWnd(nullptr)
     , bHideWindowedControls(false)
     , nJpegQuality(90)
+    , bCombinePlayPause(false)
     , bEnableCoverArt(true)
     , nCoverArtSizeLimit(600)
     , bEnableLogging(false)
@@ -1267,6 +1268,8 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_JPEG_QUALITY, nJpegQuality);
 
+    pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_PLAY_AS_PAUSE, bCombinePlayPause);
+
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_COVER_ART, bEnableCoverArt);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_COVER_ART_SIZE_LIMIT, nCoverArtSizeLimit);
 
@@ -2196,6 +2199,8 @@ void CAppSettings::LoadSettings()
     if (nJpegQuality < 20 || nJpegQuality > 100) {
         nJpegQuality = 90;
     }
+
+    bCombinePlayPause = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_PLAY_AS_PAUSE, FALSE);
 
     bEnableCoverArt = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_COVER_ART, TRUE);
     nCoverArtSizeLimit = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_COVER_ART_SIZE_LIMIT, 600);

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -912,6 +912,8 @@ public:
 
     int             nJpegQuality;
 
+    bool            bCombinePlayPause;
+
     bool            bEnableCoverArt;
     int             nCoverArtSizeLimit;
 

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -8992,7 +8992,6 @@ void CMainFrame::OnUpdatePlayPauseStop(CCmdUI* pCmdUI)
         const auto& s = AfxGetAppSettings();
         
         fCheck = (pCmdUI->m_nID == ID_PLAY_PLAY && fs == State_Running && !s.bCombinePlayPause) || // If bCombinePlayPause is disabled, check Play only in Running.
-            ((pCmdUI->m_nID == ID_PLAY_PLAY || pCmdUI->m_nID == ID_PLAY_PAUSE) && (fs == State_Running || fs == State_Paused) && s.bCombinePlayPause) || // If bCombinePlayPause is enabled, check Play in Running and Pause, too
             pCmdUI->m_nID == ID_PLAY_PAUSE && fs == State_Paused ||
             pCmdUI->m_nID == ID_PLAY_STOP && fs == State_Stopped ||
             pCmdUI->m_nID == ID_PLAY_PLAYPAUSE && (fs == State_Paused || fs == State_Running);

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -239,6 +239,9 @@ private:
     static PlaybackRateMap filePlaybackRates;
     static PlaybackRateMap dvdPlaybackRates;
 
+    int m_playButtonIconIndex = 0;
+    int m_pauseButtonIconIndex = 1;
+
     friend class CPPageFileInfoSheet;
     friend class CPPageLogo;
     friend class CMouse;
@@ -1255,6 +1258,8 @@ public:
 
     CString GetVidPos() const;
 
+    HRESULT UpdateToolbarIconsBasedOnState();
+    HRESULT UpdateToolbarIconsBasedOnState(MPC_PLAYSTATE iPlayState);
     CComPtr<ITaskbarList3> m_pTaskbarList;
     HRESULT CreateThumbnailToolbar();
     HRESULT UpdateThumbarButton();

--- a/src/mpc-hc/PPagePlayer.cpp
+++ b/src/mpc-hc/PPagePlayer.cpp
@@ -45,6 +45,7 @@ CPPagePlayer::CPPagePlayer()
     , m_fRememberDVDPos(FALSE)
     , m_fRememberFilePos(FALSE)
     , m_bRememberPlaylistItems(TRUE)
+    , m_bCombinePlayPause(FALSE)
     , m_bEnableCoverArt(TRUE)
     , m_dwCheckIniLastTick(0)
 {
@@ -74,6 +75,7 @@ void CPPagePlayer::DoDataExchange(CDataExchange* pDX)
     DDX_Check(pDX, IDC_FILE_POS, m_fRememberFilePos);
     DDX_Check(pDX, IDC_CHECK2, m_bRememberPlaylistItems);
     DDX_Check(pDX, IDC_CHECK14, m_bEnableCoverArt);
+    DDX_Check(pDX, IDC_CHECK15, m_bCombinePlayPause);
 }
 
 BEGIN_MESSAGE_MAP(CPPagePlayer, CMPCThemePPageBase)
@@ -108,6 +110,7 @@ BOOL CPPagePlayer::OnInitDialog()
     m_fRememberDVDPos = s.fRememberDVDPos;
     m_fRememberFilePos = s.fRememberFilePos;
     m_bRememberPlaylistItems = s.bRememberPlaylistItems;
+    m_bCombinePlayPause = s.bCombinePlayPause;
     m_bEnableCoverArt = s.bEnableCoverArt;
 
 
@@ -140,6 +143,7 @@ BOOL CPPagePlayer::OnApply()
     s.fRememberFilePos = !!m_fRememberFilePos;
     s.bRememberPlaylistItems = !!m_bRememberPlaylistItems;
     s.bEnableCoverArt = !!m_bEnableCoverArt;
+    s.bCombinePlayPause = !!m_bCombinePlayPause;
 
     if (!m_fKeepHistory) {
         s.ClearRecentFiles();

--- a/src/mpc-hc/PPagePlayer.h
+++ b/src/mpc-hc/PPagePlayer.h
@@ -51,6 +51,7 @@ public:
     BOOL m_fRememberDVDPos;
     BOOL m_fRememberFilePos;
     BOOL m_bRememberPlaylistItems;
+    BOOL m_bCombinePlayPause;
     BOOL m_bEnableCoverArt;
 
     ULONGLONG m_dwCheckIniLastTick;

--- a/src/mpc-hc/PPageTheme.cpp
+++ b/src/mpc-hc/PPageTheme.cpp
@@ -324,6 +324,8 @@ BOOL CPPageTheme::OnApply()
     s.fLimitWindowProportions = !!m_fLimitWindowProportions;
     s.bHideWindowedControls = !!m_bHideWindowedControls;
 
+    pFrame->UpdateToolbarIconsBasedOnState();
+
     s.bUseEnhancedTaskBar = !!m_bUseEnhancedTaskBar;
     if (pFrame) {
         if (m_bUseEnhancedTaskBar) {

--- a/src/mpc-hc/PlayerToolBar.cpp
+++ b/src/mpc-hc/PlayerToolBar.cpp
@@ -184,7 +184,7 @@ BOOL CPlayerToolBar::Create(CWnd* pParentWnd)
     const CAppSettings& s = AfxGetAppSettings();
 
     UINT styles[] = {
-        TBBS_CHECKGROUP, TBBS_CHECKGROUP, TBBS_CHECKGROUP,
+        (s.bCombinePlayPause ? TBBS_BUTTON : TBBS_CHECKGROUP), TBBS_CHECKGROUP, TBBS_CHECKGROUP,
         TBBS_SEPARATOR,
         TBBS_BUTTON, TBBS_BUTTON, TBBS_BUTTON, TBBS_BUTTON,
         TBBS_SEPARATOR,
@@ -498,30 +498,6 @@ void CPlayerToolBar::OnLButtonDown(UINT nFlags, CPoint point)
         ClientToScreen(&point);
         m_pMainFrame->PostMessage(WM_NCLBUTTONDOWN, HTCAPTION, MAKELPARAM(point.x, point.y));
     } else {
-        const CAppSettings& s = AfxGetAppSettings();
-        if (s.bCombinePlayPause) {
-            // Play acts as Pause also. In that case, uncheck the button before proceeding with click handle so that it can be retriggered.
-            if (i >= 0) {
-                TBBUTTON button;
-                GetToolBarCtrl().GetButton(i, &button);
-                if (button.idCommand == ID_PLAY_PLAY && (button.fsStyle & TBBS_CHECKGROUP)) {
-                    BOOL bChecked = (button.fsState & TBSTATE_CHECKED) != 0;
-                    if (bChecked) {
-                        GetToolBarCtrl().CheckButton(button.idCommand, FALSE);
-                        button.fsState &= ~TBSTATE_CHECKED;
-                        GetToolBarCtrl().SetState(button.idCommand, button.fsState);
-                        // Manually invoke the command handler to ensure the event is triggered
-                        CWnd* pMainWnd = AfxGetMainWnd();
-                        if (pMainWnd) {
-                            pMainWnd->SendMessage(WM_COMMAND, MAKEWPARAM(button.idCommand, BN_CLICKED), (LPARAM)GetSafeHwnd());
-                        }
-                        // Refresh the toolbar to ensure the change is reflected
-                        Invalidate();
-                        UpdateWindow();
-                    }
-                }
-            }
-        }
         __super::OnLButtonDown(nFlags, point);
         
     }

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -363,6 +363,8 @@
 #define IDS_RS_CACHESHADERS                 _T("CacheShaders")
 #define IDS_R_SHADER_CACHE                  _T("ShaderCache")
 
+# define IDS_RS_PLAY_AS_PAUSE               _T("EnablePlayAsPause")
+
 #define IDS_RS_COVER_ART                    _T("EnableCoverArt")
 #define IDS_RS_COVER_ART_SIZE_LIMIT         _T("CoverArtSizeLimit")
 #define IDS_RS_LOGGING                      _T("EnableLogging")

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -234,12 +234,13 @@ BEGIN
     CONTROL         "File name only",IDC_RADIO4,"Button",BS_AUTORADIOBUTTON,12,184,126,8
     CONTROL         "Don't prefix anything",IDC_RADIO5,"Button",BS_AUTORADIOBUTTON,12,198,126,8
     CONTROL         "Replace file name with title",IDC_CHECK13,"Button",BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP | WS_GROUP,12,212,126,18
-    GROUPBOX        "Other",IDC_STATIC,149,6,200,90,WS_GROUP
+    GROUPBOX        "Other",IDC_STATIC,149,6,200,105,WS_GROUP
     CONTROL         "Tray icon",IDC_CHECK3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,155,20,192,8
     CONTROL         "Store settings in .ini file",IDC_CHECK8,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,155,35,192,8
     CONTROL         "Disable ""Open Disc"" menu",IDC_CHECK10,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,155,50,192,8
     CONTROL         "Process priority above normal",IDC_CHECK9,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,155,65,192,8
     CONTROL         "Enable cover-art support",IDC_CHECK14,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,155,80,192,8
+    CONTROL         "Combine Play/Pause buttons into one", IDC_CHECK15, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 155, 95, 192, 8
     GROUPBOX        "History",IDC_STATIC,149,155,200,124
     CONTROL         "Keep history of recently opened files",IDC_CHECK1,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,155,169,192,8

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -413,6 +413,7 @@
 #define IDC_CHECK12                     11091
 #define IDC_CHECK13                     11092
 #define IDC_CHECK14                     11093
+#define IDC_CHECK15                     11094
 #define IDC_SPIN1                       11100
 #define IDC_SPIN2                       11101
 #define IDC_SPIN3                       11102


### PR DESCRIPTION
I have introduced a new option in View->Options->Player->Other->"Combine Play/Pause buttons into one".

This option will merge "Play" and "Pause" buttons into one, so when the video is playing, it will appear as "Pause" (with pause icon), and vice versa. This option requires to restart the application in order to take effect.

This will cover the feature request: https://github.com/clsid2/mpc-hc/issues/2003

![Settings](https://github.com/user-attachments/assets/e6b5df01-3c71-4f90-918a-37a9dcd2a758)

![Play-with-tooltip](https://github.com/user-attachments/assets/19ee63bb-ebd4-4faf-8cdb-2675b523d361)

![Pause-with-tooltip](https://github.com/user-attachments/assets/9b7b81e7-f6ba-4db6-854c-0a2d4fc10730)