### PR TITLE
Fix wrong Pan Frame Adjust movements that caused not all frame was viewable

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1601,6 +1601,23 @@ void CMainFrame::OnGetMinMaxInfo(MINMAXINFO* lpMMI)
     OSDBarSetPos();
 }
 
+void CMainFrame::SetInitialPos()
+{
+    auto vertAlign = AfxGetAppSettings().iVerticalAlignVideo;
+    if (vertAlign == CAppSettings::verticalAlignVideoType::ALIGN_TOP) {
+        m_PosY = -0.5;
+    }
+    else if (vertAlign == CAppSettings::verticalAlignVideoType::ALIGN_BOTTOM) {
+        m_PosY = 1.5;
+    }
+    else
+    {
+        m_PosY = 0.5;
+    }
+
+    m_PosX = 0.5;
+}
+
 void CMainFrame::OnMove(int x, int y)
 {
     __super::OnMove(x, y);
@@ -4310,7 +4327,7 @@ void CMainFrame::OnFilePostClosemedia(bool bNextIsQueued/* = false*/)
     if (!s.fSavePnSZoom) {
         m_AngleX = m_AngleY = m_AngleZ = 0;
         m_ZoomX = m_ZoomY = 1.0;
-        m_PosX = m_PosY = 0.5;
+        SetInitialPos();
     }
 
     if (m_closingmsg.IsEmpty()) {
@@ -8176,7 +8193,7 @@ void CMainFrame::OnViewDefaultVideoFrame(UINT nID)
 {
     AfxGetAppSettings().iDefaultVideoSize = nID - ID_VIEW_VF_HALF;
     m_ZoomX = m_ZoomY = 1;
-    m_PosX = m_PosY = 0.5;
+    SetInitialPos();
     MoveVideoWindow();
 }
 
@@ -8225,7 +8242,7 @@ void CMainFrame::OnViewSwitchVideoFrame()
     }
     s.iDefaultVideoSize = vs;
     m_ZoomX = m_ZoomY = 1;
-    m_PosX = m_PosY = 0.5;
+    SetInitialPos();
     MoveVideoWindow();
 }
 
@@ -8265,7 +8282,7 @@ void CMainFrame::OnViewPanNScan(UINT nID)
             ResetSubtitlePosAndSize(true);
             // Pan&Scan
             m_ZoomX = m_ZoomY = 1.0;
-            m_PosX = m_PosY = 0.5;
+            SetInitialPos();
             m_AngleX = m_AngleY = m_AngleZ = 0;
             PerformFlipRotate();
             break;
@@ -8398,8 +8415,7 @@ void CMainFrame::OnViewPanNScanPresets(UINT nID)
         return;
     }
 
-    m_PosX = 0.5;
-    m_PosY = 0.5;
+    SetInitialPos();
     m_ZoomX = 1.0;
     m_ZoomY = 1.0;
 
@@ -12345,14 +12361,6 @@ void CMainFrame::MoveVideoWindow(bool fShowStats/* = false*/, bool bSetStoppedVi
             // Scale video frame
             double dScaledVRWidth  = m_ZoomX * dVRWidth;
             double dScaledVRHeight = m_ZoomY * dVRHeight;
-
-            auto vertAlign = AfxGetAppSettings().iVerticalAlignVideo;
-            double vertAlignOffset = 0;
-            if (vertAlign == CAppSettings::verticalAlignVideoType::ALIGN_TOP) {
-                vertAlignOffset = -(dWRHeight - dScaledVRHeight) / 2;
-            } else if (vertAlign == CAppSettings::verticalAlignVideoType::ALIGN_BOTTOM) {
-                vertAlignOffset = (dWRHeight - dScaledVRHeight) / 2;
-            }
 
             // Position video frame
             // left and top parts are allowed to be negative

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -12356,8 +12356,8 @@ void CMainFrame::MoveVideoWindow(bool fShowStats/* = false*/, bool bSetStoppedVi
 
             // Position video frame
             // left and top parts are allowed to be negative
-            videoRect.left   = lround(m_PosX * (dWRWidth * 3.0 - dScaledVRWidth) - dWRWidth);
-            videoRect.top    = lround(m_PosY * (dWRHeight * 3.0 - dScaledVRHeight) - dWRHeight + vertAlignOffset);
+            videoRect.left = lround((dWRWidth - dScaledVRWidth) / 2 * (m_PosX + 0.5));
+            videoRect.top  = lround((dWRHeight - dScaledVRHeight) / 2 * (m_PosY + 0.5));
             // right and bottom parts are always at picture center or beyond, so never negative
             videoRect.right  = lround(videoRect.left + dScaledVRWidth);
             videoRect.bottom = lround(videoRect.top  + dScaledVRHeight);
@@ -12462,7 +12462,7 @@ void CMainFrame::SetPreviewVideoPosition() {
             h = MulDiv(w, arxy.cy, arxy.cx);
         }
 
-        const CPoint pos(int(m_PosX * (wr.Width() * 3 - w) - wr.Width()), int(m_PosY * (wr.Height() * 3 - h) - wr.Height()));
+        const CPoint pos(int((wr.Width() - w) / 2 * (m_PosX + 0.5)), int((wr.Height() - h) /2 * (m_PosY + 0.5)));
         const CRect vr(pos, CSize(w, h));
         
         if (m_pMFVDC_preview) {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1010,6 +1010,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 
     const CAppSettings& s = AfxGetAppSettings();
 
+    SetInitialPos();
+    
     // Create OSD Window
     CreateOSDBar();
 

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -859,6 +859,7 @@ public:
 
     afx_msg LRESULT OnSkypeAttach(WPARAM wParam, LPARAM lParam);
 
+    afx_msg void SetInitialPos();
     afx_msg void OnSetFocus(CWnd* pOldWnd);
     afx_msg void OnGetMinMaxInfo(MINMAXINFO* lpMMI);
     afx_msg void OnMove(int x, int y);


### PR DESCRIPTION
Incorrect formula was used for videoRect.left and videoRect.top calculations that caused wrong video rect positions and incorrect directions of movements.
This pull request fix #3418 and #3417 issues