### PR TITLE
themed scrollbar renderer integrated into native painting process

### DIFF
--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -30,7 +30,7 @@ void CMPCThemePlayerListCtrl::PreSubclassWindow()
         EnableToolTips(TRUE);
     } else {
         if (CMPCThemeUtil::canUseWin10DarkTheme()) {
-            SetWindowTheme(GetSafeHwnd(), L"DarkMode_Explorer", NULL);
+            //SetWindowTheme(GetSafeHwnd(), L"DarkMode_Explorer", NULL);
         } else {
             SetWindowTheme(GetSafeHwnd(), L"", NULL);
         }
@@ -47,6 +47,7 @@ IMPLEMENT_DYNAMIC(CMPCThemePlayerListCtrl, CListCtrl)
 
 BEGIN_MESSAGE_MAP(CMPCThemePlayerListCtrl, CListCtrl)
     ON_WM_PAINT()
+    ON_WM_NCPAINT()
     ON_WM_CREATE()
     ON_WM_MOUSEMOVE()
     ON_WM_MOUSEWHEEL()
@@ -306,6 +307,14 @@ void CMPCThemePlayerListCtrl::setCheckedColors(COLORREF checkedBG, COLORREF chec
     checkedTextClr = checkedText;
     uncheckedTextClr = uncheckedText;
     hasCheckedColors = true;
+}
+
+void CMPCThemePlayerListCtrl::OnNcPaint() {
+    if (AppNeedsThemedControls()) {
+        HandleNcPaint(m_hWnd);
+    } else {
+        __super::OnNcPaint();
+    }
 }
 
 int CMPCThemePlayerListCtrl::OnCreate(LPCREATESTRUCT lpCreateStruct)

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -333,7 +333,9 @@ int CMPCThemePlayerListCtrl::OnCreate(LPCREATESTRUCT lpCreateStruct)
 
 LRESULT CMPCThemePlayerListCtrl::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
-    CMPCThemeScrollBarRenderer::ProcessMessage(m_hWnd, message, wParam, lParam);
+    if (AppNeedsThemedControls()) {
+        CMPCThemeScrollBarRenderer::ProcessMessage(m_hWnd, message, wParam, lParam);
+    }
     LRESULT result = __super::WindowProc(message, wParam, lParam);
     return result;
 }

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.cpp
@@ -7,26 +7,20 @@
 
 CMPCThemePlayerListCtrl::ColumnCache CMPCThemePlayerListCtrl::s_columnCache;
 
-CMPCThemePlayerListCtrl::CMPCThemePlayerListCtrl() : CListCtrl()
+CMPCThemePlayerListCtrl::CMPCThemePlayerListCtrl() : CListCtrl(), CMPCThemeScrollBarRenderer()
 {
     themeGridLines = false;
     fullRowSelect = false;
-    themedSBHelper = nullptr;
     clipChildWindows = false;
     hasCheckedColors = false;
     hasCBImages = false;
     customThemeInterface = nullptr;
-    if (!CMPCThemeUtil::canUseWin10DarkTheme()) {
-        themedSBHelper = DEBUG_NEW CMPCThemeScrollBarHelper(this);
-    }
+
 }
 
 
 CMPCThemePlayerListCtrl::~CMPCThemePlayerListCtrl()
 {
-    if (nullptr != themedSBHelper) {
-        delete themedSBHelper;
-    }
 }
 
 
@@ -53,35 +47,12 @@ IMPLEMENT_DYNAMIC(CMPCThemePlayerListCtrl, CListCtrl)
 
 BEGIN_MESSAGE_MAP(CMPCThemePlayerListCtrl, CListCtrl)
     ON_WM_PAINT()
-    ON_WM_NCPAINT()
     ON_WM_CREATE()
-    ON_NOTIFY_REFLECT_EX(LVN_ENDSCROLL, OnLvnEndScroll)
     ON_WM_MOUSEMOVE()
     ON_WM_MOUSEWHEEL()
-    ON_WM_NCCALCSIZE()
-    ON_NOTIFY_REFLECT_EX(NM_CUSTOMDRAW, OnCustomDraw)
     ON_WM_ERASEBKGND()
     ON_WM_CTLCOLOR()
-    ON_NOTIFY_EX(HDN_ENDTRACKA, 0, &OnHdnEndtrack)
-    ON_NOTIFY_EX(HDN_ENDTRACKW, 0, &OnHdnEndtrack)
-    ON_NOTIFY_REFLECT_EX(LVN_ITEMCHANGED, &OnLvnItemchanged)
-    ON_MESSAGE(PLAYER_PLAYLIST_UPDATE_SCROLLBAR, OnDelayed_UpdateScrollbar)
-    ON_WM_WINDOWPOSCHANGED()
 END_MESSAGE_MAP()
-
-void CMPCThemePlayerListCtrl::OnWindowPosChanged(WINDOWPOS* lpwndpos) {
-    if (AppNeedsThemedControls()) {
-        if (themedSBHelper) {
-            if (0 != (GetStyle() & (WS_VSCROLL | WS_HSCROLL))) {
-                themedSBHelper->OnWindowPosChanged();
-            } else {
-                themedSBHelper->InvalidateScrollbarArea();
-            }
-        }
-    }
-    return __super::OnWindowPosChanged(lpwndpos);
-}
-
 
 void CMPCThemePlayerListCtrl::subclassHeader()
 {
@@ -337,20 +308,6 @@ void CMPCThemePlayerListCtrl::setCheckedColors(COLORREF checkedBG, COLORREF chec
     hasCheckedColors = true;
 }
 
-void CMPCThemePlayerListCtrl::OnNcPaint()
-{
-    if (AppNeedsThemedControls()) {
-        if (nullptr != themedSBHelper) {
-            themedSBHelper->themedNcPaintWithSB();
-        } else {
-            CMPCThemeScrollBarHelper::themedNcPaint(this, this);
-        }
-    } else {
-        __super::OnNcPaint();
-    }
-}
-
-
 int CMPCThemePlayerListCtrl::OnCreate(LPCREATESTRUCT lpCreateStruct)
 {
     if (__super::OnCreate(lpCreateStruct) == -1) {
@@ -365,56 +322,10 @@ int CMPCThemePlayerListCtrl::OnCreate(LPCREATESTRUCT lpCreateStruct)
     return 0;
 }
 
-BOOL CMPCThemePlayerListCtrl::OnLvnEndScroll(NMHDR* pNMHDR, LRESULT* pResult)
-{
-    if (AppNeedsThemedControls()) {
-        if (nullptr != themedSBHelper) {
-            themedSBHelper->updateScrollInfo();
-        }
-        *pResult = 0;
-    }
-    return FALSE;
-}
-
-void CMPCThemePlayerListCtrl::updateSB()
-{
-    if (nullptr != themedSBHelper) {
-        themedSBHelper->hideNativeScrollBars();
-    }
-}
-
-void CMPCThemePlayerListCtrl::updateScrollInfo(bool invalidate /*=false*/)
-{
-    if (nullptr != themedSBHelper) {
-        themedSBHelper->updateScrollInfo(invalidate ? SCROLL_INVALIDATE : SCROLL_NOPAINT);
-    }
-}
-
 LRESULT CMPCThemePlayerListCtrl::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
-    if (AppNeedsThemedControls() && nullptr != themedSBHelper) {
-        if (themedSBHelper->WindowProc(this, message, wParam, lParam)) {
-            return 1;
-        }
-    }
-
+    CMPCThemeScrollBarRenderer::ProcessMessage(m_hWnd, message, wParam, lParam);
     LRESULT result = __super::WindowProc(message, wParam, lParam);
-
-    if (message == WM_NOTIFY) {
-        LPNMHDR pNMHDR = (LPNMHDR)lParam;
-
-        CHeaderCtrl* pHeader = GetHeaderFast();
-        if (pHeader && pNMHDR->hwndFrom == pHeader->GetSafeHwnd()) {
-            switch (pNMHDR->code) {
-            case HDN_ITEMCHANGED:
-                if (nullptr != themedSBHelper) {
-                    themedSBHelper->updateScrollInfo(SCROLL_REDRAW);
-                }
-                break;
-            }
-        }
-    }
-
     return result;
 }
 
@@ -459,18 +370,6 @@ BOOL CMPCThemePlayerListCtrl::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
     ScreenToClient(&pt);
     updateToolTip(pt);
     return ret;
-}
-
-
-void CMPCThemePlayerListCtrl::OnNcCalcSize(BOOL bCalcValidRects, NCCALCSIZE_PARAMS* lpncsp)
-{
-    __super::OnNcCalcSize(bCalcValidRects, lpncsp);
-    if (AppNeedsThemedControls()) {
-        if (GetStyle() & WS_HSCROLL && nullptr == themedSBHelper) {
-            themedSBHelper = DEBUG_NEW CMPCThemeScrollBarHelper(this);
-        }
-        ::PostMessage(m_hWnd, PLAYER_PLAYLIST_UPDATE_SCROLLBAR, (WPARAM)0, (LPARAM)TRUE);
-    }
 }
 
 void CMPCThemePlayerListCtrl::drawItem(CDC* pDC, int nItem, int nSubItem, CRect rRow, DWORD dwStyle, DWORD extendedStyle, UINT itemState, bool isChecked, CImageList* smallImageList, UINT cbResID)
@@ -847,39 +746,6 @@ HBRUSH CMPCThemePlayerListCtrl::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
     } else {
         return __super::OnCtlColor(pDC, pWnd, nCtlColor);
     }
-}
-
-
-BOOL CMPCThemePlayerListCtrl::OnHdnEndtrack(UINT id, NMHDR* pNMHDR, LRESULT* pResult)
-{
-    //    LPNMHEADER phdr = reinterpret_cast<LPNMHEADER>(pNMHDR);
-    if (AppNeedsThemedControls()) {
-        if (nullptr != themedSBHelper) {
-            themedSBHelper->updateScrollInfo();
-        }
-    }
-    *pResult = 0;
-
-    //we don't want to prevent this event from being processed
-    //it's used when "show windows contents while dragging" is false,
-    //to draw the outline of the resized column
-    return FALSE; 
-}
-
-LRESULT CMPCThemePlayerListCtrl::OnDelayed_UpdateScrollbar(WPARAM, LPARAM invalidate)
-{
-    updateScrollInfo((bool)invalidate);
-    return 0;
-}
-
-BOOL CMPCThemePlayerListCtrl::OnLvnItemchanged(NMHDR* pNMHDR, LRESULT* pResult)
-{
-    //LPNMLISTVIEW pNMLV = reinterpret_cast<LPNMLISTVIEW>(pNMHDR);
-    if (AppNeedsThemedControls()) {
-        ::PostMessage(m_hWnd, PLAYER_PLAYLIST_UPDATE_SCROLLBAR, (WPARAM)0, (LPARAM)0);
-    }
-    *pResult = 0;
-    return FALSE;
 }
 
 void CMPCThemePlayerListCtrl::DrawAllItems(CDC* pDC, const CRect& drawRect) {

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.h
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.h
@@ -52,6 +52,7 @@ public:
 
     DECLARE_MESSAGE_MAP()
     afx_msg void OnPaint();
+    afx_msg void OnNcPaint();
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
     afx_msg void OnMouseMove(UINT nFlags, CPoint point);
     afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);

--- a/src/mpc-hc/CMPCThemePlayerListCtrl.h
+++ b/src/mpc-hc/CMPCThemePlayerListCtrl.h
@@ -4,6 +4,7 @@
 #include "CMPCThemeUtil.h"
 #include "CMPCThemeHeaderCtrl.h"
 #include "MemoryDCBuffer.h"
+#include "CMPCThemeScrollBarRenderer.h"
 
 //undocumented state changes for LVS_EX_CHECKBOXES
 #define LVIS_UNCHECKED  0x1000
@@ -18,7 +19,7 @@ public:
     virtual bool UseCustomGrid() { return true; };
 };
 
-class CMPCThemePlayerListCtrl : public CListCtrl, CMPCThemeUtil, CMPCThemeScrollable
+class CMPCThemePlayerListCtrl : public CListCtrl, CMPCThemeUtil, public CMPCThemeScrollBarRenderer
 {
 private:
     MemoryDCBuffer m_listBuffer;
@@ -31,8 +32,6 @@ public:
     virtual ~CMPCThemePlayerListCtrl();
     DECLARE_DYNAMIC(CMPCThemePlayerListCtrl)
 
-    void updateSB();
-    void updateScrollInfo(bool invalidate = false);
     LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
     void updateToolTip(CPoint point);
     virtual BOOL PreTranslateMessage(MSG* pMsg);
@@ -53,13 +52,9 @@ public:
 
     DECLARE_MESSAGE_MAP()
     afx_msg void OnPaint();
-    afx_msg void OnWindowPosChanged(WINDOWPOS* lpwndpos);
-    afx_msg void OnNcPaint();
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
-    afx_msg BOOL OnLvnEndScroll(NMHDR* pNMHDR, LRESULT* pResult);
     afx_msg void OnMouseMove(UINT nFlags, CPoint point);
     afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
-    afx_msg void OnNcCalcSize(BOOL bCalcValidRects, NCCALCSIZE_PARAMS* lpncsp);
     afx_msg BOOL OnCustomDraw(NMHDR* pNMHDR, LRESULT* pResult);
     afx_msg BOOL OnEraseBkgnd(CDC* pDC);
     afx_msg HBRUSH OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor);
@@ -80,11 +75,6 @@ protected:
     BOOL EraseBkgnd(CDC* pDC, CRect updateRect);
     void drawItem(CDC* pDC, int nItem, int nSubItem, CRect itemRect, DWORD dwStyle, DWORD extendedStyle, UINT itemState, bool isChecked, CImageList* smallImageList, UINT cbResID);
     virtual void PreSubclassWindow();
-public:
-    void doDefault() { Default(); };
-    afx_msg BOOL OnHdnEndtrack(UINT id, NMHDR* pNMHDR, LRESULT* pResult);
-    afx_msg LRESULT OnDelayed_UpdateScrollbar(WPARAM, LPARAM);
-    afx_msg BOOL OnLvnItemchanged(NMHDR* pNMHDR, LRESULT* pResult);
 private:
     struct ColumnCache {
         struct ColumnInfo {

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -395,7 +395,6 @@ void CMPCThemeScrollBarRenderer::DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, co
             continue;
         }
 
-        XSB_EDRAWELEM eState;
         if (!bScrollBarEnabled) {
             eState = eDisabled;
         } else if (state.bDragging && stArea.IsThumb()) {
@@ -614,31 +613,32 @@ void CMPCThemeScrollBarRenderer::OnNcMouseMove(HWND hWnd, WPARAM wParam, LPARAM 
         return;
     }
 
-    if (bHasVScroll && vScrollRect.PtInRect(point)) {
-        eXSB_AREA area = GetScrollBarArea(hWnd, point, true, vScrollRect);
-        if (m_vScrollState.bDragging) {
-            m_vScrollState.eMouseOverArea.eArea = area;
-        } else if (m_vScrollState.eMouseDownArea.eArea != eNone) {
-            m_vScrollState.eMouseOverArea.eArea = (area == m_vScrollState.eMouseDownArea.eArea) ? area : eNone;
-        } else {
-            m_vScrollState.eMouseOverArea.eArea = area;
-        }
-    } else {
-        m_vScrollState.eMouseOverArea.eArea = eNone;
-    }
+    auto updateScrollBarState = [&](ScrollBarState& state, bool bHasScrollBar, const CRect& scrollRect, bool bVertical) {
+        if (bHasScrollBar && scrollRect.PtInRect(point)) {
+            eXSB_AREA area = GetScrollBarArea(hWnd, point, bVertical, scrollRect);
+            eXSB_AREA oldArea = state.eMouseOverArea.eArea;
 
-    if (bHasHScroll && hScrollRect.PtInRect(point)) {
-        eXSB_AREA area = GetScrollBarArea(hWnd, point, false, hScrollRect);
-        if (m_hScrollState.bDragging) {
-            m_hScrollState.eMouseOverArea.eArea = area;
-        } else if (m_hScrollState.eMouseDownArea.eArea != eNone) {
-            m_hScrollState.eMouseOverArea.eArea = (area == m_hScrollState.eMouseDownArea.eArea) ? area : eNone;
+            if (state.bDragging) {
+                state.eMouseOverArea.eArea = area;
+            } else if (state.eMouseDownArea.eArea != eNone) {
+                state.eMouseOverArea.eArea = (area == state.eMouseDownArea.eArea) ? area : eNone;
+            } else {
+                state.eMouseOverArea.eArea = area;
+            }
+
+            // Only clear ignore flag if mouse actually changed areas
+            if (oldArea != state.eMouseOverArea.eArea) {
+                state.bIgnoreNextLeave = false;
+            }
         } else {
-            m_hScrollState.eMouseOverArea.eArea = area;
+            state.eMouseOverArea.eArea = eNone;
+            // Mouse moved outside scrollbar - clear flag
+            state.bIgnoreNextLeave = false;
         }
-    } else {
-        m_hScrollState.eMouseOverArea.eArea = eNone;
-    }
+    };
+
+    updateScrollBarState(m_vScrollState, bHasVScroll, vScrollRect, true);
+    updateScrollBarState(m_hScrollState, bHasHScroll, hScrollRect, false);
 }
 
 void CMPCThemeScrollBarRenderer::OnNcLButtonDown(HWND hWnd, WPARAM wParam, LPARAM lParam) {
@@ -656,6 +656,7 @@ void CMPCThemeScrollBarRenderer::OnNcLButtonDown(HWND hWnd, WPARAM wParam, LPARA
         if (m_vScrollState.eMouseDownArea.IsThumb()) {
             m_vScrollState.bDragging = true;
         }
+        m_vScrollState.bIgnoreNextLeave = true;
         InstallMouseHook(hWnd);
     }
 
@@ -664,6 +665,7 @@ void CMPCThemeScrollBarRenderer::OnNcLButtonDown(HWND hWnd, WPARAM wParam, LPARA
         if (m_hScrollState.eMouseDownArea.IsThumb()) {
             m_hScrollState.bDragging = true;
         }
+        m_hScrollState.bIgnoreNextLeave = true;
         InstallMouseHook(hWnd);
     }
 }
@@ -678,6 +680,20 @@ void CMPCThemeScrollBarRenderer::OnNcLButtonUp(HWND hWnd, WPARAM wParam, LPARAM 
 }
 
 void CMPCThemeScrollBarRenderer::OnNcMouseLeave(HWND hWnd) {
+    // CRITICAL FIX: Ignore first spurious leave after button down
+    // Windows sends WM_NCMOUSELEAVE immediately when auto-repeat starts (horizontal scrollbar)
+    // Clear flag after ignoring to handle subsequent real leave events
+    if (m_vScrollState.bIgnoreNextLeave) {
+        m_vScrollState.bIgnoreNextLeave = false;
+        return;
+    }
+
+    if (m_hScrollState.bIgnoreNextLeave) {
+        m_hScrollState.bIgnoreNextLeave = false;
+        return;
+    }
+
+    // Mouse really left - clear over state
     m_vScrollState.eMouseOverArea.eArea = eNone;
     m_hScrollState.eMouseOverArea.eArea = eNone;
 }

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -197,17 +197,17 @@ inline bool CMPCThemeScrollBarRenderer::GetClippedScrollBarRects(HWND hWnd, HDC 
     return true;
 }
 
-BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, HRGN& hOldClipRgn, bool bDrawThemedScrollbars) {
-    hOldClipRgn = NULL;
+CMPCThemeScrollBarRenderer::ClipRegionState CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, bool bDrawThemedScrollbars) {
+    ClipRegionState clipState;
 
     if (m_bDrawingScrollbar) {
-        return TRUE;
+        return clipState;
     }
 
     CRect vScrollRect, hScrollRect;
     bool bHasVScroll, bHasHScroll, bNeedsCorner;
     if (!GetClippedScrollBarRects(hWnd, hdc, drawRect, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll, bNeedsCorner)) {
-        return TRUE;
+        return clipState;
     }
 
     if (bDrawThemedScrollbars) {
@@ -219,40 +219,52 @@ BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, cons
         m_bDrawingScrollbar = false;
     }
 
-    hOldClipRgn = CreateRectRgn(0, 0, 0, 0);
-    if (GetClipRgn(hdc, hOldClipRgn) <= 0) {
-        DeleteObject(hOldClipRgn);
-        hOldClipRgn = NULL;
+    clipState.bModifiedDC = true;
+
+    clipState.hOldClipRgn = CreateRectRgn(0, 0, 0, 0);
+    int getClipResult = GetClipRgn(hdc, clipState.hOldClipRgn);
+    if (getClipResult <= 0) {
+        DeleteObject(clipState.hOldClipRgn);
+        clipState.hOldClipRgn = NULL;
     }
 
     auto excludeScrollbar = [&](const CRect& rect) -> bool {
         int result = ExcludeClipRect(hdc, rect.left, rect.top, rect.right, rect.bottom);
         if (result == NULLREGION || result == ERROR) {
-            if (hOldClipRgn) {
-                DeleteObject(hOldClipRgn);
-                hOldClipRgn = NULL;
+            if (clipState.hOldClipRgn) {
+                DeleteObject(clipState.hOldClipRgn);
+                clipState.hOldClipRgn = NULL;
             }
+            clipState.bFullyClipped = true;
             return false;
         }
         return true;
     };
 
     if (bHasVScroll && !excludeScrollbar(vScrollRect)) {
-        return FALSE;
+        return clipState;
     }
     if (bHasHScroll && !excludeScrollbar(hScrollRect)) {
-        return FALSE;
+        return clipState;
     }
 
-    return TRUE;
+    return clipState;
 }
 
-void CMPCThemeScrollBarRenderer::RestoreClipping(HDC hdc, HRGN hOldClipRgn) {
-    SelectClipRgn(hdc, hOldClipRgn);
-    if (hOldClipRgn) {
-        DeleteObject(hOldClipRgn);
+void CMPCThemeScrollBarRenderer::RestoreClipping(HDC hdc, ClipRegionState& clipState) {
+    if (!clipState.bModifiedDC) {
+        return;
+    }
+    
+    if (clipState.hOldClipRgn == NULL) {
+        SelectClipRgn(hdc, NULL);
+    } else {
+        SelectClipRgn(hdc, clipState.hOldClipRgn);
+        DeleteObject(clipState.hOldClipRgn);
     }
 }
+
+
 
 void CMPCThemeScrollBarRenderer::drawSBArrow(CDC& dc, COLORREF arrowClr, CRect arrowRect, arrowOrientation orientation, int dpi) {
     Gdiplus::Graphics gfx(dc.m_hDC);

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -728,14 +728,14 @@ void CMPCThemeScrollBarRenderer::HandleNcPaint(HWND hWnd) {
 
     dc.RestoreDC(oldDC);
 
-    if (bHasVScroll || bHasHScroll) {
-        //this code is called with fMask=0, which should do nothing, but it triggers themed code that sets SB state
-        //if we draw directly, we fail to reset the SB state which can cause the internal hover detection to fail
-        //use case: switch between property pages and the scrollbar hover stops working
-        SCROLLINFO si = { sizeof(SCROLLINFO) };
-        ::GetScrollInfo(hWnd, SB_HORZ, &si);
+    //we force the draw to go through the native path, so that the hover states are property updated
+    //note, the fMask is zero -- it doesn't actually change any scroll info
+    if (bHasVScroll) {
+        SCROLLINFO si = { sizeof(SCROLLINFO), 0 };
+        ::SetScrollInfo(hWnd, SB_VERT, &si, false);
+    }
+    if (bHasHScroll) {
+        SCROLLINFO si = { sizeof(SCROLLINFO), 0 };
         ::SetScrollInfo(hWnd, SB_HORZ, &si, false);
-
-        DrawThemedScrollBars(&dc, hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll);
     }
 }

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -26,6 +26,9 @@ void CMPCThemeScrollBarRenderer::ProcessMessage(HWND hWnd, UINT message, WPARAM 
     case WM_NCLBUTTONDOWN:
         OnNcLButtonDown(hWnd, wParam, lParam);
         break;
+    case WM_NCLBUTTONDBLCLK:
+        OnNcLButtonDown(hWnd, wParam, lParam);
+        break;
     case WM_NCLBUTTONUP:
         OnNcLButtonUp(hWnd, wParam, lParam);
         break;
@@ -86,7 +89,6 @@ void CMPCThemeScrollBarRenderer::HandleMouseEvent(WPARAM wParam, const POINT& pt
         ProcessMessage(m_hWndTracking, WM_NCMOUSEMOVE, 0, lParam);
         break;
     }
-
     case WM_LBUTTONUP: {
         ProcessMessage(m_hWndTracking, WM_NCLBUTTONUP, 0, lParam);
         break;

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -522,7 +522,9 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
         rectThumb.SetRectEmpty();
         rectTLChannel.SetRectEmpty();
         rectBRChannel.SetRectEmpty();
-        if (pbEnabled) *pbEnabled = false;
+        if (pbEnabled) {
+            *pbEnabled = false;
+        }
         return;
     }
 
@@ -534,8 +536,11 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
         }
         *pbEnabled = bEnabled;
     }
+
     bool bHorizontal = (nBar == SB_HORZ);
     UINT uArrowWH = bHorizontal ? scrollRect.Height() : scrollRect.Width();
+
+    // Use system scrollbar width as minimum thumb size (matches Windows 10)
     UINT uThumbMinHW = GetSystemMetrics(SM_CXVSCROLL);
 
     if (bHorizontal) {
@@ -547,16 +552,18 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
 
         int cxChannel = cxClient - (2 * cxArrow);
         int nRange = si.nMax - si.nMin + 1;
-        if (nRange > 0 && cxChannel > (int)uThumbMinHW) {
-            double dblPx_SU = (double)cxChannel / (double)nRange;
-            int xThumb = (int)((si.nPos - si.nMin) * dblPx_SU);
-            int cxThumb = std::max((int)uThumbMinHW, (int)(si.nPage * dblPx_SU));
 
-            if (cxThumb > cxChannel) {
-                cxThumb = cxChannel;
-            }
-            if (xThumb + cxThumb > cxChannel) {
-                xThumb = cxChannel - cxThumb;
+        if (nRange > 0 && cxChannel > (int)uThumbMinHW) {
+            // Calculate thumb size
+            int cxThumb = std::clamp(MulDiv(cxChannel, si.nPage, nRange), (int)uThumbMinHW, cxChannel);
+
+            // Calculate thumb position based on available movement range
+            int movementRange = cxChannel - cxThumb;
+            int scrollRange = nRange - si.nPage;
+
+            int xThumb = 0;
+            if (scrollRange > 0) {
+                xThumb = MulDiv(movementRange, si.nPos - si.nMin, scrollRange);
             }
 
             xThumb += rectTLArrow.right;
@@ -578,16 +585,18 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
 
         int cyChannel = cyClient - (2 * cyArrow);
         int nRange = si.nMax - si.nMin + 1;
-        if (nRange > 0 && cyChannel > (int)uThumbMinHW) {
-            double dblPx_SU = (double)cyChannel / (double)nRange;
-            int yThumb = (int)((si.nPos - si.nMin) * dblPx_SU);
-            int cyThumb = std::max((int)uThumbMinHW, (int)(si.nPage * dblPx_SU));
 
-            if (cyThumb > cyChannel) {
-                cyThumb = cyChannel;
-            }
-            if (yThumb + cyThumb > cyChannel) {
-                yThumb = cyChannel - cyThumb;
+        if (nRange > 0 && cyChannel > (int)uThumbMinHW) {
+            // Calculate thumb size
+            int cyThumb = std::clamp(MulDiv(cyChannel, si.nPage, nRange), (int)uThumbMinHW, cyChannel);
+
+            // Calculate thumb position based on available movement range
+            int movementRange = cyChannel - cyThumb;
+            int scrollRange = nRange - si.nPage;
+
+            int yThumb = 0;
+            if (scrollRange > 0) {
+                yThumb = MulDiv(movementRange, si.nPos - si.nMin, scrollRange);
             }
 
             yThumb += rectTLArrow.bottom;

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -178,6 +178,24 @@ void CMPCThemeScrollBarRenderer::DrawScrollBarCorner(CDC* pDC, HWND hWnd, const 
     pDC->FillRect(cornerRect, &brushCorner);
 }
 
+inline bool CMPCThemeScrollBarRenderer::GetClippedScrollBarRects(HWND hWnd, HDC hdc, const CRect& drawRect, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll) {
+    CRect clipBox, effectiveDrawRect, dummy;
+    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+        return false;
+    }
+
+    GetClipBox(hdc, &clipBox);
+    if (!effectiveDrawRect.IntersectRect(&drawRect, &clipBox)) {
+        bHasVScroll = bHasHScroll = false;
+        return true;
+    }
+
+    bHasVScroll = bHasVScroll && dummy.IntersectRect(&effectiveDrawRect, &vScrollRect);
+    bHasHScroll = bHasHScroll && dummy.IntersectRect(&effectiveDrawRect, &hScrollRect);
+
+    return true;
+}
+
 BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, HRGN& hOldClipRgn, bool bDrawThemedScrollbars) {
     hOldClipRgn = NULL;
 
@@ -187,31 +205,17 @@ BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, cons
 
     CRect vScrollRect, hScrollRect;
     bool bHasVScroll, bHasHScroll;
-    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
-        return TRUE;
-    }
-
-    CRect vIntersect, hIntersect;
-    BOOL bIntersectsV = bHasVScroll && vIntersect.IntersectRect(&drawRect, &vScrollRect);
-    BOOL bIntersectsH = bHasHScroll && hIntersect.IntersectRect(&drawRect, &hScrollRect);
-    if (!bIntersectsV && !bIntersectsH) {
+    if (!GetClippedScrollBarRects(hWnd, hdc, drawRect, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
         return TRUE;
     }
 
     if (bDrawThemedScrollbars) {
         m_bDrawingScrollbar = true;
-
         CDC* pDC = CDC::FromHandle(hdc);
         if (pDC) {
             DrawThemedScrollBars(pDC, hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll);
         }
-
         m_bDrawingScrollbar = false;
-    }
-
-    CRect excludeRect = bIntersectsV ? vScrollRect : hScrollRect;
-    if (bIntersectsV && bIntersectsH) {
-        excludeRect.UnionRect(&vScrollRect, &hScrollRect);
     }
 
     hOldClipRgn = CreateRectRgn(0, 0, 0, 0);
@@ -220,34 +224,25 @@ BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, cons
         hOldClipRgn = NULL;
     }
 
-    HRGN hDrawRgn = CreateRectRgn(drawRect.left, drawRect.top, drawRect.right, drawRect.bottom);
-    HRGN hExcludeRgn = CreateRectRgn(excludeRect.left, excludeRect.top, excludeRect.right, excludeRect.bottom);
-    HRGN hFinalRgn = CreateRectRgn(0, 0, 0, 0);
-
-    auto cleanup = [&](BOOL deleteOldRgn) {
-        DeleteObject(hFinalRgn);
-        DeleteObject(hExcludeRgn);
-        DeleteObject(hDrawRgn);
-        if (deleteOldRgn && hOldClipRgn) {
-            DeleteObject(hOldClipRgn);
-            hOldClipRgn = NULL;
+    auto excludeScrollbar = [&](const CRect& rect) -> bool {
+        int result = ExcludeClipRect(hdc, rect.left, rect.top, rect.right, rect.bottom);
+        if (result == NULLREGION || result == ERROR) {
+            if (hOldClipRgn) {
+                DeleteObject(hOldClipRgn);
+                hOldClipRgn = NULL;
+            }
+            return false;
         }
+        return true;
     };
 
-    if (!hDrawRgn || !hExcludeRgn || !hFinalRgn) {
-        cleanup(TRUE);
-        return TRUE;
+    if (bHasVScroll && !excludeScrollbar(vScrollRect)) {
+        return FALSE;
     }
-
-    int result = CombineRgn(hFinalRgn, hDrawRgn, hExcludeRgn, RGN_DIFF);
-
-    if (result == NULLREGION || result == ERROR) {
-        cleanup(TRUE);
+    if (bHasHScroll && !excludeScrollbar(hScrollRect)) {
         return FALSE;
     }
 
-    SelectClipRgn(hdc, hFinalRgn);
-    cleanup(FALSE);
     return TRUE;
 }
 

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -18,6 +18,14 @@ CMPCThemeScrollBarRenderer::~CMPCThemeScrollBarRenderer() {
     UninstallMouseHook();
 }
 
+static bool ScreenToNcClient(HWND hWnd, CPoint& point) {
+    if (!::ScreenToClient(hWnd, &point)) {
+        return false;
+    }
+    point += CMPCThemeUtil::GetClientRectOffset(CWnd::FromHandlePermanent(hWnd));
+    return true;
+}
+
 void CMPCThemeScrollBarRenderer::ProcessMessage(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
     switch (message) {
     case WM_NCMOUSEMOVE:
@@ -622,7 +630,7 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
 
 void CMPCThemeScrollBarRenderer::OnNcMouseMove(HWND hWnd, WPARAM wParam, LPARAM lParam) {
     CPoint point(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
-    ::ScreenToClient(hWnd, &point);
+    ScreenToNcClient(hWnd, point);
 
     CRect vScrollRect, hScrollRect;
     bool bHasVScroll, bHasHScroll;
@@ -660,7 +668,7 @@ void CMPCThemeScrollBarRenderer::OnNcMouseMove(HWND hWnd, WPARAM wParam, LPARAM 
 
 void CMPCThemeScrollBarRenderer::OnNcLButtonDown(HWND hWnd, WPARAM wParam, LPARAM lParam) {
     CPoint point(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
-    ::ScreenToClient(hWnd, &point);
+    ScreenToNcClient(hWnd, point);
 
     CRect vScrollRect, hScrollRect;
     bool bHasVScroll, bHasHScroll;

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -1,0 +1,689 @@
+#include "stdafx.h"
+#include "CMPCThemeScrollBarRenderer.h"
+#include "CMPCTheme.h"
+#include "CMPCThemeUtil.h"
+#include "DpiHelper.h"
+#include <gdiplus.h>
+
+CMPCThemeScrollBarRenderer* CMPCThemeScrollBarRenderer::s_pActiveRenderer = nullptr;
+
+CMPCThemeScrollBarRenderer::CMPCThemeScrollBarRenderer()
+    : m_bDrawingScrollbar(false)
+    , m_hMouseHook(NULL)
+    , m_hWndTracking(NULL)
+    , m_dwThreadId(0) {
+}
+
+CMPCThemeScrollBarRenderer::~CMPCThemeScrollBarRenderer() {
+    UninstallMouseHook();
+}
+
+void CMPCThemeScrollBarRenderer::ProcessMessage(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
+    switch (message) {
+    case WM_NCMOUSEMOVE:
+        OnNcMouseMove(hWnd, wParam, lParam);
+        break;
+    case WM_NCLBUTTONDOWN:
+        OnNcLButtonDown(hWnd, wParam, lParam);
+        break;
+    case WM_NCLBUTTONUP:
+        OnNcLButtonUp(hWnd, wParam, lParam);
+        break;
+    case WM_NCMOUSELEAVE:
+        OnNcMouseLeave(hWnd);
+        break;
+    }
+}
+
+void CMPCThemeScrollBarRenderer::InstallMouseHook(HWND hWnd) {
+    if (m_hMouseHook != NULL) {
+        return;
+    }
+
+    m_hWndTracking = hWnd;
+    m_dwThreadId = GetWindowThreadProcessId(hWnd, NULL);
+    s_pActiveRenderer = this;
+
+    m_hMouseHook = SetWindowsHookExW(WH_MOUSE, MouseProc, NULL, m_dwThreadId);
+
+    if (m_hMouseHook == NULL) {
+        TRACE(L"Failed to install mouse hook: %d\n", GetLastError());
+    }
+}
+
+void CMPCThemeScrollBarRenderer::UninstallMouseHook() {
+    if (m_hMouseHook != NULL) {
+        UnhookWindowsHookEx(m_hMouseHook);
+        m_hMouseHook = NULL;
+    }
+
+    if (s_pActiveRenderer == this) {
+        s_pActiveRenderer = nullptr;
+    }
+
+    m_hWndTracking = NULL;
+    m_dwThreadId = 0;
+}
+
+LRESULT CALLBACK CMPCThemeScrollBarRenderer::MouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode >= 0 && s_pActiveRenderer != nullptr) {
+        MOUSEHOOKSTRUCT* pMouseStruct = (MOUSEHOOKSTRUCT*)lParam;
+        s_pActiveRenderer->HandleMouseEvent(wParam, pMouseStruct->pt);
+    }
+
+    return CallNextHookEx(NULL, nCode, wParam, lParam);
+}
+
+void CMPCThemeScrollBarRenderer::HandleMouseEvent(WPARAM wParam, const POINT& pt) {
+    if (m_hWndTracking == NULL || !::IsWindow(m_hWndTracking)) {
+        return;
+    }
+
+    LPARAM lParam = MAKELPARAM(pt.x, pt.y);
+
+    switch (wParam) {
+    case WM_MOUSEMOVE: {
+        ProcessMessage(m_hWndTracking, WM_NCMOUSEMOVE, 0, lParam);
+        break;
+    }
+
+    case WM_LBUTTONUP: {
+        ProcessMessage(m_hWndTracking, WM_NCLBUTTONUP, 0, lParam);
+        break;
+    }
+    }
+}
+
+BOOL CMPCThemeScrollBarRenderer::GetScrollBarRect(HWND hWnd, BOOL bVertical, CRect& rect) {
+    if (!hWnd) {
+        return FALSE;
+    }
+
+    SCROLLBARINFO sbi = { 0 };
+    sbi.cbSize = sizeof(SCROLLBARINFO);
+    if (!GetScrollBarInfo(hWnd, bVertical ? OBJID_VSCROLL : OBJID_HSCROLL, &sbi)) {
+        return FALSE;
+    }
+
+    if (sbi.rgstate[0] & STATE_SYSTEM_INVISIBLE || sbi.rgstate[0] & STATE_SYSTEM_UNAVAILABLE) {
+        return FALSE;
+    }
+
+    rect = sbi.rcScrollBar;
+    MapWindowPoints(HWND_DESKTOP, hWnd, (LPPOINT)&rect, 2);
+    CPoint offset = CMPCThemeUtil::GetClientRectOffset(CWnd::FromHandlePermanent(hWnd));
+    rect += offset;
+    return TRUE;
+}
+
+bool CMPCThemeScrollBarRenderer::GetScrollBarRects(HWND hWnd, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll) {
+    bHasVScroll = GetScrollBarRect(hWnd, TRUE, vScrollRect);
+    bHasHScroll = GetScrollBarRect(hWnd, FALSE, hScrollRect);
+    return bHasVScroll || bHasHScroll;
+}
+
+bool CMPCThemeScrollBarRenderer::GetScrollBarCornerRect(HWND hWnd, CRect& cornerRect) {
+    cornerRect.SetRectEmpty();
+
+    if (!hWnd || !::IsWindow(hWnd)) {
+        return false;
+    }
+
+    CWnd* pWnd = CWnd::FromHandlePermanent(hWnd);
+    if (!pWnd) {
+        return false;
+    }
+
+    CRect vScrollRect, hScrollRect;
+    bool bHasVScroll, bHasHScroll;
+    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+        return false;
+    }
+
+    if (!bHasVScroll || !bHasHScroll) {
+        return false;
+    }
+
+    CRect wr;
+    pWnd->GetWindowRect(wr);
+    wr.OffsetRect(-wr.left, -wr.top);
+
+    int sbThickness = GetSystemMetrics(SM_CXVSCROLL);
+    CPoint clientOffset = CMPCThemeUtil::GetClientRectOffset(pWnd);
+    int borderThickness = clientOffset.x;
+
+    if (sbThickness >= wr.Width() - borderThickness * 2 || sbThickness >= wr.Height() - borderThickness * 2) {
+        return false;
+    }
+
+    if (CMPCThemeUtil::IsRTL(pWnd)) {
+        cornerRect = CRect(wr.left + borderThickness, wr.bottom - sbThickness - borderThickness, wr.left + sbThickness + borderThickness, wr.bottom - borderThickness);
+    } else {
+        cornerRect = CRect(wr.right - sbThickness - borderThickness, wr.bottom - sbThickness - borderThickness, wr.right - borderThickness, wr.bottom - borderThickness);
+    }
+
+    return true;
+}
+
+void CMPCThemeScrollBarRenderer::DrawScrollBarCorner(CDC* pDC, HWND hWnd, const CRect& cornerRect) {
+    if (cornerRect.IsRectEmpty()) {
+        return;
+    }
+
+    CBrush brushCorner(CMPCTheme::ContentBGColor);
+    pDC->FillRect(cornerRect, &brushCorner);
+}
+
+BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, HRGN& hOldClipRgn, bool bDrawThemedScrollbars) {
+    hOldClipRgn = NULL;
+
+    if (m_bDrawingScrollbar) {
+        return TRUE;
+    }
+
+    CRect vScrollRect, hScrollRect;
+    bool bHasVScroll, bHasHScroll;
+    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+        return TRUE;
+    }
+
+    CRect vIntersect, hIntersect;
+    BOOL bIntersectsV = bHasVScroll && vIntersect.IntersectRect(&drawRect, &vScrollRect);
+    BOOL bIntersectsH = bHasHScroll && hIntersect.IntersectRect(&drawRect, &hScrollRect);
+    if (!bIntersectsV && !bIntersectsH) {
+        return TRUE;
+    }
+
+    if (bDrawThemedScrollbars) {
+        m_bDrawingScrollbar = true;
+
+        CDC* pDC = CDC::FromHandle(hdc);
+        if (pDC) {
+            DrawThemedScrollBars(pDC, hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll);
+        }
+
+        m_bDrawingScrollbar = false;
+    }
+
+    CRect excludeRect = bIntersectsV ? vScrollRect : hScrollRect;
+    if (bIntersectsV && bIntersectsH) {
+        excludeRect.UnionRect(&vScrollRect, &hScrollRect);
+    }
+
+    hOldClipRgn = CreateRectRgn(0, 0, 0, 0);
+    if (GetClipRgn(hdc, hOldClipRgn) <= 0) {
+        DeleteObject(hOldClipRgn);
+        hOldClipRgn = NULL;
+    }
+
+    HRGN hDrawRgn = CreateRectRgn(drawRect.left, drawRect.top, drawRect.right, drawRect.bottom);
+    HRGN hExcludeRgn = CreateRectRgn(excludeRect.left, excludeRect.top, excludeRect.right, excludeRect.bottom);
+    HRGN hFinalRgn = CreateRectRgn(0, 0, 0, 0);
+
+    auto cleanup = [&](BOOL deleteOldRgn) {
+        DeleteObject(hFinalRgn);
+        DeleteObject(hExcludeRgn);
+        DeleteObject(hDrawRgn);
+        if (deleteOldRgn && hOldClipRgn) {
+            DeleteObject(hOldClipRgn);
+            hOldClipRgn = NULL;
+        }
+    };
+
+    if (!hDrawRgn || !hExcludeRgn || !hFinalRgn) {
+        cleanup(TRUE);
+        return TRUE;
+    }
+
+    int result = CombineRgn(hFinalRgn, hDrawRgn, hExcludeRgn, RGN_DIFF);
+
+    if (result == NULLREGION || result == ERROR) {
+        cleanup(TRUE);
+        return FALSE;
+    }
+
+    SelectClipRgn(hdc, hFinalRgn);
+    cleanup(FALSE);
+    return TRUE;
+}
+
+void CMPCThemeScrollBarRenderer::RestoreClipping(HDC hdc, HRGN hOldClipRgn) {
+    SelectClipRgn(hdc, hOldClipRgn);
+    if (hOldClipRgn) {
+        DeleteObject(hOldClipRgn);
+    }
+}
+
+void CMPCThemeScrollBarRenderer::drawSBArrow(CDC& dc, COLORREF arrowClr, CRect arrowRect, arrowOrientation orientation, int dpi) {
+    Gdiplus::Graphics gfx(dc.m_hDC);
+    Gdiplus::Color clr;
+    clr.SetFromCOLORREF(arrowClr);
+
+    int xPos;
+    int yPos;
+    int xsign, ysign;
+    int rows, steps;
+
+    if (dpi < 120) {
+        rows = 3;
+        steps = 3;
+    } else if (dpi < 144) {
+        rows = 3;
+        steps = 4;
+    } else if (dpi < 168) {
+        rows = 4;
+        steps = 5;
+    } else if (dpi < 192) {
+        rows = 4;
+        steps = 5;
+    } else {
+        rows = 4;
+        steps = 5;
+    }
+
+    float shortDim = steps + rows;
+    int indent;
+    switch (orientation) {
+    case arrowLeft:
+        indent = ceil((arrowRect.Width() - shortDim) / 2);
+        xPos = arrowRect.right - indent - 1;
+        yPos = arrowRect.top + (arrowRect.Height() - (steps * 2 + 1)) / 2;
+        xsign = -1;
+        ysign = 1;
+        break;
+    case arrowRight:
+        indent = ceil((arrowRect.Width() - shortDim) / 2);
+        yPos = arrowRect.top + (arrowRect.Height() - (steps * 2 + 1)) / 2;
+        xPos = arrowRect.left + indent;
+        xsign = 1;
+        ysign = 1;
+        break;
+    case arrowTop:
+        xPos = arrowRect.left + (arrowRect.Width() - (steps * 2 + 1)) / 2;
+        indent = ceil((arrowRect.Height() - shortDim) / 2);
+        yPos = arrowRect.top + indent + shortDim - 1;
+        xsign = 1;
+        ysign = -1;
+        break;
+    case arrowBottom:
+    default:
+        xPos = arrowRect.left + (arrowRect.Width() - (steps * 2 + 1)) / 2;
+        indent = ceil((arrowRect.Height() - shortDim) / 2);
+        yPos = arrowRect.top + indent;
+        xsign = 1;
+        ysign = 1;
+        break;
+    }
+
+    gfx.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+    Gdiplus::Pen pen(clr, 1);
+    for (int i = 0; i < rows; i++) {
+        if (orientation == arrowLeft || orientation == arrowRight) {
+            gfx.DrawLine(&pen, xPos + i * xsign, yPos, xPos + (steps + i) * xsign, steps * ysign + yPos);
+            gfx.DrawLine(&pen, xPos + (steps + i) * xsign, steps * ysign + yPos, xPos + i * xsign, (steps * 2) * ysign + yPos);
+        } else {
+            gfx.DrawLine(&pen, xPos, yPos + i * ysign, steps * xsign + xPos, yPos + (steps + i) * ysign);
+            gfx.DrawLine(&pen, steps * xsign + xPos, yPos + (steps + i) * ysign, (steps * 2) * xsign + xPos, yPos + i * ysign);
+        }
+    }
+}
+
+void CMPCThemeScrollBarRenderer::DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, const CRect& targetRect, bool bEnabled) {
+    DpiHelper dpiWindow;
+    dpiWindow.Override(hWnd);
+    int nDPI = dpiWindow.DPIX();
+
+    bool bHorizontal = (nBar == SB_HORZ);
+    ScrollBarState& state = bHorizontal ? m_hScrollState : m_vScrollState;
+
+    CRect rectTLArrow, rectBRArrow, rectThumb, rectTLChannel, rectBRChannel;
+    CalculateScrollBarRects(hWnd, nBar, targetRect, rectTLArrow, rectBRArrow, rectThumb, rectTLChannel, rectBRChannel);
+
+    int xOffset = targetRect.left;
+    int yOffset = targetRect.top;
+
+    CDC dcMem;
+    dcMem.CreateCompatibleDC(pDC);
+    CBitmap bmMem;
+    bmMem.CreateCompatibleBitmap(pDC, targetRect.Width(), targetRect.Height());
+    CBitmap* pOldBm = dcMem.SelectObject(&bmMem);
+
+    CBrush brushBG(CMPCTheme::ScrollBGColor);
+    CRect memRect(0, 0, targetRect.Width(), targetRect.Height());
+    dcMem.FillRect(memRect, &brushBG);
+
+    CBrush brushChannel(CMPCTheme::ScrollBGColor);
+
+    XSB_EDRAWELEM eState;
+    stXSB_AREA stArea;
+
+    for (int nElem = eTLbutton; nElem <= eThumb; nElem++) {
+        stArea.eArea = (eXSB_AREA)nElem;
+
+        const CRect* prcElem = nullptr;
+        eState = eNotDrawn;
+
+        switch (stArea.eArea) {
+        case eTLbutton:
+            prcElem = &rectTLArrow;
+            break;
+        case eBRbutton:
+            prcElem = &rectBRArrow;
+            break;
+        case eTLchannel:
+            prcElem = &rectTLChannel;
+            break;
+        case eBRchannel:
+            prcElem = &rectBRChannel;
+            break;
+        case eThumb:
+            prcElem = &rectThumb;
+            break;
+        }
+
+        if (!prcElem || prcElem->IsRectEmpty()) {
+            continue;
+        }
+
+        XSB_EDRAWELEM eState;
+        if (!bEnabled) {
+            eState = eDisabled;
+        } else if (state.bDragging && stArea.IsThumb()) {
+            eState = eDown;
+        } else if (state.eMouseDownArea.eArea == stArea.eArea && state.eMouseOverArea.eArea == stArea.eArea) {
+            eState = eDown;
+        } else if (state.eMouseOverArea.eArea == stArea.eArea && !state.bDragging) {
+            eState = eHot;
+        } else {
+            eState = eNormal;
+        }
+
+        CRect butRect = *prcElem;
+        butRect.OffsetRect(-xOffset, -yOffset);
+
+        if (bHorizontal) {
+            butRect.top += 1;
+            butRect.bottom -= 1;
+        } else {
+            butRect.left += 1;
+            butRect.right -= 1;
+        }
+
+        if (stArea.IsButton()) {
+            CBrush brushButton;
+            COLORREF buttonClr = RGB(0, 0, 0);
+            COLORREF buttonFGClr = CMPCTheme::ScrollButtonArrowColor;
+            switch (eState) {
+            case eDisabled:
+                buttonClr = CMPCTheme::ScrollBGColor;
+                break;
+            case eNormal:
+                buttonClr = CMPCTheme::ScrollBGColor;
+                break;
+            case eDown:
+                buttonClr = CMPCTheme::ScrollButtonClickColor;
+                buttonFGClr = CMPCTheme::ScrollButtonArrowClickColor;
+                break;
+            case eHot:
+                buttonClr = CMPCTheme::ScrollButtonHoverColor;
+                break;
+            default:
+                ASSERT(FALSE);
+            }
+            brushButton.CreateSolidBrush(buttonClr);
+            dcMem.FillRect(butRect, &brushButton);
+            brushButton.DeleteObject();
+
+            if (bHorizontal) {
+                if (nElem == eTLbutton) {
+                    drawSBArrow(dcMem, buttonFGClr, butRect, arrowOrientation::arrowLeft, nDPI);
+                } else {
+                    drawSBArrow(dcMem, buttonFGClr, butRect, arrowOrientation::arrowRight, nDPI);
+                }
+            } else {
+                if (nElem == eTLbutton) {
+                    drawSBArrow(dcMem, buttonFGClr, butRect, arrowOrientation::arrowTop, nDPI);
+                } else {
+                    drawSBArrow(dcMem, buttonFGClr, butRect, arrowOrientation::arrowBottom, nDPI);
+                }
+            }
+        } else if (stArea.IsChannel()) {
+            dcMem.FillRect(butRect, &brushChannel);
+        } else {
+            CBrush brushThumb;
+            switch (eState) {
+            case eDisabled:
+                brushThumb.CreateSolidBrush(CMPCTheme::ScrollBGColor);
+                break;
+            case eNormal:
+                brushThumb.CreateSolidBrush(CMPCTheme::ScrollThumbColor);
+                break;
+            case eDown:
+                brushThumb.CreateSolidBrush(CMPCTheme::ScrollThumbDragColor);
+                break;
+            case eHot:
+                brushThumb.CreateSolidBrush(CMPCTheme::ScrollThumbHoverColor);
+                break;
+            default:
+                ASSERT(FALSE);
+            }
+            dcMem.FillRect(butRect, &brushThumb);
+            brushThumb.DeleteObject();
+        }
+    }
+
+    pDC->BitBlt(targetRect.left, targetRect.top, targetRect.Width(), targetRect.Height(), &dcMem, 0, 0, SRCCOPY);
+
+    dcMem.SelectObject(pOldBm);
+    bmMem.DeleteObject();
+}
+
+eXSB_AREA CMPCThemeScrollBarRenderer::GetScrollBarArea(HWND hWnd, CPoint clientPoint, bool bVertical, const CRect& scrollRect) {
+    if (!scrollRect.PtInRect(clientPoint)) {
+        return eNone;
+    }
+
+    CRect rectTLArrow, rectBRArrow, rectThumb, rectTLChannel, rectBRChannel;
+    int nBar = bVertical ? SB_VERT : SB_HORZ;
+    CalculateScrollBarRects(hWnd, nBar, scrollRect, rectTLArrow, rectBRArrow, rectThumb, rectTLChannel, rectBRChannel);
+
+    if (rectThumb.PtInRect(clientPoint)) {
+        return eThumb;
+    } else if (rectTLArrow.PtInRect(clientPoint)) {
+        return eTLbutton;
+    } else if (rectBRArrow.PtInRect(clientPoint)) {
+        return eBRbutton;
+    } else if (rectTLChannel.PtInRect(clientPoint)) {
+        return eTLchannel;
+    } else if (rectBRChannel.PtInRect(clientPoint)) {
+        return eBRchannel;
+    }
+
+    return eNone;
+}
+
+void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, const CRect& scrollRect,
+    CRect& rectTLArrow, CRect& rectBRArrow, CRect& rectThumb,
+    CRect& rectTLChannel, CRect& rectBRChannel) {
+    // Get scroll info
+    SCROLLINFO si = { 0 };
+    si.cbSize = sizeof(SCROLLINFO);
+    si.fMask = SIF_ALL;
+    if (!::GetScrollInfo(hWnd, nBar, &si)) {
+        rectTLArrow.SetRectEmpty();
+        rectBRArrow.SetRectEmpty();
+        rectThumb.SetRectEmpty();
+        rectTLChannel.SetRectEmpty();
+        rectBRChannel.SetRectEmpty();
+        return;
+    }
+
+    bool bHorizontal = (nBar == SB_HORZ);
+    bool bEnabled = ::IsWindowEnabled(hWnd);
+    UINT uArrowWH = bHorizontal ? scrollRect.Height() : scrollRect.Width();
+    UINT uThumbMinHW = 8;
+
+    if (bHorizontal) {
+        int cxClient = scrollRect.Width();
+        int cxArrow = std::min((int)uArrowWH, cxClient / 2);
+
+        rectTLArrow.SetRect(scrollRect.left, scrollRect.top, scrollRect.left + cxArrow, scrollRect.bottom);
+        rectBRArrow.SetRect(scrollRect.right - cxArrow, scrollRect.top, scrollRect.right, scrollRect.bottom);
+
+        int cxChannel = cxClient - (2 * cxArrow);
+        int nRange = si.nMax - si.nMin + 1;
+        if (nRange > 0 && cxChannel > (int)uThumbMinHW && bEnabled) {
+            double dblPx_SU = (double)cxChannel / (double)nRange;
+            int xThumb = (int)((si.nPos - si.nMin) * dblPx_SU);
+            int cxThumb = std::max((int)uThumbMinHW, (int)(si.nPage * dblPx_SU));
+
+            if (cxThumb > cxChannel) {
+                cxThumb = cxChannel;
+            }
+            if (xThumb + cxThumb > cxChannel) {
+                xThumb = cxChannel - cxThumb;
+            }
+
+            xThumb += rectTLArrow.right;
+            rectThumb.SetRect(xThumb, scrollRect.top, xThumb + cxThumb, scrollRect.bottom);
+
+            rectTLChannel.SetRect(rectTLArrow.right, scrollRect.top, rectThumb.left, scrollRect.bottom);
+            rectBRChannel.SetRect(rectThumb.right, scrollRect.top, rectBRArrow.left, scrollRect.bottom);
+        } else {
+            rectThumb.SetRectEmpty();
+            rectTLChannel.SetRect(rectTLArrow.right, scrollRect.top, rectBRArrow.left, scrollRect.bottom);
+            rectBRChannel.SetRectEmpty();
+        }
+    } else {
+        int cyClient = scrollRect.Height();
+        int cyArrow = std::min((int)uArrowWH, cyClient / 2);
+
+        rectTLArrow.SetRect(scrollRect.left, scrollRect.top, scrollRect.right, scrollRect.top + cyArrow);
+        rectBRArrow.SetRect(scrollRect.left, scrollRect.bottom - cyArrow, scrollRect.right, scrollRect.bottom);
+
+        int cyChannel = cyClient - (2 * cyArrow);
+        int nRange = si.nMax - si.nMin + 1;
+        if (nRange > 0 && cyChannel > (int)uThumbMinHW && bEnabled) {
+            double dblPx_SU = (double)cyChannel / (double)nRange;
+            int yThumb = (int)((si.nPos - si.nMin) * dblPx_SU);
+            int cyThumb = std::max((int)uThumbMinHW, (int)(si.nPage * dblPx_SU));
+
+            if (cyThumb > cyChannel) {
+                cyThumb = cyChannel;
+            }
+            if (yThumb + cyThumb > cyChannel) {
+                yThumb = cyChannel - cyThumb;
+            }
+
+            yThumb += rectTLArrow.bottom;
+            rectThumb.SetRect(scrollRect.left, yThumb, scrollRect.right, yThumb + cyThumb);
+
+            rectTLChannel.SetRect(scrollRect.left, rectTLArrow.bottom, scrollRect.right, rectThumb.top);
+            rectBRChannel.SetRect(scrollRect.left, rectThumb.bottom, scrollRect.right, rectBRArrow.top);
+        } else {
+            rectThumb.SetRectEmpty();
+            rectTLChannel.SetRect(scrollRect.left, rectTLArrow.bottom, scrollRect.right, rectBRArrow.top);
+            rectBRChannel.SetRectEmpty();
+        }
+    }
+}
+
+void CMPCThemeScrollBarRenderer::OnNcMouseMove(HWND hWnd, WPARAM wParam, LPARAM lParam) {
+    CPoint point(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
+    ::ScreenToClient(hWnd, &point);
+
+    CRect vScrollRect, hScrollRect;
+    bool bHasVScroll, bHasHScroll;
+    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+        return;
+    }
+
+    if (bHasVScroll && vScrollRect.PtInRect(point)) {
+        eXSB_AREA area = GetScrollBarArea(hWnd, point, true, vScrollRect);
+        if (m_vScrollState.bDragging) {
+            m_vScrollState.eMouseOverArea.eArea = area;
+        } else if (m_vScrollState.eMouseDownArea.eArea != eNone) {
+            m_vScrollState.eMouseOverArea.eArea = (area == m_vScrollState.eMouseDownArea.eArea) ? area : eNone;
+        } else {
+            m_vScrollState.eMouseOverArea.eArea = area;
+        }
+    } else {
+        m_vScrollState.eMouseOverArea.eArea = eNone;
+    }
+
+    if (bHasHScroll && hScrollRect.PtInRect(point)) {
+        eXSB_AREA area = GetScrollBarArea(hWnd, point, false, hScrollRect);
+        if (m_hScrollState.bDragging) {
+            m_hScrollState.eMouseOverArea.eArea = area;
+        } else if (m_hScrollState.eMouseDownArea.eArea != eNone) {
+            m_hScrollState.eMouseOverArea.eArea = (area == m_hScrollState.eMouseDownArea.eArea) ? area : eNone;
+        } else {
+            m_hScrollState.eMouseOverArea.eArea = area;
+        }
+    } else {
+        m_hScrollState.eMouseOverArea.eArea = eNone;
+    }
+}
+
+void CMPCThemeScrollBarRenderer::OnNcLButtonDown(HWND hWnd, WPARAM wParam, LPARAM lParam) {
+    CPoint point(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
+    ::ScreenToClient(hWnd, &point);
+
+    CRect vScrollRect, hScrollRect;
+    bool bHasVScroll, bHasHScroll;
+    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+        return;
+    }
+
+    if (bHasVScroll && vScrollRect.PtInRect(point)) {
+        m_vScrollState.eMouseDownArea = m_vScrollState.eMouseOverArea;
+        if (m_vScrollState.eMouseDownArea.IsThumb()) {
+            m_vScrollState.bDragging = true;
+        }
+        InstallMouseHook(hWnd);
+    }
+
+    if (bHasHScroll && hScrollRect.PtInRect(point)) {
+        m_hScrollState.eMouseDownArea = m_hScrollState.eMouseOverArea;
+        if (m_hScrollState.eMouseDownArea.IsThumb()) {
+            m_hScrollState.bDragging = true;
+        }
+        InstallMouseHook(hWnd);
+    }
+}
+
+void CMPCThemeScrollBarRenderer::OnNcLButtonUp(HWND hWnd, WPARAM wParam, LPARAM lParam) {
+    m_vScrollState.eMouseDownArea.eArea = eNone;
+    m_vScrollState.bDragging = false;
+    m_hScrollState.eMouseDownArea.eArea = eNone;
+    m_hScrollState.bDragging = false;
+
+    UninstallMouseHook();
+}
+
+void CMPCThemeScrollBarRenderer::OnNcMouseLeave(HWND hWnd) {
+    m_vScrollState.eMouseOverArea.eArea = eNone;
+    m_hScrollState.eMouseOverArea.eArea = eNone;
+}
+
+void CMPCThemeScrollBarRenderer::DrawThemedScrollBars(CDC* pDC, HWND hWnd,
+    const CRect& vScrollRect, const CRect& hScrollRect,
+    bool bHasVScroll, bool bHasHScroll) {
+    bool bEnabled = ::IsWindowEnabled(hWnd);
+
+    if (bHasVScroll && !vScrollRect.IsRectEmpty()) {
+        DrawScrollBar(pDC, hWnd, SB_VERT, vScrollRect, bEnabled);
+    }
+
+    if (bHasHScroll && !hScrollRect.IsRectEmpty()) {
+        DrawScrollBar(pDC, hWnd, SB_HORZ, hScrollRect, bEnabled);
+    }
+
+    // Draw corner if both scrollbars present
+    if (bHasVScroll && bHasHScroll) {
+        CRect cornerRect;
+        if (GetScrollBarCornerRect(hWnd, cornerRect)) {
+            DrawScrollBarCorner(pDC, hWnd, cornerRect);
+        }
+    }
+}

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -162,11 +162,7 @@ bool CMPCThemeScrollBarRenderer::GetScrollBarCornerRect(HWND hWnd, CRect& corner
         return false;
     }
 
-    if (CMPCThemeUtil::IsRTL(pWnd)) {
-        cornerRect = CRect(wr.left + borderThickness, wr.bottom - sbThickness - borderThickness, wr.left + sbThickness + borderThickness, wr.bottom - borderThickness);
-    } else {
-        cornerRect = CRect(wr.right - sbThickness - borderThickness, wr.bottom - sbThickness - borderThickness, wr.right - borderThickness, wr.bottom - borderThickness);
-    }
+    cornerRect = CRect(wr.right - sbThickness - borderThickness, wr.bottom - sbThickness - borderThickness, wr.right - borderThickness, wr.bottom - borderThickness);
 
     return true;
 }
@@ -351,6 +347,11 @@ void CMPCThemeScrollBarRenderer::DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, co
 
     CDC dcMem;
     dcMem.CreateCompatibleDC(pDC);
+    DWORD dwLayout = GetLayout(dcMem.m_hDC);
+    if (dwLayout != GDI_ERROR && (dwLayout & LAYOUT_RTL)) {
+        SetLayout(dcMem.m_hDC, dwLayout & ~LAYOUT_RTL);
+    }
+
     CBitmap bmMem;
     bmMem.CreateCompatibleBitmap(pDC, targetRect.Width(), targetRect.Height());
     CBitmap* pOldBm = dcMem.SelectObject(&bmMem);

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -536,7 +536,7 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
     }
     bool bHorizontal = (nBar == SB_HORZ);
     UINT uArrowWH = bHorizontal ? scrollRect.Height() : scrollRect.Width();
-    UINT uThumbMinHW = 8;
+    UINT uThumbMinHW = GetSystemMetrics(SM_CXVSCROLL);
 
     if (bHorizontal) {
         int cxClient = scrollRect.Width();

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -687,3 +687,38 @@ void CMPCThemeScrollBarRenderer::DrawThemedScrollBars(CDC* pDC, HWND hWnd,
         }
     }
 }
+
+void CMPCThemeScrollBarRenderer::HandleNcPaint(HWND hWnd) {
+    CWindowDC dc(CWnd::FromHandle(hWnd));
+    int oldDC = dc.SaveDC();
+
+    CRect wr;
+    ::GetWindowRect(hWnd, wr);
+    wr.OffsetRect(-wr.left, -wr.top);
+
+    CRect clip = wr;
+    CPoint clientOffset = CMPCThemeUtil::GetClientRectOffset(CWnd::FromHandle(hWnd));
+    clip.DeflateRect(clientOffset.x, clientOffset.x);
+    dc.ExcludeClipRect(clip);
+
+    CRect vScrollRect, hScrollRect;
+    bool bHasVScroll, bHasHScroll;
+    if (GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+        if (bHasVScroll) {
+            dc.ExcludeClipRect(vScrollRect);
+        }
+        if (bHasHScroll) {
+            dc.ExcludeClipRect(hScrollRect);
+        }
+    }
+
+    CBrush brush(CMPCTheme::WindowBorderColorLight);
+    dc.FillSolidRect(wr, CMPCTheme::ContentBGColor);
+    dc.FrameRect(wr, &brush);
+
+    dc.RestoreDC(oldDC);
+
+    if (bHasVScroll || bHasHScroll) {
+        DrawThemedScrollBars(&dc, hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll);
+    }
+}

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -178,20 +178,21 @@ void CMPCThemeScrollBarRenderer::DrawScrollBarCorner(CDC* pDC, HWND hWnd, const 
     pDC->FillRect(cornerRect, &brushCorner);
 }
 
-inline bool CMPCThemeScrollBarRenderer::GetClippedScrollBarRects(HWND hWnd, HDC hdc, const CRect& drawRect, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll) {
+inline bool CMPCThemeScrollBarRenderer::GetClippedScrollBarRects(HWND hWnd, HDC hdc, const CRect& drawRect, CRect& vScrollRect, CRect& hScrollRect, bool& bNeedsVScroll, bool& bNeedsHScroll, bool& bNeedsCorner) {
     CRect clipBox, effectiveDrawRect, dummy;
-    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+    if (!GetScrollBarRects(hWnd, vScrollRect, hScrollRect, bNeedsVScroll, bNeedsHScroll)) {
         return false;
     }
 
+    bNeedsCorner = bNeedsVScroll && bNeedsHScroll; //this is based on the presence of two scrollbars, not whether they will be rendered
     GetClipBox(hdc, &clipBox);
     if (!effectiveDrawRect.IntersectRect(&drawRect, &clipBox)) {
-        bHasVScroll = bHasHScroll = false;
+        bNeedsVScroll = bNeedsHScroll = false;
         return true;
     }
 
-    bHasVScroll = bHasVScroll && dummy.IntersectRect(&effectiveDrawRect, &vScrollRect);
-    bHasHScroll = bHasHScroll && dummy.IntersectRect(&effectiveDrawRect, &hScrollRect);
+    bNeedsVScroll = bNeedsVScroll && dummy.IntersectRect(&effectiveDrawRect, &vScrollRect);
+    bNeedsHScroll = bNeedsHScroll && dummy.IntersectRect(&effectiveDrawRect, &hScrollRect);
 
     return true;
 }
@@ -204,8 +205,8 @@ BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, cons
     }
 
     CRect vScrollRect, hScrollRect;
-    bool bHasVScroll, bHasHScroll;
-    if (!GetClippedScrollBarRects(hWnd, hdc, drawRect, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll)) {
+    bool bHasVScroll, bHasHScroll, bNeedsCorner;
+    if (!GetClippedScrollBarRects(hWnd, hdc, drawRect, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll, bNeedsCorner)) {
         return TRUE;
     }
 
@@ -213,7 +214,7 @@ BOOL CMPCThemeScrollBarRenderer::ApplyScrollbarClipping(HDC hdc, HWND hWnd, cons
         m_bDrawingScrollbar = true;
         CDC* pDC = CDC::FromHandle(hdc);
         if (pDC) {
-            DrawThemedScrollBars(pDC, hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll);
+            DrawThemedScrollBars(pDC, hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll, bNeedsCorner);
         }
         m_bDrawingScrollbar = false;
     }
@@ -684,7 +685,7 @@ void CMPCThemeScrollBarRenderer::OnNcLButtonUp(HWND hWnd, WPARAM wParam, LPARAM 
 }
 
 void CMPCThemeScrollBarRenderer::OnNcMouseLeave(HWND hWnd) {
-    // CRITICAL FIX: Ignore first spurious leave after button down
+    // Ignore first spurious leave after button down
     // Windows sends WM_NCMOUSELEAVE immediately when auto-repeat starts (horizontal scrollbar)
     // Clear flag after ignoring to handle subsequent real leave events
     if (m_vScrollState.bIgnoreNextLeave) {
@@ -702,7 +703,7 @@ void CMPCThemeScrollBarRenderer::OnNcMouseLeave(HWND hWnd) {
     m_hScrollState.eMouseOverArea.eArea = eNone;
 }
 
-void CMPCThemeScrollBarRenderer::DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll) {
+void CMPCThemeScrollBarRenderer::DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll, bool bDrawCorner) {
 
     if (bHasVScroll && !vScrollRect.IsRectEmpty()) {
         DrawScrollBar(pDC, hWnd, SB_VERT, vScrollRect);
@@ -712,8 +713,7 @@ void CMPCThemeScrollBarRenderer::DrawThemedScrollBars(CDC* pDC, HWND hWnd, const
         DrawScrollBar(pDC, hWnd, SB_HORZ, hScrollRect);
     }
 
-    // Draw corner if both scrollbars present
-    if (bHasVScroll && bHasHScroll) {
+    if (bDrawCorner) {
         CRect cornerRect;
         if (GetScrollBarCornerRect(hWnd, cornerRect)) {
             DrawScrollBarCorner(pDC, hWnd, cornerRect);
@@ -755,10 +755,10 @@ void CMPCThemeScrollBarRenderer::HandleNcPaint(HWND hWnd) {
     //note, the fMask is zero -- it doesn't actually change any scroll info
     if (bHasVScroll) {
         SCROLLINFO si = { sizeof(SCROLLINFO), 0 };
-        ::SetScrollInfo(hWnd, SB_VERT, &si, false);
+        ::SetScrollInfo(hWnd, SB_VERT, &si, true);
     }
     if (bHasHScroll) {
         SCROLLINFO si = { sizeof(SCROLLINFO), 0 };
-        ::SetScrollInfo(hWnd, SB_HORZ, &si, false);
+        ::SetScrollInfo(hWnd, SB_HORZ, &si, true);
     }
 }

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -729,6 +729,13 @@ void CMPCThemeScrollBarRenderer::HandleNcPaint(HWND hWnd) {
     dc.RestoreDC(oldDC);
 
     if (bHasVScroll || bHasHScroll) {
+        //this code is called with fMask=0, which should do nothing, but it triggers themed code that sets SB state
+        //if we draw directly, we fail to reset the SB state which can cause the internal hover detection to fail
+        //use case: switch between property pages and the scrollbar hover stops working
+        SCROLLINFO si = { sizeof(SCROLLINFO) };
+        ::GetScrollInfo(hWnd, SB_HORZ, &si);
+        ::SetScrollInfo(hWnd, SB_HORZ, &si, false);
+
         DrawThemedScrollBars(&dc, hWnd, vScrollRect, hScrollRect, bHasVScroll, bHasHScroll);
     }
 }

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -694,6 +694,9 @@ void CMPCThemeScrollBarRenderer::OnNcLButtonUp(HWND hWnd, WPARAM wParam, LPARAM 
     m_hScrollState.bDragging = false;
 
     UninstallMouseHook();
+
+    //in case we have caused the thumb to be in hover state by clicking the channel, we recheck the mouse position
+    OnNcMouseMove(hWnd, wParam, lParam);
 }
 
 void CMPCThemeScrollBarRenderer::OnNcMouseLeave(HWND hWnd) {

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.cpp
@@ -94,18 +94,24 @@ void CMPCThemeScrollBarRenderer::HandleMouseEvent(WPARAM wParam, const POINT& pt
     }
 }
 
+bool CMPCThemeScrollBarRenderer::GetScrollBarState(HWND hWnd, int nBar, SCROLLBARINFO& sbi) {
+    sbi.cbSize = sizeof(SCROLLBARINFO);
+    int objId = (nBar == SB_VERT) ? OBJID_VSCROLL : OBJID_HSCROLL;
+    return GetScrollBarInfo(hWnd, objId, &sbi) != FALSE;
+}
+
 BOOL CMPCThemeScrollBarRenderer::GetScrollBarRect(HWND hWnd, BOOL bVertical, CRect& rect) {
     if (!hWnd) {
         return FALSE;
     }
 
     SCROLLBARINFO sbi = { 0 };
-    sbi.cbSize = sizeof(SCROLLBARINFO);
-    if (!GetScrollBarInfo(hWnd, bVertical ? OBJID_VSCROLL : OBJID_HSCROLL, &sbi)) {
+    int nBar = bVertical ? SB_VERT : SB_HORZ;
+    if (!GetScrollBarState(hWnd, nBar, sbi)) {
         return FALSE;
     }
 
-    if (sbi.rgstate[0] & STATE_SYSTEM_INVISIBLE || sbi.rgstate[0] & STATE_SYSTEM_UNAVAILABLE) {
+    if (sbi.rgstate[0] & STATE_SYSTEM_INVISIBLE) {
         return FALSE;
     }
 
@@ -328,7 +334,7 @@ void CMPCThemeScrollBarRenderer::drawSBArrow(CDC& dc, COLORREF arrowClr, CRect a
     }
 }
 
-void CMPCThemeScrollBarRenderer::DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, const CRect& targetRect, bool bEnabled) {
+void CMPCThemeScrollBarRenderer::DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, const CRect& targetRect) {
     DpiHelper dpiWindow;
     dpiWindow.Override(hWnd);
     int nDPI = dpiWindow.DPIX();
@@ -337,7 +343,8 @@ void CMPCThemeScrollBarRenderer::DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, co
     ScrollBarState& state = bHorizontal ? m_hScrollState : m_vScrollState;
 
     CRect rectTLArrow, rectBRArrow, rectThumb, rectTLChannel, rectBRChannel;
-    CalculateScrollBarRects(hWnd, nBar, targetRect, rectTLArrow, rectBRArrow, rectThumb, rectTLChannel, rectBRChannel);
+    bool bScrollBarEnabled = true;
+    CalculateScrollBarRects(hWnd, nBar, targetRect, rectTLArrow, rectBRArrow, rectThumb, rectTLChannel, rectBRChannel, &bScrollBarEnabled);
 
     int xOffset = targetRect.left;
     int yOffset = targetRect.top;
@@ -386,7 +393,7 @@ void CMPCThemeScrollBarRenderer::DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, co
         }
 
         XSB_EDRAWELEM eState;
-        if (!bEnabled) {
+        if (!bScrollBarEnabled) {
             eState = eDisabled;
         } else if (state.bDragging && stArea.IsThumb()) {
             eState = eDown;
@@ -502,9 +509,7 @@ eXSB_AREA CMPCThemeScrollBarRenderer::GetScrollBarArea(HWND hWnd, CPoint clientP
     return eNone;
 }
 
-void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, const CRect& scrollRect,
-    CRect& rectTLArrow, CRect& rectBRArrow, CRect& rectThumb,
-    CRect& rectTLChannel, CRect& rectBRChannel) {
+void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, const CRect& scrollRect, CRect& rectTLArrow, CRect& rectBRArrow, CRect& rectThumb, CRect& rectTLChannel, CRect& rectBRChannel, bool* pbEnabled) {
     // Get scroll info
     SCROLLINFO si = { 0 };
     si.cbSize = sizeof(SCROLLINFO);
@@ -515,11 +520,19 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
         rectThumb.SetRectEmpty();
         rectTLChannel.SetRectEmpty();
         rectBRChannel.SetRectEmpty();
+        if (pbEnabled) *pbEnabled = false;
         return;
     }
 
+    bool bEnabled = true;
+    if (pbEnabled) {
+        SCROLLBARINFO sbi = { 0 };
+        if (GetScrollBarState(hWnd, nBar, sbi)) {
+            bEnabled = !(sbi.rgstate[0] & STATE_SYSTEM_UNAVAILABLE);
+        }
+        *pbEnabled = bEnabled;
+    }
     bool bHorizontal = (nBar == SB_HORZ);
-    bool bEnabled = ::IsWindowEnabled(hWnd);
     UINT uArrowWH = bHorizontal ? scrollRect.Height() : scrollRect.Width();
     UINT uThumbMinHW = 8;
 
@@ -532,7 +545,7 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
 
         int cxChannel = cxClient - (2 * cxArrow);
         int nRange = si.nMax - si.nMin + 1;
-        if (nRange > 0 && cxChannel > (int)uThumbMinHW && bEnabled) {
+        if (nRange > 0 && cxChannel > (int)uThumbMinHW) {
             double dblPx_SU = (double)cxChannel / (double)nRange;
             int xThumb = (int)((si.nPos - si.nMin) * dblPx_SU);
             int cxThumb = std::max((int)uThumbMinHW, (int)(si.nPage * dblPx_SU));
@@ -563,7 +576,7 @@ void CMPCThemeScrollBarRenderer::CalculateScrollBarRects(HWND hWnd, int nBar, co
 
         int cyChannel = cyClient - (2 * cyArrow);
         int nRange = si.nMax - si.nMin + 1;
-        if (nRange > 0 && cyChannel > (int)uThumbMinHW && bEnabled) {
+        if (nRange > 0 && cyChannel > (int)uThumbMinHW) {
             double dblPx_SU = (double)cyChannel / (double)nRange;
             int yThumb = (int)((si.nPos - si.nMin) * dblPx_SU);
             int cyThumb = std::max((int)uThumbMinHW, (int)(si.nPage * dblPx_SU));
@@ -666,17 +679,14 @@ void CMPCThemeScrollBarRenderer::OnNcMouseLeave(HWND hWnd) {
     m_hScrollState.eMouseOverArea.eArea = eNone;
 }
 
-void CMPCThemeScrollBarRenderer::DrawThemedScrollBars(CDC* pDC, HWND hWnd,
-    const CRect& vScrollRect, const CRect& hScrollRect,
-    bool bHasVScroll, bool bHasHScroll) {
-    bool bEnabled = ::IsWindowEnabled(hWnd);
+void CMPCThemeScrollBarRenderer::DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll) {
 
     if (bHasVScroll && !vScrollRect.IsRectEmpty()) {
-        DrawScrollBar(pDC, hWnd, SB_VERT, vScrollRect, bEnabled);
+        DrawScrollBar(pDC, hWnd, SB_VERT, vScrollRect);
     }
 
     if (bHasHScroll && !hScrollRect.IsRectEmpty()) {
-        DrawScrollBar(pDC, hWnd, SB_HORZ, hScrollRect, bEnabled);
+        DrawScrollBar(pDC, hWnd, SB_HORZ, hScrollRect);
     }
 
     // Draw corner if both scrollbars present

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.h
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.h
@@ -1,0 +1,64 @@
+#pragma once
+#include "XeScrollBar/XeScrollBarBase.h"
+
+class CMPCThemeScrollBarRenderer
+{
+public:
+    CMPCThemeScrollBarRenderer();
+    virtual ~CMPCThemeScrollBarRenderer();
+
+    void ProcessMessage(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+    void DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll);
+    BOOL ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, HRGN& hOldClipRgn, bool bDrawThemedScrollbars = false);
+    static void RestoreClipping(HDC hdc, HRGN hOldClipRgn);
+    eXSB_AREA HitTestScrollBar(HWND hWnd, CPoint point, bool bVertical, const CRect& scrollRect);
+    bool GetScrollBarRects(HWND hWnd, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll);
+    bool GetScrollBarCornerRect(HWND hWnd, CRect& cornerRect);
+    void DrawScrollBarCorner(CDC* pDC, HWND hWnd, const CRect& cornerRect);
+
+protected:
+    enum arrowOrientation {
+        arrowLeft,
+        arrowRight,
+        arrowTop,
+        arrowBottom
+    };
+
+    struct ScrollBarState {
+        stXSB_AREA eMouseOverArea;
+        stXSB_AREA eMouseDownArea;
+        bool bDragging;
+
+        ScrollBarState() {
+            eMouseOverArea.eArea = eNone;
+            eMouseDownArea.eArea = eNone;
+            bDragging = false;
+        }
+    };
+
+    ScrollBarState m_vScrollState;
+    ScrollBarState m_hScrollState;
+    bool m_bDrawingScrollbar;
+
+    HHOOK m_hMouseHook;
+    HWND m_hWndTracking;
+    DWORD m_dwThreadId;
+
+    static LRESULT CALLBACK MouseProc(int nCode, WPARAM wParam, LPARAM lParam);
+    static CMPCThemeScrollBarRenderer* s_pActiveRenderer;
+
+    void InstallMouseHook(HWND hWnd);
+    void UninstallMouseHook();
+    void HandleMouseEvent(WPARAM wParam, const POINT& pt);
+
+    void OnNcMouseMove(HWND hWnd, WPARAM wParam, LPARAM lParam);
+    void OnNcLButtonDown(HWND hWnd, WPARAM wParam, LPARAM lParam);
+    void OnNcLButtonUp(HWND hWnd, WPARAM wParam, LPARAM lParam);
+    void OnNcMouseLeave(HWND hWnd);
+
+    eXSB_AREA GetScrollBarArea(HWND hWnd, CPoint clientPoint, bool bVertical, const CRect& scrollRect);
+    void CalculateScrollBarRects(HWND hWnd, int nBar, const CRect& scrollRect, CRect& rectTLArrow, CRect& rectBRArrow, CRect& rectThumb, CRect& rectTLChannel, CRect& rectBRChannel);
+    BOOL GetScrollBarRect(HWND hWnd, BOOL bVertical, CRect& rect);
+    static void drawSBArrow(CDC& dc, COLORREF arrowClr, CRect arrowRect, arrowOrientation orientation, int dpi);
+    void DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, const CRect& targetRect, bool bEnabled);
+};

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.h
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.h
@@ -52,14 +52,16 @@ protected:
     void UninstallMouseHook();
     void HandleMouseEvent(WPARAM wParam, const POINT& pt);
 
+    bool GetScrollBarState(HWND hWnd, int nBar, SCROLLBARINFO& sbi);
+
     void OnNcMouseMove(HWND hWnd, WPARAM wParam, LPARAM lParam);
     void OnNcLButtonDown(HWND hWnd, WPARAM wParam, LPARAM lParam);
     void OnNcLButtonUp(HWND hWnd, WPARAM wParam, LPARAM lParam);
     void OnNcMouseLeave(HWND hWnd);
 
     eXSB_AREA GetScrollBarArea(HWND hWnd, CPoint clientPoint, bool bVertical, const CRect& scrollRect);
-    void CalculateScrollBarRects(HWND hWnd, int nBar, const CRect& scrollRect, CRect& rectTLArrow, CRect& rectBRArrow, CRect& rectThumb, CRect& rectTLChannel, CRect& rectBRChannel);
+    void CalculateScrollBarRects(HWND hWnd, int nBar, const CRect& scrollRect, CRect& rectTLArrow, CRect& rectBRArrow, CRect& rectThumb, CRect& rectTLChannel, CRect& rectBRChannel, bool* pbEnabled = nullptr);
     BOOL GetScrollBarRect(HWND hWnd, BOOL bVertical, CRect& rect);
     static void drawSBArrow(CDC& dc, COLORREF arrowClr, CRect arrowRect, arrowOrientation orientation, int dpi);
-    void DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, const CRect& targetRect, bool bEnabled);
+    void DrawScrollBar(CDC* pDC, HWND hWnd, int nBar, const CRect& targetRect);
 };

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.h
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.h
@@ -7,11 +7,21 @@ public:
     CMPCThemeScrollBarRenderer();
     virtual ~CMPCThemeScrollBarRenderer();
 
+    struct ClipRegionState {
+        HRGN hOldClipRgn;
+        bool bModifiedDC;
+        bool bFullyClipped;
+        
+        ClipRegionState() : hOldClipRgn(NULL), bModifiedDC(false), bFullyClipped(false) {}
+        
+        bool IsFullyClipped() const { return bFullyClipped; }
+    };
+
     void ProcessMessage(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
     void DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll, bool bDrawCorner);
     void HandleNcPaint(HWND hWnd);
-    BOOL ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, HRGN& hOldClipRgn, bool bDrawThemedScrollbars = false);
-    static void RestoreClipping(HDC hdc, HRGN hOldClipRgn);
+    ClipRegionState ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, bool bDrawThemedScrollbars = false);
+    static void RestoreClipping(HDC hdc, ClipRegionState& clipState);
     bool GetScrollBarRects(HWND hWnd, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll);
     bool GetScrollBarCornerRect(HWND hWnd, CRect& cornerRect);
     void DrawScrollBarCorner(CDC* pDC, HWND hWnd, const CRect& cornerRect);
@@ -29,13 +39,13 @@ protected:
         stXSB_AREA eMouseOverArea;
         stXSB_AREA eMouseDownArea;
         bool bDragging;
-        bool bIgnoreNextLeave;  // Add this member
+        bool bIgnoreNextLeave;
 
         ScrollBarState() {
             eMouseOverArea.eArea = eNone;
             eMouseDownArea.eArea = eNone;
             bDragging = false;
-            bIgnoreNextLeave = false;  // Initialize to false
+            bIgnoreNextLeave = false;
         }
     };
 

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.h
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.h
@@ -16,6 +16,7 @@ public:
     bool GetScrollBarRects(HWND hWnd, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll);
     bool GetScrollBarCornerRect(HWND hWnd, CRect& cornerRect);
     void DrawScrollBarCorner(CDC* pDC, HWND hWnd, const CRect& cornerRect);
+    inline bool GetClippedScrollBarRects(HWND hWnd, HDC hdc, const CRect& drawRect, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll);
 
 protected:
     enum arrowOrientation {

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.h
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.h
@@ -9,6 +9,7 @@ public:
 
     void ProcessMessage(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
     void DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll);
+    void HandleNcPaint(HWND hWnd);
     BOOL ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, HRGN& hOldClipRgn, bool bDrawThemedScrollbars = false);
     static void RestoreClipping(HDC hdc, HRGN hOldClipRgn);
     eXSB_AREA HitTestScrollBar(HWND hWnd, CPoint point, bool bVertical, const CRect& scrollRect);

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.h
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.h
@@ -8,15 +8,14 @@ public:
     virtual ~CMPCThemeScrollBarRenderer();
 
     void ProcessMessage(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
-    void DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll);
+    void DrawThemedScrollBars(CDC* pDC, HWND hWnd, const CRect& vScrollRect, const CRect& hScrollRect, bool bHasVScroll, bool bHasHScroll, bool bDrawCorner);
     void HandleNcPaint(HWND hWnd);
     BOOL ApplyScrollbarClipping(HDC hdc, HWND hWnd, const CRect& drawRect, HRGN& hOldClipRgn, bool bDrawThemedScrollbars = false);
     static void RestoreClipping(HDC hdc, HRGN hOldClipRgn);
-    eXSB_AREA HitTestScrollBar(HWND hWnd, CPoint point, bool bVertical, const CRect& scrollRect);
     bool GetScrollBarRects(HWND hWnd, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll);
     bool GetScrollBarCornerRect(HWND hWnd, CRect& cornerRect);
     void DrawScrollBarCorner(CDC* pDC, HWND hWnd, const CRect& cornerRect);
-    inline bool GetClippedScrollBarRects(HWND hWnd, HDC hdc, const CRect& drawRect, CRect& vScrollRect, CRect& hScrollRect, bool& bHasVScroll, bool& bHasHScroll);
+    inline bool GetClippedScrollBarRects(HWND hWnd, HDC hdc, const CRect& drawRect, CRect& vScrollRect, CRect& hScrollRect, bool& bNeedsVScroll, bool& bNeedsHScroll, bool& bNeedsCorner);
 
 protected:
     enum arrowOrientation {

--- a/src/mpc-hc/CMPCThemeScrollBarRenderer.h
+++ b/src/mpc-hc/CMPCThemeScrollBarRenderer.h
@@ -29,11 +29,13 @@ protected:
         stXSB_AREA eMouseOverArea;
         stXSB_AREA eMouseDownArea;
         bool bDragging;
+        bool bIgnoreNextLeave;  // Add this member
 
         ScrollBarState() {
             eMouseOverArea.eArea = eNone;
             eMouseDownArea.eArea = eNone;
             bDragging = false;
+            bIgnoreNextLeave = false;  // Initialize to false
         }
     };
 

--- a/src/mpc-hc/PPageFullscreen.cpp
+++ b/src/mpc-hc/PPageFullscreen.cpp
@@ -136,6 +136,7 @@ void CPPageFullscreen::ModesUpdate()
         CString strItemPos;
         strItemPos.Format(_T("%02d"), nItem);
         VERIFY(m_list.InsertItem(nItem, strItemPos) == nItem);
+        VERIFY(m_list.InsertItem(nItem, strItemPos) == nItem);
 
         m_list.SetCheck(nItem, mode.bChecked);
 

--- a/src/mpc-hc/PPageFullscreen.cpp
+++ b/src/mpc-hc/PPageFullscreen.cpp
@@ -760,4 +760,3 @@ BOOL CPPageFullscreen::OnToolTipNotify(UINT id, NMHDR* pNMH, LRESULT* pResult)
 
     return bRet;
 }
-

--- a/src/mpc-hc/PPageFullscreen.cpp
+++ b/src/mpc-hc/PPageFullscreen.cpp
@@ -136,7 +136,6 @@ void CPPageFullscreen::ModesUpdate()
         CString strItemPos;
         strItemPos.Format(_T("%02d"), nItem);
         VERIFY(m_list.InsertItem(nItem, strItemPos) == nItem);
-        VERIFY(m_list.InsertItem(nItem, strItemPos) == nItem);
 
         m_list.SetCheck(nItem, mode.bChecked);
 
@@ -761,3 +760,4 @@ BOOL CPPageFullscreen::OnToolTipNotify(UINT id, NMHDR* pNMH, LRESULT* pResult)
 
     return bRet;
 }
+

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1129,7 +1129,6 @@ void CPlayerPlaylistBar::Append(CAtlList<CString>& fns, bool fMulti, CAtlList<CS
         if (activateListItemIndex) { // Select the first added item only if some were already present
             m_list.SetItemState(activateListItemIndex, LVIS_SELECTED, LVIS_SELECTED);
         }
-        m_list.updateSB();
     }
 }
 
@@ -1772,7 +1771,6 @@ void CPlayerPlaylistBar::ResizeListColumn()
         m_list.SetRedraw(TRUE);
 
         Invalidate();
-        m_list.updateSB();
         m_list.RedrawWindow(nullptr, nullptr, RDW_FRAME | RDW_INVALIDATE);
     }
 }

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -144,6 +144,7 @@
     <ClCompile Include="CMPCThemePropPageButton.cpp" />
     <ClCompile Include="CMPCThemeResizablePropertyPage.cpp" />
     <ClCompile Include="CMPCThemeResizablePropertySheet.cpp" />
+    <ClCompile Include="CMPCThemeScrollBarRenderer.cpp" />
     <ClCompile Include="CMPCThemeTitleBarControlButton.cpp" />
     <ClCompile Include="CMPCThemeUtil.cpp" />
     <ClCompile Include="CMPCThemeComboBox.cpp" />
@@ -337,6 +338,7 @@
     <ClInclude Include="CMPCThemePropPageButton.h" />
     <ClInclude Include="CMPCThemeResizablePropertyPage.h" />
     <ClInclude Include="CMPCThemeResizablePropertySheet.h" />
+    <ClInclude Include="CMPCThemeScrollBarRenderer.h" />
     <ClInclude Include="CMPCThemeTitleBarControlButton.h" />
     <ClInclude Include="CMPCThemeUtil.h" />
     <ClInclude Include="CMPCThemeComboBox.h" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -630,6 +630,9 @@
     <ClCompile Include="PPageToolBarLayout.cpp">
       <Filter>Property Dialogs\Player Options\Pages</Filter>
     </ClCompile>
+    <ClCompile Include="CMPCThemeScrollBarRenderer.cpp">
+      <Filter>MPCTheme</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AppSettings.h">
@@ -1199,6 +1202,9 @@
     </ClInclude>
     <ClInclude Include="MemoryDCBuffer.h">
       <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="CMPCThemeScrollBarRenderer.h">
+      <Filter>MPCTheme</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -1683,6 +1683,97 @@ static BOOL CreateFakeVideoTS(LPCWSTR strIFOPath, LPWSTR strFakeFile, size_t nFa
     return bRet;
 }
 
+// Helper to get renderer from window
+static CMPCThemeScrollBarRenderer* GetScrollBarRenderer(HWND hWnd) {
+    CWnd* pWnd = CWnd::FromHandlePermanent(hWnd);
+
+    if (pWnd && AppNeedsThemedControls()) {
+        CMPCThemePlayerListCtrl* pListCtrl = DYNAMIC_DOWNCAST(CMPCThemePlayerListCtrl, pWnd);
+        if (pListCtrl) {
+            return pListCtrl; // Implicit upcast to CMPCThemeScrollBarRenderer*
+        }
+    }
+    return nullptr;
+}
+
+static BOOL(WINAPI* Real_BitBlt)(HDC, int, int, int, int, HDC, int, int, DWORD) = BitBlt;
+BOOL WINAPI Mine_BitBlt(HDC hdc, int x, int y, int cx, int cy,
+    HDC hdcSrc, int x1, int y1, DWORD rop) {
+
+    HWND hWnd = WindowFromDC(hdc);
+    CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
+
+    if (pRenderer) {
+        CRect drawRect(x, y, x + cx, y + cy);
+        HRGN hOldClipRgn = NULL;
+
+        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, true))
+            return TRUE; // Entire area clipped
+
+        BOOL result = Real_BitBlt(hdc, x, y, cx, cy, hdcSrc, x1, y1, rop);
+
+        if (hOldClipRgn)
+            CMPCThemeScrollBarRenderer::RestoreClipping(hdc, hOldClipRgn);
+
+        return result;
+    }
+
+    return Real_BitBlt(hdc, x, y, cx, cy, hdcSrc, x1, y1, rop);
+}
+
+static BOOL(WINAPI* Real_GdiAlphaBlend)(HDC, int, int, int, int, HDC, int, int, int, int, BLENDFUNCTION) = GdiAlphaBlend;
+BOOL WINAPI Mine_GdiAlphaBlend(HDC hdcDest, int xoriginDest, int yoriginDest,
+    int wDest, int hDest, HDC hdcSrc, int xoriginSrc, int yoriginSrc,
+    int wSrc, int hSrc, BLENDFUNCTION ftn) {
+
+    HWND hWnd = WindowFromDC(hdcDest);
+    CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
+
+    if (pRenderer) {
+        CRect drawRect(xoriginDest, yoriginDest, xoriginDest + wDest, yoriginDest + hDest);
+        HRGN hOldClipRgn = NULL;
+
+        if (!pRenderer->ApplyScrollbarClipping(hdcDest, hWnd, drawRect, hOldClipRgn, true))
+            return TRUE; // Entire area clipped
+
+        BOOL result = Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest,
+            hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
+
+        if (hOldClipRgn)
+            CMPCThemeScrollBarRenderer::RestoreClipping(hdcDest, hOldClipRgn);
+
+        return result;
+    }
+
+    return Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest,
+        hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
+}
+
+static HRESULT(WINAPI* Real_DrawThemeBackground)(HTHEME, HDC, int, int, LPCRECT, LPCRECT) = DrawThemeBackground;
+HRESULT WINAPI Mine_DrawThemeBackground(HTHEME hTheme, HDC hdc, int iPartId, int iStateId,
+    LPCRECT pRect, LPCRECT pClipRect) {
+
+    HWND hWnd = WindowFromDC(hdc);
+    CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
+
+    if (pRenderer) {
+        CRect drawRect(pRect);
+        HRGN hOldClipRgn = NULL;
+
+        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, false))
+            return S_OK; // Entire area clipped
+
+        HRESULT result = Real_DrawThemeBackground(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
+
+        if (hOldClipRgn)
+            CMPCThemeScrollBarRenderer::RestoreClipping(hdc, hOldClipRgn);
+
+        return result;
+    }
+
+    return Real_DrawThemeBackground(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
+}
+
 int(WINAPI* Real_ScrollWindowEx)(HWND, int, int, CONST RECT*, CONST RECT*, HRGN, LPRECT, UINT) = ScrollWindowEx;
 int WINAPI Mine_ScrollWindowEx(HWND hWnd, int dx, int dy, CONST RECT* prcScroll, CONST RECT* prcClip, HRGN hrgnUpdate, LPRECT prcUpdate, UINT flags)
 {
@@ -1856,6 +1947,9 @@ BOOL CMPlayerCApp::InitInstance()
     bHookingSuccessful &= !!Mhook_SetHookEx(&Real_CreateFileW, Mine_CreateFileW);
     bHookingSuccessful &= !!Mhook_SetHookEx(&Real_DeviceIoControl, Mine_DeviceIoControl);
     bHookingSuccessful &= !!Mhook_SetHookEx(&Real_ScrollWindowEx, Mine_ScrollWindowEx);
+    bHookingSuccessful &= !!Mhook_SetHookEx(&Real_BitBlt, Mine_BitBlt);
+    bHookingSuccessful &= !!Mhook_SetHookEx(&Real_GdiAlphaBlend, Mine_GdiAlphaBlend);
+    bHookingSuccessful &= !!Mhook_SetHookEx(&Real_DrawThemeBackground, Mine_DrawThemeBackground);
 
     bHookingSuccessful &= MH_EnableHook(MH_ALL_HOOKS) == MH_OK;
 

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -1718,18 +1718,17 @@ static BOOL(WINAPI* Real_GdiAlphaBlend)(HDC, int, int, int, int, HDC, int, int, 
 BOOL WINAPI Mine_GdiAlphaBlend(HDC hdcDest, int xoriginDest, int yoriginDest, int wDest, int hDest, HDC hdcSrc, int xoriginSrc, int yoriginSrc, int wSrc, int hSrc, BLENDFUNCTION ftn) {
     HWND hWnd = WindowFromDC(hdcDest);
     CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
+
     if (pRenderer) {
         CRect drawRect(xoriginDest, yoriginDest, xoriginDest + wDest, yoriginDest + hDest);
-        auto clipState = pRenderer->ApplyScrollbarClipping(hdcDest, hWnd, drawRect, true);
         
-        BOOL result = TRUE;
-        if (!clipState.IsFullyClipped()) {
-            result = Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest, hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
-        }
-        
-        CMPCThemeScrollBarRenderer::RestoreClipping(hdcDest, clipState);
-        return result;
+        // We draw to the src of the blend function -- note, this relies on an assumption
+        // that win32 uses a src hdc with the same origin as the window (double buffer hdc?)
+        // Real_GdiAlphaBlend will then function normally with our src data
+        auto clipState = pRenderer->ApplyScrollbarClipping(hdcSrc, hWnd, drawRect, true);
+        CMPCThemeScrollBarRenderer::RestoreClipping(hdcSrc, clipState);
     }
+    
     return Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest, hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
 }
 

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -1683,7 +1683,6 @@ static BOOL CreateFakeVideoTS(LPCWSTR strIFOPath, LPWSTR strFakeFile, size_t nFa
     return bRet;
 }
 
-// Helper to get renderer from window
 static CMPCThemeScrollBarRenderer* GetScrollBarRenderer(HWND hWnd) {
     CWnd* pWnd = CWnd::FromHandlePermanent(hWnd);
 
@@ -1697,80 +1696,59 @@ static CMPCThemeScrollBarRenderer* GetScrollBarRenderer(HWND hWnd) {
 }
 
 static BOOL(WINAPI* Real_BitBlt)(HDC, int, int, int, int, HDC, int, int, DWORD) = BitBlt;
-BOOL WINAPI Mine_BitBlt(HDC hdc, int x, int y, int cx, int cy,
-    HDC hdcSrc, int x1, int y1, DWORD rop) {
-
+BOOL WINAPI Mine_BitBlt(HDC hdc, int x, int y, int cx, int cy, HDC hdcSrc, int x1, int y1, DWORD rop) {
     HWND hWnd = WindowFromDC(hdc);
     CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
-
     if (pRenderer) {
         CRect drawRect(x, y, x + cx, y + cy);
         HRGN hOldClipRgn = NULL;
-
-        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, true))
-            return TRUE; // Entire area clipped
-
+        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, true)) {
+            return TRUE;
+        }
         BOOL result = Real_BitBlt(hdc, x, y, cx, cy, hdcSrc, x1, y1, rop);
-
-        if (hOldClipRgn)
+        if (hOldClipRgn) {
             CMPCThemeScrollBarRenderer::RestoreClipping(hdc, hOldClipRgn);
-
+        }
         return result;
     }
-
     return Real_BitBlt(hdc, x, y, cx, cy, hdcSrc, x1, y1, rop);
 }
 
 static BOOL(WINAPI* Real_GdiAlphaBlend)(HDC, int, int, int, int, HDC, int, int, int, int, BLENDFUNCTION) = GdiAlphaBlend;
-BOOL WINAPI Mine_GdiAlphaBlend(HDC hdcDest, int xoriginDest, int yoriginDest,
-    int wDest, int hDest, HDC hdcSrc, int xoriginSrc, int yoriginSrc,
-    int wSrc, int hSrc, BLENDFUNCTION ftn) {
-
+BOOL WINAPI Mine_GdiAlphaBlend(HDC hdcDest, int xoriginDest, int yoriginDest, int wDest, int hDest, HDC hdcSrc, int xoriginSrc, int yoriginSrc, int wSrc, int hSrc, BLENDFUNCTION ftn) {
     HWND hWnd = WindowFromDC(hdcDest);
     CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
-
     if (pRenderer) {
         CRect drawRect(xoriginDest, yoriginDest, xoriginDest + wDest, yoriginDest + hDest);
         HRGN hOldClipRgn = NULL;
-
-        if (!pRenderer->ApplyScrollbarClipping(hdcDest, hWnd, drawRect, hOldClipRgn, true))
-            return TRUE; // Entire area clipped
-
-        BOOL result = Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest,
-            hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
-
-        if (hOldClipRgn)
+        if (!pRenderer->ApplyScrollbarClipping(hdcDest, hWnd, drawRect, hOldClipRgn, true)) {
+            return TRUE;
+        }
+        BOOL result = Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest, hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
+        if (hOldClipRgn) {
             CMPCThemeScrollBarRenderer::RestoreClipping(hdcDest, hOldClipRgn);
-
+        }
         return result;
     }
-
-    return Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest,
-        hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
+    return Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest, hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
 }
 
 static HRESULT(WINAPI* Real_DrawThemeBackground)(HTHEME, HDC, int, int, LPCRECT, LPCRECT) = DrawThemeBackground;
-HRESULT WINAPI Mine_DrawThemeBackground(HTHEME hTheme, HDC hdc, int iPartId, int iStateId,
-    LPCRECT pRect, LPCRECT pClipRect) {
-
+HRESULT WINAPI Mine_DrawThemeBackground(HTHEME hTheme, HDC hdc, int iPartId, int iStateId, LPCRECT pRect, LPCRECT pClipRect) {
     HWND hWnd = WindowFromDC(hdc);
     CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
-
     if (pRenderer) {
         CRect drawRect(pRect);
         HRGN hOldClipRgn = NULL;
-
-        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, false))
-            return S_OK; // Entire area clipped
-
+        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, false)) {
+            return S_OK;
+        }
         HRESULT result = Real_DrawThemeBackground(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
-
-        if (hOldClipRgn)
+        if (hOldClipRgn) {
             CMPCThemeScrollBarRenderer::RestoreClipping(hdc, hOldClipRgn);
-
+        }
         return result;
     }
-
     return Real_DrawThemeBackground(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
 }
 

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -1701,14 +1701,14 @@ BOOL WINAPI Mine_BitBlt(HDC hdc, int x, int y, int cx, int cy, HDC hdcSrc, int x
     CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
     if (pRenderer) {
         CRect drawRect(x, y, x + cx, y + cy);
-        HRGN hOldClipRgn = NULL;
-        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, true)) {
-            return TRUE;
+        auto clipState = pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, true);
+        
+        BOOL result = TRUE;
+        if (!clipState.IsFullyClipped()) {
+            result = Real_BitBlt(hdc, x, y, cx, cy, hdcSrc, x1, y1, rop);
         }
-        BOOL result = Real_BitBlt(hdc, x, y, cx, cy, hdcSrc, x1, y1, rop);
-        if (hOldClipRgn) {
-            CMPCThemeScrollBarRenderer::RestoreClipping(hdc, hOldClipRgn);
-        }
+        
+        CMPCThemeScrollBarRenderer::RestoreClipping(hdc, clipState);
         return result;
     }
     return Real_BitBlt(hdc, x, y, cx, cy, hdcSrc, x1, y1, rop);
@@ -1720,14 +1720,14 @@ BOOL WINAPI Mine_GdiAlphaBlend(HDC hdcDest, int xoriginDest, int yoriginDest, in
     CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
     if (pRenderer) {
         CRect drawRect(xoriginDest, yoriginDest, xoriginDest + wDest, yoriginDest + hDest);
-        HRGN hOldClipRgn = NULL;
-        if (!pRenderer->ApplyScrollbarClipping(hdcDest, hWnd, drawRect, hOldClipRgn, true)) {
-            return TRUE;
+        auto clipState = pRenderer->ApplyScrollbarClipping(hdcDest, hWnd, drawRect, true);
+        
+        BOOL result = TRUE;
+        if (!clipState.IsFullyClipped()) {
+            result = Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest, hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
         }
-        BOOL result = Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest, hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
-        if (hOldClipRgn) {
-            CMPCThemeScrollBarRenderer::RestoreClipping(hdcDest, hOldClipRgn);
-        }
+        
+        CMPCThemeScrollBarRenderer::RestoreClipping(hdcDest, clipState);
         return result;
     }
     return Real_GdiAlphaBlend(hdcDest, xoriginDest, yoriginDest, wDest, hDest, hdcSrc, xoriginSrc, yoriginSrc, wSrc, hSrc, ftn);
@@ -1739,14 +1739,14 @@ HRESULT WINAPI Mine_DrawThemeBackground(HTHEME hTheme, HDC hdc, int iPartId, int
     CMPCThemeScrollBarRenderer* pRenderer = GetScrollBarRenderer(hWnd);
     if (pRenderer) {
         CRect drawRect(pRect);
-        HRGN hOldClipRgn = NULL;
-        if (!pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, hOldClipRgn, false)) {
-            return S_OK;
+        auto clipState = pRenderer->ApplyScrollbarClipping(hdc, hWnd, drawRect, false);
+        
+        HRESULT result = S_OK;
+        if (!clipState.IsFullyClipped()) {
+            result = Real_DrawThemeBackground(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
         }
-        HRESULT result = Real_DrawThemeBackground(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
-        if (hOldClipRgn) {
-            CMPCThemeScrollBarRenderer::RestoreClipping(hdc, hOldClipRgn);
-        }
+        
+        CMPCThemeScrollBarRenderer::RestoreClipping(hdc, clipState);
         return result;
     }
     return Real_DrawThemeBackground(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);


### PR DESCRIPTION
This is a complete replacement for themed scrollbar rendering code.  Currently, only applied to listview, but can be reused on CEdit in the future (less of a concern performance-wise).

The main challenge with drawing themed scrollbars is listview scrollbars are drawn inside a tight event loop during dragging and pressing, bypassing WM_PAINT and WM_NCPAINT, and swallowing all mouse messages.  As a result after a lot of research I previously used an "old and true" method of drawing over the window while regioning out the native scrollbars--a very complex and tricky approach.

The new code draws inside the tight event loop using windows hooks.

For context, the old code:

1. Created 1 or 2 scrollbar windows and placed them over the scrollable window
2. Used regions to hide the native scrollbars and prevent flicker
3. Passed SB messages from the SB windows to the native window
4. Extracted SB state from the window to reproduce in the SB windows
5. Used a helper class to manage the window and SB states and message passing, which required instantiating as a member variable
6. Painted the border and corner during NC paint (special logic needed to deal with the hiding regions)
7. Was repainted in response to messages triggered by parent window events.  As a result it may not have drawn exactly at the same cadence as the event loop drew

The new code:

1. Uses a rendering class to draw the SBs, but is not its own window
2. Intercepts native win32 functions that try to draw the SB, and draws it with themed code
3. Watches (not handles) mouse messages from the parent window to track the draw state
4. Provides a similar HandleNcPaint to draw NC area while drawing SBs (necessary initially but all later updates are drawn through intercept)

The advantage of this approach:

1. Should be faster
2. Less region flipping (faster)
3. Simpler approach--native window handles everything except the drawing of the SBs
5. No message passing between SB windows and real window (faster)
6. Fixes some small bugs like the scrollbar doesn't drag when the mouse is too far from the window, hover bugs when holding button down
8. Eliminate 8 message handlers in the listview class that existed just to alert the SBs to changes
9. Included as a parent class to simplify member handling