### PR TITLE
center icons in buttons

### DIFF
--- a/src/mpc-hc/PlayerToolBar.cpp
+++ b/src/mpc-hc/PlayerToolBar.cpp
@@ -617,7 +617,9 @@ void drawButtonBG(NMCUSTOMDRAW nmcd, COLORREF c)
     dc.Attach(nmcd.hdc);
     CRect br;
     br.CopyRect(&nmcd.rc);
-    br.DeflateRect(0, 0, 1, 1); //we aren't offsetting button when pressed, so try to center better
+    //adipose: remove the below code.  it is no longer necessary due to TBCDRF_NOOFFSET
+    //and redesigning toolbar icons to be centered vs the old MFC style of "upper left" alignment
+    //br.DeflateRect(0, 0, 1, 1); //we aren't offsetting button when pressed, so try to center better
 
     dc.FillSolidRect(br, c);
 

--- a/src/mpc-hc/res/buttons16.svg
+++ b/src/mpc-hc/res/buttons16.svg
@@ -8,30 +8,30 @@
 	<inkscape:grid  id="grid3353" type="xygrid"></inkscape:grid>
 </sodipodi:namedview>
 <path id="path4159" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M3,45V34l11,5.5L3,45z"/>
-<rect id="rect4161" x="20" y="35" style="fill:#C8C8C8;" width="3" height="9"/>
-<rect id="rect4163" x="25" y="35" style="fill:#C8C8C8;" width="3" height="9"/>
-<rect id="rect4165" x="36" y="35" style="fill:#C8C8C8;" width="8" height="9"/>
-<rect id="rect4167" x="50" y="36" style="fill:#C8C8C8;" width="1" height="7"/>
+	M3,45.5v-11L14,40L3,45.5z"/>
+<rect id="rect4161" x="20" y="35.5" style="fill:#C8C8C8;" width="3" height="9"/>
+<rect id="rect4163" x="25" y="35.5" style="fill:#C8C8C8;" width="3" height="9"/>
+<rect id="rect4165" x="36" y="35.5" style="fill:#C8C8C8;" width="8" height="9"/>
+<rect id="rect4167" x="50" y="36.5" style="fill:#C8C8C8;" width="1" height="7"/>
 <path id="path4169" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M52,39.5l4-3.5v7L52,39.5z"/>
+	M52,40l4-3.5v7L52,40z"/>
 <path id="path4171" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M57,39.5l4-3.5v7L57,39.5z"/>
+	M57,40l4-3.5v7L57,40z"/>
 <path id="path4173" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M115,39.5l4-3.5v7L115,39.5z"/>
+	M115,40l4-3.5v7L115,40z"/>
 <path id="path4175" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M120,39.5l4-3.5v7L120,39.5z"/>
-<rect id="rect4177" x="76" y="36" style="fill:#C8C8C8;" width="1" height="7"/>
+	M120,40l4-3.5v7L120,40z"/>
+<rect id="rect4177" x="76" y="36.5" style="fill:#C8C8C8;" width="1" height="7"/>
 <path id="path4179" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M75,39.5L71,43v-7L75,39.5z"/>
+	M75,40l-4,3.5v-7L75,40z"/>
 <path id="path4181" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M70,39.5L66,43v-7L70,39.5z"/>
+	M70,40l-4,3.5v-7L70,40z"/>
 <path id="path4183" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M141,39.5l-4,3.5v-7L141,39.5z"/>
+	M141,40l-4,3.5v-7L141,40z"/>
 <path id="path4185" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M136,39.5l-4,3.5v-7L136,39.5z"/>
-<rect id="rect4187" x="148" y="36" style="fill:#C8C8C8;" width="2" height="7"/>
-<path style="fill:#C8C8C8;" d="M152,36h1v7h-1V36z M157,39.5l-4,3.5v-7L157,39.5z"/>
+	M136,40l-4,3.5v-7L136,40z"/>
+<rect id="rect4187" x="148" y="36.5" style="fill:#C8C8C8;" width="2" height="7"/>
+<path style="fill:#C8C8C8;" d="M152,36.5h1v7h-1V36.5z M157,40l-4,3.5v-7L157,40z"/>
 <path id="path4179-5" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
 	M384,40l8-7v14L384,40z"/>
 <rect id="rect4187-3" x="384" y="37" style="fill:#C8C8C8;" width="4" height="6"/>
@@ -49,46 +49,46 @@
 <path style="fill:#C8C8C8;" d="M404,56l8-7v14L404,56z M404,53h4v6h-4V53z"/>
 <path id="path4276" inkscape:connector-curvature="0" style="fill:none;stroke:#FF0000;" d="M402,34l12,12"/>
 <path id="path4159_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M3,61V50l11,5.5L3,61z"/>
-<rect id="rect4161_1_" x="20" y="51" style="fill:#646464;" width="3" height="9"/>
-<rect id="rect4163_1_" x="25" y="51" style="fill:#646464;" width="3" height="9"/>
-<rect id="rect4165_1_" x="36" y="51" style="fill:#646464;" width="8" height="9"/>
-<rect id="rect4167_1_" x="50" y="52" style="fill:#646464;" width="1" height="7"/>
+	M3,61.5v-11L14,56L3,61.5z"/>
+<rect id="rect4161_1_" x="20" y="51.5" style="fill:#646464;" width="3" height="9"/>
+<rect id="rect4163_1_" x="25" y="51.5" style="fill:#646464;" width="3" height="9"/>
+<rect id="rect4165_1_" x="36" y="51.5" style="fill:#646464;" width="8" height="9"/>
+<rect id="rect4167_1_" x="50" y="52.5" style="fill:#646464;" width="1" height="7"/>
 <path id="path4169_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M52,55.5l4-3.5v7L52,55.5z"/>
+	M52,56l4-3.5v7L52,56z"/>
 <path id="path4171_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M57,55.5l4-3.5v7L57,55.5z"/>
+	M57,56l4-3.5v7L57,56z"/>
 <path id="path4173_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M115,55.5l4-3.5v7L115,55.5z"/>
+	M115,56l4-3.5v7L115,56z"/>
 <path id="path4175_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M120,55.5l4-3.5v7L120,55.5z"/>
-<rect id="rect4177_1_" x="76" y="52" style="fill:#646464;" width="1" height="7"/>
+	M120,56l4-3.5v7L120,56z"/>
+<rect id="rect4177_1_" x="76" y="52.5" style="fill:#646464;" width="1" height="7"/>
 <path id="path4179_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M75,55.5L71,59v-7L75,55.5z"/>
+	M75,56l-4,3.5v-7L75,56z"/>
 <path id="path4181_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M70,55.5L66,59v-7L70,55.5z"/>
+	M70,56l-4,3.5v-7L70,56z"/>
 <path id="path4183_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M141,55.5l-4,3.5v-7L141,55.5z"/>
+	M141,56l-4,3.5v-7L141,56z"/>
 <path id="path4185_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M136,55.5l-4,3.5v-7L136,55.5z"/>
-<rect id="rect4187_1_" x="148" y="52" style="fill:#646464;" width="2" height="7"/>
-<path style="fill:#646464;" d="M152,52h1v7h-1V52z M157,55.5l-4,3.5v-7L157,55.5z"/>
-<polygon points="3,13 3,2 14,7.5 "/>
-<rect x="20" y="3" width="3" height="9"/>
-<rect x="25" y="3" width="3" height="9"/>
-<rect x="36" y="3" width="8" height="9"/>
-<rect x="50" y="4" width="1" height="7"/>
-<polygon points="52,7.5 56,4 56,11 "/>
-<polygon points="57,7.5 61,4 61,11 "/>
-<polygon points="115,7.5 119,4 119,11 "/>
-<polygon points="120,7.5 124,4 124,11 "/>
-<rect x="76" y="4" width="1" height="7"/>
-<polygon points="75,7.5 71,11 71,4 "/>
-<polygon points="70,7.5 66,11 66,4 "/>
-<polygon points="141,7.5 137,11 137,4 "/>
-<polygon points="136,7.5 132,11 132,4 "/>
-<rect x="148" y="4" width="2" height="7"/>
-<path d="M153,11h-1V4h1V11z M157,7.5l-4,3.5V4L157,7.5z"/>
+	M136,56l-4,3.5v-7L136,56z"/>
+<rect id="rect4187_1_" x="148" y="52.5" style="fill:#646464;" width="2" height="7"/>
+<path style="fill:#646464;" d="M152,52.5h1v7h-1V52.5z M157,56l-4,3.5v-7L157,56z"/>
+<polygon points="3,13.5 3,2.5 14,8 "/>
+<rect x="20" y="3.5" width="3" height="9"/>
+<rect x="25" y="3.5" width="3" height="9"/>
+<rect x="36" y="3.5" width="8" height="9"/>
+<rect x="50" y="4.5" width="1" height="7"/>
+<polygon points="52,8 56,4.5 56,11.5 "/>
+<polygon points="57,8 61,4.5 61,11.5 "/>
+<polygon points="115,8 119,4.5 119,11.5 "/>
+<polygon points="120,8 124,4.5 124,11.5 "/>
+<rect x="76" y="4.5" width="1" height="7"/>
+<polygon points="75,8 71,11.5 71,4.5 "/>
+<polygon points="70,8 66,11.5 66,4.5 "/>
+<polygon points="141,8 137,11.5 137,4.5 "/>
+<polygon points="136,8 132,11.5 132,4.5 "/>
+<rect x="148" y="4.5" width="2" height="7"/>
+<path d="M153,11.5h-1v-7h1V11.5z M157,8l-4,3.5v-7L157,8z"/>
 <polygon points="384,8 392,1 392,15 "/>
 <path d="M388,11h-4V5h4V11z"/>
 <path style="fill:none;stroke:#000000;stroke-width:0.5;" d="M392.5,6.9c0.6,0,1,0.5,1,1.1s-0.4,1-1,1.1"/>
@@ -98,24 +98,24 @@
 <rect x="404" y="5" width="4" height="6"/>
 <path d="M404,24l8-7v14L404,24z M408,27h-4v-6h4V27z"/>
 <path style="fill:none;stroke:#FF0000;" d="M402,2l12,12"/>
-<polygon style="fill:#7F7F7F;" points="3,29 3,18 14,23.5 "/>
-<rect x="20" y="19" style="fill:#7F7F7F;" width="3" height="9"/>
-<rect x="25" y="19" style="fill:#7F7F7F;" width="3" height="9"/>
-<rect x="36" y="19" style="fill:#7F7F7F;" width="8" height="9"/>
-<rect x="50" y="20" style="fill:#7F7F7F;" width="1" height="7"/>
-<polygon style="fill:#7F7F7F;" points="52,23.5 56,20 56,27 "/>
-<polygon style="fill:#7F7F7F;" points="57,23.5 61,20 61,27 "/>
-<polygon style="fill:#7F7F7F;" points="115,23.5 119,20 119,27 "/>
-<polygon style="fill:#7F7F7F;" points="120,23.5 124,20 124,27 "/>
-<rect x="76" y="20" style="fill:#7F7F7F;" width="1" height="7"/>
-<polygon style="fill:#7F7F7F;" points="75,23.5 71,27 71,20 "/>
-<polygon style="fill:#7F7F7F;" points="70,23.5 66,27 66,20 "/>
-<polygon style="fill:#7F7F7F;" points="141,23.5 137,27 137,20 "/>
-<polygon style="fill:#7F7F7F;" points="136,23.5 132,27 132,20 "/>
-<rect x="148" y="20" style="fill:#7F7F7F;" width="2" height="7"/>
-<path style="fill:#7F7F7F;" d="M153,27h-1v-7h1V27z M157,23.5l-4,3.5v-7L157,23.5z"/>
+<polygon style="fill:#7F7F7F;" points="3,29.5 3,18.5 14,24 "/>
+<rect x="20" y="19.5" style="fill:#7F7F7F;" width="3" height="9"/>
+<rect x="25" y="19.5" style="fill:#7F7F7F;" width="3" height="9"/>
+<rect x="36" y="19.5" style="fill:#7F7F7F;" width="8" height="9"/>
+<rect x="50" y="20.5" style="fill:#7F7F7F;" width="1" height="7"/>
+<polygon style="fill:#7F7F7F;" points="52,24 56,20.5 56,27.5 "/>
+<polygon style="fill:#7F7F7F;" points="57,24 61,20.5 61,27.5 "/>
+<polygon style="fill:#7F7F7F;" points="115,24 119,20.5 119,27.5 "/>
+<polygon style="fill:#7F7F7F;" points="120,24 124,20.5 124,27.5 "/>
+<rect x="76" y="20.5" style="fill:#7F7F7F;" width="1" height="7"/>
+<polygon style="fill:#7F7F7F;" points="75,24 71,27.5 71,20.5 "/>
+<polygon style="fill:#7F7F7F;" points="70,24 66,27.5 66,20.5 "/>
+<polygon style="fill:#7F7F7F;" points="141,24 137,27.5 137,20.5 "/>
+<polygon style="fill:#7F7F7F;" points="136,24 132,27.5 132,20.5 "/>
+<rect x="148" y="20.5" style="fill:#7F7F7F;" width="2" height="7"/>
+<path style="fill:#7F7F7F;" d="M153,27.5h-1v-7h1V27.5z M157,24l-4,3.5v-7L157,24z"/>
 <rect x="256" y="-16" width="16" height="16"/>
-<rect id="rect4165_47_" x="80" y="6" width="1" height="3"/>
+<rect id="rect4165_47_" x="80" y="6.5" width="1" height="3"/>
 <polygon style="fill:#7F7F7F;" points="384,24 392,17 392,31 "/>
 <path style="fill:#7F7F7F;" d="M388,27h-4v-6h4V27z"/>
 <path style="fill:none;stroke:#7F7F7F;stroke-width:0.5;" d="M392.5,22.9c0.6,0,1,0.5,1,1.1s-0.4,1-1,1.1"/>
@@ -128,28 +128,28 @@
 <path id="path4230-0_1_" sodipodi:cx="201.32703" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="2.2667139" sodipodi:ry="2.1307797" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#646464;stroke-width:0.6;" d="
 	M393.5,53.8c1.2,0.1,2.1,1,2.1,2.1s-0.9,2-2.1,2.1"/>
 <g>
-	<path d="M103.7,9.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2l-0.2,0.7
-		c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,9.8z"/>
-	<path d="M108.2,9.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2L108,5.9
-		c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,9.8z"/>
+	<path d="M103.7,10.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2l-0.2,0.7
+		c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,10.3z"/>
+	<path d="M108.2,10.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2L108,6.4
+		c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,10.3z"/>
 </g>
 <g>
-	<path style="fill:#7F7F7F;" d="M103.7,25.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
-		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,25.8z"/>
-	<path style="fill:#7F7F7F;" d="M108.2,25.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
-		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,25.8z"/>
+	<path style="fill:#7F7F7F;" d="M103.7,26.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
+		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,26.3z"/>
+	<path style="fill:#7F7F7F;" d="M108.2,26.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
+		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,26.3z"/>
 </g>
 <g>
-	<path style="fill:#C8C8C8;" d="M103.7,41.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
-		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,41.8z"/>
-	<path style="fill:#C8C8C8;" d="M108.2,41.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
-		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,41.8z"/>
+	<path style="fill:#C8C8C8;" d="M103.7,42.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
+		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,42.3z"/>
+	<path style="fill:#C8C8C8;" d="M108.2,42.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
+		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,42.3z"/>
 </g>
 <g>
-	<path style="fill:#646464;" d="M103.7,57.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
-		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,57.8z"/>
-	<path style="fill:#646464;" d="M108.2,57.8c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
-		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,57.8z"/>
+	<path style="fill:#646464;" d="M103.7,58.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
+		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L103.7,58.3z"/>
+	<path style="fill:#646464;" d="M108.2,58.3c-0.2,0.1-0.7,0.3-1.4,0.3c-1.5,0-2.4-1-2.4-2.5s1-2.6,2.6-2.6c0.5,0,1,0.1,1.2,0.2
+		l-0.2,0.7c-0.2-0.1-0.5-0.2-1-0.2c-1.1,0-1.7,0.8-1.7,1.8c0,1.1,0.7,1.8,1.7,1.8c0.5,0,0.8-0.1,1.1-0.2L108.2,58.3z"/>
 </g>
 <rect x="164" y="10" width="8" height="2"/>
 <path d="M172,7v1h-8V7H172z M168,3l4,4h-8L168,3z"/>
@@ -158,26 +158,26 @@
 <rect id="rect4165_48_" x="182" y="10" width="3" height="1"/>
 <rect id="rect4165_49_" x="186" y="8" width="3" height="1"/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-miterlimit:10;" points="225,5.5 228.1,5.5 232.9,11.5 236,11.5 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-miterlimit:10;" points="225,5 228.1,5 232.9,11 236,11 	"/>
 </g>
-<rect id="rect4165_103_" x="211" y="52" style="fill:#C8C8C8;" width="10" height="1"/>
-<rect id="rect4165_102_" x="211" y="55" style="fill:#C8C8C8;" width="10" height="1"/>
-<rect id="rect4165_97_" x="211" y="58" style="fill:#C8C8C8;" width="5" height="1"/>
-<polygon style="fill:#C8C8C8;" points="221,59 218,61 218,57 "/>
+<rect id="rect4165_103_" x="211" y="52.5" style="fill:#C8C8C8;" width="10" height="1"/>
+<rect id="rect4165_102_" x="211" y="55.5" style="fill:#C8C8C8;" width="10" height="1"/>
+<rect id="rect4165_97_" x="211" y="58.5" style="fill:#C8C8C8;" width="5" height="1"/>
+<polygon style="fill:#C8C8C8;" points="221,59.5 218,61.5 218,57.5 "/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="217.5" y1="41.5" x2="220.5" y2="44.5"/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="217.5" y1="44.5" x2="220.5" y2="41.5"/>
-<rect id="rect4165_17_" x="211" y="36" style="fill:#C8C8C8;" width="10" height="1"/>
-<rect id="rect4165_16_" x="211" y="39" style="fill:#C8C8C8;" width="10" height="1"/>
-<rect id="rect4165_10_" x="211" y="42" style="fill:#C8C8C8;" width="5" height="1"/>
-<rect id="rect4165_105_" x="211" y="20" width="10" height="1"/>
-<rect id="rect4165_104_" x="211" y="23" width="10" height="1"/>
-<rect id="rect4165_101_" x="211" y="26" width="5" height="1"/>
-<polygon points="221,27 218,29 218,25 "/>
+<rect id="rect4165_17_" x="211" y="36.5" style="fill:#C8C8C8;" width="10" height="1"/>
+<rect id="rect4165_16_" x="211" y="39.5" style="fill:#C8C8C8;" width="10" height="1"/>
+<rect id="rect4165_10_" x="211" y="42.5" style="fill:#C8C8C8;" width="5" height="1"/>
+<rect id="rect4165_105_" x="211" y="20.5" width="10" height="1"/>
+<rect id="rect4165_104_" x="211" y="23.5" width="10" height="1"/>
+<rect id="rect4165_101_" x="211" y="26.5" width="5" height="1"/>
+<polygon points="221,27.5 218,29.5 218,25.5 "/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="217.5" y1="9.5" x2="220.5" y2="12.5"/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="217.5" y1="12.5" x2="220.5" y2="9.5"/>
-<rect id="rect4165_100_" x="211" y="4" width="10" height="1"/>
-<rect id="rect4165_99_" x="211" y="7" width="10" height="1"/>
-<rect id="rect4165_98_" x="211" y="10" width="5" height="1"/>
+<rect id="rect4165_100_" x="211" y="4.5" width="10" height="1"/>
+<rect id="rect4165_99_" x="211" y="7.5" width="10" height="1"/>
+<rect id="rect4165_98_" x="211" y="10.5" width="5" height="1"/>
 <rect id="rect4165_67_" x="195" y="28" width="4" height="1"/>
 <rect id="rect4165_66_" x="195" y="25" width="1" height="4"/>
 <rect id="rect4165_73_" x="195" y="19" width="1" height="4"/>
@@ -268,23 +268,23 @@
 <path style="fill:#C8C8C8;" d="M172,39v1h-8v-1H172z M168,35l4,4h-8L168,35z"/>
 <rect x="164" y="58" style="fill:#646464;" width="8" height="2"/>
 <path style="fill:#646464;" d="M172,55v1h-8v-1H172z M168,51l4,4h-8L168,51z"/>
-<polygon points="239,11.5 236,14 236,9 "/>
+<polygon points="239,11 236,13.5 236,8.5 "/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-miterlimit:10;" points="236,5.5 232.9,5.5 228.1,11.5 225,11.5 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-miterlimit:10;" points="236,5 232.9,5 228.1,11 225,11 	"/>
 </g>
-<polygon points="236,8 236,3 239,5.5 "/>
+<polygon points="236,7.5 236,2.5 239,5 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" points="225,37.5 228.1,37.5 232.9,43.5 236,43.5 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" points="225,37 228.1,37 232.9,43 236,43 	"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="239,43.5 236,46 236,41 "/>
+<polygon style="fill:#C8C8C8;" points="239,43 236,45.5 236,40.5 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" points="236,37.5 232.9,37.5 228.1,43.5 225,43.5 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" points="236,37 232.9,37 228.1,43 225,43 	"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="236,40 236,35 239,37.5 "/>
-<path d="M225,21h11v1h-11V21z M236,24v-5l3,2.5L236,24z"/>
-<path d="M225,27h11v1h-11V27z M239,27.5l-3,2.5v-5L239,27.5z"/>
-<path style="fill:#C8C8C8;" d="M225,53h11v1h-11V53z M236,56v-5l3,2.5L236,56z"/>
-<path style="fill:#C8C8C8;" d="M225,59h11v1h-11V59z M239,59.5l-3,2.5v-5L239,59.5z"/>
+<polygon style="fill:#C8C8C8;" points="236,39.5 236,34.5 239,37 "/>
+<path d="M225,20.5h11v1h-11V20.5z M236,23.5v-5l3,2.5L236,23.5z"/>
+<path d="M225,26.5h11v1h-11V26.5z M239,27l-3,2.5v-5L239,27z"/>
+<path style="fill:#C8C8C8;" d="M225,52.5h11v1h-11V52.5z M236,55.5v-5l3,2.5L236,55.5z"/>
+<path style="fill:#C8C8C8;" d="M225,58.5h11v1h-11V58.5z M239,59l-3,2.5v-5L239,59z"/>
 <path d="M247,11h7v1h-7V11z M253,5h1v6h-1V5z M252,4h2v1h-2V4z M247,9v5l-3-2.5L247,9z"/>
 <path d="M242,11h2v1h-2V11z M242,4h7v1h-7V4z M249,7V2l3,2.5L249,7z M242,5h1v6h-1V5z"/>
 <path style="fill:#C8C8C8;" d="M247,43h7v1h-7V43z M253,37h1v6h-1V37z M252,36h2v1h-2V36z M247,41v5l-3-2.5L247,41z"/>
@@ -305,37 +305,37 @@
 <polygon style="fill:#C8C8C8;" points="249,55 249,50 252,52.5 "/>
 <polygon style="fill:#C8C8C8;" points="247,57 247,62 244,59.5 "/>
 <rect id="rect4165_112_" x="242" y="53" style="fill:#C8C8C8;" width="1" height="6"/>
-<rect id="rect4165_44_" x="82" y="5" width="1" height="5"/>
-<rect id="rect4165_45_" x="84" y="3" width="1" height="9"/>
-<rect id="rect4165_163_" x="88" y="1" width="1" height="13"/>
-<rect id="rect4165_162_" x="86" y="4" width="1" height="7"/>
-<rect id="rect4165_46_" x="90" y="4" width="1" height="7"/>
-<rect id="rect4165_164_" x="92" y="3" width="1" height="9"/>
-<rect id="rect4165_168_" x="94" y="5" width="1" height="5"/>
-<rect id="rect4165_169_" x="80" y="38" style="fill:#C8C8C8;" width="1" height="3"/>
-<rect id="rect4165_167_" x="82" y="37" style="fill:#C8C8C8;" width="1" height="5"/>
-<rect id="rect4165_166_" x="84" y="35" style="fill:#C8C8C8;" width="1" height="9"/>
-<rect id="rect4165_165_" x="88" y="33" style="fill:#C8C8C8;" width="1" height="13"/>
-<rect id="rect4165_39_" x="86" y="36" style="fill:#C8C8C8;" width="1" height="7"/>
-<rect id="rect4165_38_" x="90" y="36" style="fill:#C8C8C8;" width="1" height="7"/>
-<rect id="rect4165_37_" x="92" y="35" style="fill:#C8C8C8;" width="1" height="9"/>
-<rect id="rect4165_36_" x="94" y="37" style="fill:#C8C8C8;" width="1" height="5"/>
-<rect id="rect4165_43_" x="80" y="22" style="fill:#7F7F7F;" width="1" height="3"/>
-<rect id="rect4165_42_" x="82" y="21" style="fill:#7F7F7F;" width="1" height="5"/>
-<rect id="rect4165_41_" x="84" y="19" style="fill:#7F7F7F;" width="1" height="9"/>
-<rect id="rect4165_40_" x="88" y="17" style="fill:#7F7F7F;" width="1" height="13"/>
-<rect id="rect4165_31_" x="86" y="20" style="fill:#7F7F7F;" width="1" height="7"/>
-<rect id="rect4165_30_" x="90" y="20" style="fill:#7F7F7F;" width="1" height="7"/>
-<rect id="rect4165_3_" x="92" y="19" style="fill:#7F7F7F;" width="1" height="9"/>
-<rect id="rect4165_2_" x="94" y="21" style="fill:#7F7F7F;" width="1" height="5"/>
-<rect id="rect4165_177_" x="80" y="54" style="fill:#646464;" width="1" height="3"/>
-<rect id="rect4165_176_" x="82" y="53" style="fill:#646464;" width="1" height="5"/>
-<rect id="rect4165_175_" x="84" y="51" style="fill:#646464;" width="1" height="9"/>
-<rect id="rect4165_174_" x="88" y="49" style="fill:#646464;" width="1" height="13"/>
-<rect id="rect4165_173_" x="86" y="52" style="fill:#646464;" width="1" height="7"/>
-<rect id="rect4165_172_" x="90" y="52" style="fill:#646464;" width="1" height="7"/>
-<rect id="rect4165_171_" x="92" y="51" style="fill:#646464;" width="1" height="9"/>
-<rect id="rect4165_170_" x="94" y="53" style="fill:#646464;" width="1" height="5"/>
+<rect id="rect4165_44_" x="82" y="5.5" width="1" height="5"/>
+<rect id="rect4165_45_" x="84" y="3.5" width="1" height="9"/>
+<rect id="rect4165_163_" x="88" y="1.5" width="1" height="13"/>
+<rect id="rect4165_162_" x="86" y="4.5" width="1" height="7"/>
+<rect id="rect4165_46_" x="90" y="4.5" width="1" height="7"/>
+<rect id="rect4165_164_" x="92" y="3.5" width="1" height="9"/>
+<rect id="rect4165_168_" x="94" y="5.5" width="1" height="5"/>
+<rect id="rect4165_169_" x="80" y="38.5" style="fill:#C8C8C8;" width="1" height="3"/>
+<rect id="rect4165_167_" x="82" y="37.5" style="fill:#C8C8C8;" width="1" height="5"/>
+<rect id="rect4165_166_" x="84" y="35.5" style="fill:#C8C8C8;" width="1" height="9"/>
+<rect id="rect4165_165_" x="88" y="33.5" style="fill:#C8C8C8;" width="1" height="13"/>
+<rect id="rect4165_39_" x="86" y="36.5" style="fill:#C8C8C8;" width="1" height="7"/>
+<rect id="rect4165_38_" x="90" y="36.5" style="fill:#C8C8C8;" width="1" height="7"/>
+<rect id="rect4165_37_" x="92" y="35.5" style="fill:#C8C8C8;" width="1" height="9"/>
+<rect id="rect4165_36_" x="94" y="37.5" style="fill:#C8C8C8;" width="1" height="5"/>
+<rect id="rect4165_43_" x="80" y="22.5" style="fill:#7F7F7F;" width="1" height="3"/>
+<rect id="rect4165_42_" x="82" y="21.5" style="fill:#7F7F7F;" width="1" height="5"/>
+<rect id="rect4165_41_" x="84" y="19.5" style="fill:#7F7F7F;" width="1" height="9"/>
+<rect id="rect4165_40_" x="88" y="17.5" style="fill:#7F7F7F;" width="1" height="13"/>
+<rect id="rect4165_31_" x="86" y="20.5" style="fill:#7F7F7F;" width="1" height="7"/>
+<rect id="rect4165_30_" x="90" y="20.5" style="fill:#7F7F7F;" width="1" height="7"/>
+<rect id="rect4165_3_" x="92" y="19.5" style="fill:#7F7F7F;" width="1" height="9"/>
+<rect id="rect4165_2_" x="94" y="21.5" style="fill:#7F7F7F;" width="1" height="5"/>
+<rect id="rect4165_177_" x="80" y="54.5" style="fill:#646464;" width="1" height="3"/>
+<rect id="rect4165_176_" x="82" y="53.5" style="fill:#646464;" width="1" height="5"/>
+<rect id="rect4165_175_" x="84" y="51.5" style="fill:#646464;" width="1" height="9"/>
+<rect id="rect4165_174_" x="88" y="49.5" style="fill:#646464;" width="1" height="13"/>
+<rect id="rect4165_173_" x="86" y="52.5" style="fill:#646464;" width="1" height="7"/>
+<rect id="rect4165_172_" x="90" y="52.5" style="fill:#646464;" width="1" height="7"/>
+<rect id="rect4165_171_" x="92" y="51.5" style="fill:#646464;" width="1" height="9"/>
+<rect id="rect4165_170_" x="94" y="53.5" style="fill:#646464;" width="1" height="5"/>
 <path d="M271,5h-13V4h13V5z M258.5,10L256,7h5L258.5,10z M271,10h-1V5h1V10z M259,7h-1V5h1V7z"/>
 <rect id="rect4165_181_" x="270" y="11" width="1" height="1"/>
 <rect id="rect4165_182_" x="268" y="11" width="1" height="1"/>

--- a/src/mpc-hc/res/buttons24.svg
+++ b/src/mpc-hc/res/buttons24.svg
@@ -8,30 +8,30 @@
 	<inkscape:grid  id="grid3353" type="xygrid"></inkscape:grid>
 </sodipodi:namedview>
 <path id="path4159" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M4.5,67.5V51L21,59.2L4.5,67.5z"/>
-<rect id="rect4161" x="30" y="52.5" style="fill:#C8C8C8;" width="4.5" height="13.5"/>
-<rect id="rect4163" x="37.5" y="52.5" style="fill:#C8C8C8;" width="4.5" height="13.5"/>
-<rect id="rect4165" x="54" y="52.5" style="fill:#C8C8C8;" width="12" height="13.5"/>
-<rect id="rect4167" x="75" y="54" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
+	M4.5,68.2V51.8L21,60L4.5,68.2z"/>
+<rect id="rect4161" x="30" y="53.2" style="fill:#C8C8C8;" width="4.5" height="13.5"/>
+<rect id="rect4163" x="37.5" y="53.2" style="fill:#C8C8C8;" width="4.5" height="13.5"/>
+<rect id="rect4165" x="54" y="53.2" style="fill:#C8C8C8;" width="12" height="13.5"/>
+<rect id="rect4167" x="75" y="54.8" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
 <path id="path4169" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M78,59.2l6-5.2v10.5L78,59.2z"/>
+	M78,60l6-5.2v10.5L78,60z"/>
 <path id="path4171" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M85.5,59.2l6-5.2v10.5L85.5,59.2z"/>
+	M85.5,60l6-5.2v10.5L85.5,60z"/>
 <path id="path4173" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M172.5,59.2l6-5.2v10.5L172.5,59.2z"/>
+	M172.5,60l6-5.2v10.5L172.5,60z"/>
 <path id="path4175" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M180,59.2l6-5.2v10.5L180,59.2z"/>
-<rect id="rect4177" x="114" y="54" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
+	M180,60l6-5.2v10.5L180,60z"/>
+<rect id="rect4177" x="114" y="54.8" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
 <path id="path4179" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M112.5,59.2l-6,5.2V54L112.5,59.2z"/>
+	M112.5,60l-6,5.2V54.8L112.5,60z"/>
 <path id="path4181" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M105,59.2l-6,5.2V54L105,59.2z"/>
+	M105,60l-6,5.2V54.8L105,60z"/>
 <path id="path4183" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M211.5,59.2l-6,5.2V54L211.5,59.2z"/>
+	M211.5,60l-6,5.2V54.8L211.5,60z"/>
 <path id="path4185" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M204,59.2l-6,5.2V54L204,59.2z"/>
-<rect id="rect4187" x="222" y="54" style="fill:#C8C8C8;" width="3" height="10.5"/>
-<path style="fill:#C8C8C8;" d="M228,54h1.5v10.5H228V54z M235.5,59.2l-6,5.2V54L235.5,59.2z"/>
+	M204,60l-6,5.2V54.8L204,60z"/>
+<rect id="rect4187" x="222" y="54.8" style="fill:#C8C8C8;" width="3" height="10.5"/>
+<path style="fill:#C8C8C8;" d="M228,54.8h1.5v10.5H228V54.8z M235.5,60l-6,5.2V54.8L235.5,60z"/>
 <path id="path4179-5" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
 	M576,60l12-10.5v21L576,60z"/>
 <rect id="rect4187-3" x="576" y="55.5" style="fill:#C8C8C8;" width="6" height="9"/>
@@ -42,53 +42,53 @@
 <path id="path4230-0" sodipodi:cx="201.32703" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="2.2667139" sodipodi:ry="2.1307797" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#C8C8C8;stroke-width:0.6;" d="
 	M590.2,56.7c1.8,0.1,3.2,1.5,3.2,3.1s-1.3,3-3.2,3.1"/>
 <path id="path4230-0-7" sodipodi:cx="201.63358" sodipodi:cy="1044.3519" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="4.5334277" sodipodi:ry="4.2615595" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#C8C8C8;stroke-width:0.7;" d="
-	M591,53.5c3.5,0.3,6.2,3,6.2,6.3c0,3.3-2.7,6.1-6.2,6.3"/>
+	M591,53.5c3.5,0.3,6.2,3,6.2,6.3s-2.7,6.1-6.2,6.3"/>
 <path id="path4262" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
 	M606,60l12-10.5v21L606,60z"/>
 <rect id="rect4264" x="606" y="55.5" style="fill:#C8C8C8;" width="6" height="9"/>
 <path style="fill:#C8C8C8;" d="M606,84l12-10.5v21L606,84z M606,79.5h6v9h-6V79.5z"/>
 <path id="path4276" inkscape:connector-curvature="0" style="fill:none;stroke:#FF0000;stroke-width:1.5;" d="M603,51l18,18"/>
 <path id="path4159_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M4.5,91.5V75L21,83.2L4.5,91.5z"/>
-<rect id="rect4161_1_" x="30" y="76.5" style="fill:#646464;" width="4.5" height="13.5"/>
-<rect id="rect4163_1_" x="37.5" y="76.5" style="fill:#646464;" width="4.5" height="13.5"/>
-<rect id="rect4165_1_" x="54" y="76.5" style="fill:#646464;" width="12" height="13.5"/>
-<rect id="rect4167_1_" x="75" y="78" style="fill:#646464;" width="1.5" height="10.5"/>
+	M4.5,92.2V75.8L21,83.9L4.5,92.2z"/>
+<rect id="rect4161_1_" x="30" y="77.2" style="fill:#646464;" width="4.5" height="13.5"/>
+<rect id="rect4163_1_" x="37.5" y="77.2" style="fill:#646464;" width="4.5" height="13.5"/>
+<rect id="rect4165_1_" x="54" y="77.2" style="fill:#646464;" width="12" height="13.5"/>
+<rect id="rect4167_1_" x="75" y="78.8" style="fill:#646464;" width="1.5" height="10.5"/>
 <path id="path4169_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M78,83.2l6-5.2v10.5L78,83.2z"/>
+	M78,83.9l6-5.2v10.5L78,83.9z"/>
 <path id="path4171_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M85.5,83.2l6-5.2v10.5L85.5,83.2z"/>
+	M85.5,83.9l6-5.2v10.5L85.5,83.9z"/>
 <path id="path4173_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M172.5,83.2l6-5.2v10.5L172.5,83.2z"/>
+	M172.5,83.9l6-5.2v10.5L172.5,83.9z"/>
 <path id="path4175_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M180,83.2l6-5.2v10.5L180,83.2z"/>
-<rect id="rect4177_1_" x="114" y="78" style="fill:#646464;" width="1.5" height="10.5"/>
+	M180,83.9l6-5.2v10.5L180,83.9z"/>
+<rect id="rect4177_1_" x="114" y="78.8" style="fill:#646464;" width="1.5" height="10.5"/>
 <path id="path4179_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M112.5,83.2l-6,5.2V78L112.5,83.2z"/>
+	M112.5,83.9l-6,5.2V78.8L112.5,83.9z"/>
 <path id="path4181_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M105,83.2l-6,5.2V78L105,83.2z"/>
+	M105,83.9l-6,5.2V78.8L105,83.9z"/>
 <path id="path4183_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M211.5,83.2l-6,5.2V78L211.5,83.2z"/>
+	M211.5,83.9l-6,5.2V78.8L211.5,83.9z"/>
 <path id="path4185_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M204,83.2l-6,5.2V78L204,83.2z"/>
-<rect id="rect4187_1_" x="222" y="78" style="fill:#646464;" width="3" height="10.5"/>
-<path style="fill:#646464;" d="M228,78h1.5v10.5H228V78z M235.5,83.2l-6,5.2V78L235.5,83.2z"/>
-<polygon points="4.5,19.5 4.5,3 21,11.2 "/>
-<rect x="30" y="4.5" width="4.5" height="13.5"/>
-<rect x="37.5" y="4.5" width="4.5" height="13.5"/>
-<rect x="54" y="4.5" width="12" height="13.5"/>
-<rect x="75" y="6" width="1.5" height="10.5"/>
-<polygon points="78,11.2 84,6 84,16.5 "/>
-<polygon points="85.5,11.2 91.5,6 91.5,16.5 "/>
-<polygon points="172.5,11.2 178.5,6 178.5,16.5 "/>
-<polygon points="180,11.2 186,6 186,16.5 "/>
-<rect x="114" y="6" width="1.5" height="10.5"/>
-<polygon points="112.5,11.2 106.5,16.5 106.5,6 "/>
-<polygon points="105,11.2 99,16.5 99,6 "/>
-<polygon points="211.5,11.2 205.5,16.5 205.5,6 "/>
-<polygon points="204,11.2 198,16.5 198,6 "/>
-<rect x="222" y="6" width="3" height="10.5"/>
-<path d="M229.5,16.5H228V6h1.5V16.5z M235.5,11.2l-6,5.2V6L235.5,11.2z"/>
+	M204,83.9l-6,5.2V78.8L204,83.9z"/>
+<rect id="rect4187_1_" x="222" y="78.8" style="fill:#646464;" width="3" height="10.5"/>
+<path style="fill:#646464;" d="M228,78.8h1.5v10.5H228V78.8z M235.5,83.9l-6,5.2V78.8L235.5,83.9z"/>
+<polygon points="4.5,20.2 4.5,3.8 21,11.9 "/>
+<rect x="30" y="5.2" width="4.5" height="13.5"/>
+<rect x="37.5" y="5.2" width="4.5" height="13.5"/>
+<rect x="54" y="5.2" width="12" height="13.5"/>
+<rect x="75" y="6.8" width="1.5" height="10.5"/>
+<polygon points="78,11.9 84,6.8 84,17.2 "/>
+<polygon points="85.5,11.9 91.5,6.8 91.5,17.2 "/>
+<polygon points="172.5,11.9 178.5,6.8 178.5,17.2 "/>
+<polygon points="180,11.9 186,6.8 186,17.2 "/>
+<rect x="114" y="6.8" width="1.5" height="10.5"/>
+<polygon points="112.5,11.9 106.5,17.2 106.5,6.8 "/>
+<polygon points="105,11.9 99,17.2 99,6.8 "/>
+<polygon points="211.5,11.9 205.5,17.2 205.5,6.8 "/>
+<polygon points="204,11.9 198,17.2 198,6.8 "/>
+<rect x="222" y="6.8" width="3" height="10.5"/>
+<path d="M229.5,17.2H228V6.8h1.5V17.2z M235.5,11.9l-6,5.2V6.8L235.5,11.9z"/>
 <polygon points="576,12 588,1.5 588,22.5 "/>
 <path d="M582,16.5h-6v-9h6V16.5z"/>
 <path style="fill:none;stroke:#000000;stroke-width:0.5;" d="M588.7,10.3c0.9,0,1.5,0.8,1.5,1.6c0,0.9-0.6,1.5-1.5,1.7"/>
@@ -98,27 +98,27 @@
 <rect x="606" y="7.5" width="6" height="9"/>
 <path d="M606,36l12-10.5v21L606,36z M612,40.5h-6v-9h6V40.5z"/>
 <path style="fill:none;stroke:#FF0000;stroke-width:1.5;" d="M603,3l18,18"/>
-<polygon style="fill:#7F7F7F;" points="4.5,43.5 4.5,27 21,35.2 "/>
-<rect x="30" y="28.5" style="fill:#7F7F7F;" width="4.5" height="13.5"/>
-<rect x="37.5" y="28.5" style="fill:#7F7F7F;" width="4.5" height="13.5"/>
-<rect x="54" y="28.5" style="fill:#7F7F7F;" width="12" height="13.5"/>
-<rect x="75" y="30" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
-<polygon style="fill:#7F7F7F;" points="78,35.2 84,30 84,40.5 "/>
-<polygon style="fill:#7F7F7F;" points="85.5,35.2 91.5,30 91.5,40.5 "/>
-<polygon style="fill:#7F7F7F;" points="172.5,35.2 178.5,30 178.5,40.5 "/>
-<polygon style="fill:#7F7F7F;" points="180,35.2 186,30 186,40.5 "/>
-<rect x="114" y="30" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
-<polygon style="fill:#7F7F7F;" points="112.5,35.2 106.5,40.5 106.5,30 "/>
-<polygon style="fill:#7F7F7F;" points="105,35.2 99,40.5 99,30 "/>
-<polygon style="fill:#7F7F7F;" points="211.5,35.2 205.5,40.5 205.5,30 "/>
-<polygon style="fill:#7F7F7F;" points="204,35.2 198,40.5 198,30 "/>
-<rect x="222" y="30" style="fill:#7F7F7F;" width="3" height="10.5"/>
-<path style="fill:#7F7F7F;" d="M229.5,40.5H228V30h1.5V40.5z M235.5,35.2l-6,5.2V30L235.5,35.2z"/>
+<polygon style="fill:#7F7F7F;" points="4.5,44.2 4.5,27.8 21,36 "/>
+<rect x="30" y="29.2" style="fill:#7F7F7F;" width="4.5" height="13.5"/>
+<rect x="37.5" y="29.2" style="fill:#7F7F7F;" width="4.5" height="13.5"/>
+<rect x="54" y="29.2" style="fill:#7F7F7F;" width="12" height="13.5"/>
+<rect x="75" y="30.8" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
+<polygon style="fill:#7F7F7F;" points="78,36 84,30.8 84,41.2 "/>
+<polygon style="fill:#7F7F7F;" points="85.5,36 91.5,30.8 91.5,41.2 "/>
+<polygon style="fill:#7F7F7F;" points="172.5,36 178.5,30.8 178.5,41.2 "/>
+<polygon style="fill:#7F7F7F;" points="180,36 186,30.8 186,41.2 "/>
+<rect x="114" y="30.8" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
+<polygon style="fill:#7F7F7F;" points="112.5,36 106.5,41.2 106.5,30.8 "/>
+<polygon style="fill:#7F7F7F;" points="105,36 99,41.2 99,30.8 "/>
+<polygon style="fill:#7F7F7F;" points="211.5,36 205.5,41.2 205.5,30.8 "/>
+<polygon style="fill:#7F7F7F;" points="204,36 198,41.2 198,30.8 "/>
+<rect x="222" y="30.8" style="fill:#7F7F7F;" width="3" height="10.5"/>
+<path style="fill:#7F7F7F;" d="M229.5,41.2H228V30.8h1.5V41.2z M235.5,36l-6,5.2V30.8L235.5,36z"/>
 <rect x="384" y="-24" width="24" height="24"/>
-<rect id="rect4165_47_" x="120" y="9" width="1.5" height="4.5"/>
+<rect id="rect4165_47_" x="120" y="9.8" width="1.5" height="4.5"/>
 <polygon style="fill:#7F7F7F;" points="576,36 588,25.5 588,46.5 "/>
 <path style="fill:#7F7F7F;" d="M582,40.5h-6v-9h6V40.5z"/>
-<path style="fill:none;stroke:#7F7F7F;stroke-width:0.5;" d="M588.7,34.3c0.9,0,1.5,0.8,1.5,1.7c0,0.9-0.6,1.5-1.5,1.6"/>
+<path style="fill:none;stroke:#7F7F7F;stroke-width:0.5;" d="M588.7,34.3c0.9,0,1.5,0.8,1.5,1.7s-0.6,1.5-1.5,1.6"/>
 <path style="fill:none;stroke:#7F7F7F;stroke-width:0.6;" d="M590.2,32.8c1.8,0.2,3.2,1.5,3.2,3.2c0,1.6-1.3,3-3.2,3.1"/>
 <path id="path4179-5_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
 	M576,84l12-10.5v21L576,84z"/>
@@ -128,28 +128,28 @@
 <path id="path4230-0_1_" sodipodi:cx="201.32703" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="2.2667139" sodipodi:ry="2.1307797" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#646464;stroke-width:0.6;" d="
 	M590.2,80.7c1.8,0.1,3.2,1.5,3.2,3.1c0,1.7-1.3,3-3.2,3.2"/>
 <g>
-	<path d="M155.5,14.7c-0.3,0.2-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3l-0.3,1
-		c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.2,1.6-0.3L155.5,14.7z"/>
-	<path d="M162.3,14.7c-0.3,0.2-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3l-0.3,1
-		c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.6,1.2-2.6,2.7c0,1.7,1.1,2.7,2.6,2.7c0.8,0,1.2-0.2,1.6-0.3L162.3,14.7z"/>
+	<path d="M155.5,15.4c-0.3,0.2-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3l-0.3,1
+		c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.2,1.6-0.3L155.5,15.4z"/>
+	<path d="M162.3,15.4c-0.3,0.2-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3l-0.3,1
+		c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.6,1.2-2.6,2.7c0,1.7,1.1,2.7,2.6,2.7c0.8,0,1.2-0.2,1.6-0.3L162.3,15.4z"/>
 </g>
 <g>
-	<path style="fill:#7F7F7F;" d="M155.5,38.7c-0.3,0.2-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
-		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L155.5,38.7z"/>
-	<path style="fill:#7F7F7F;" d="M162.3,38.7c-0.3,0.2-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
-		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L162.3,38.7z"/>
+	<path style="fill:#7F7F7F;" d="M155.5,39.5c-0.3,0.2-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
+		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L155.5,39.5z"/>
+	<path style="fill:#7F7F7F;" d="M162.3,39.5c-0.3,0.2-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
+		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L162.3,39.5z"/>
 </g>
 <g>
-	<path style="fill:#C8C8C8;" d="M155.5,62.7c-0.3,0.1-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
-		l-0.3,1.1c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.6,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L155.5,62.7z"/>
-	<path style="fill:#C8C8C8;" d="M162.3,62.7c-0.3,0.1-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
-		l-0.3,1.1c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.6,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L162.3,62.7z"/>
+	<path style="fill:#C8C8C8;" d="M155.5,63.5c-0.3,0.1-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
+		l-0.3,1.1c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.6,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L155.5,63.5z"/>
+	<path style="fill:#C8C8C8;" d="M162.3,63.5c-0.3,0.1-1,0.5-2.1,0.5c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.1,1.8,0.3
+		l-0.3,1.1c-0.3-0.1-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.6,1,2.7,2.5,2.7c0.8,0,1.2-0.1,1.6-0.3L162.3,63.5z"/>
 </g>
 <g>
-	<path style="fill:#646464;" d="M155.5,86.7c-0.3,0.1-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.2,1.8,0.3
-		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.2,1.6-0.3L155.5,86.7z"/>
-	<path style="fill:#646464;" d="M162.3,86.7c-0.3,0.1-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.2,1.8,0.3
-		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.2,1.6-0.3L162.3,86.7z"/>
+	<path style="fill:#646464;" d="M155.5,87.4c-0.3,0.1-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.2,1.8,0.3
+		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.2,1.6-0.3L155.5,87.4z"/>
+	<path style="fill:#646464;" d="M162.3,87.4c-0.3,0.1-1,0.4-2.1,0.4c-2.2,0-3.6-1.5-3.6-3.8s1.5-3.9,3.9-3.9c0.8,0,1.5,0.2,1.8,0.3
+		l-0.3,1.1c-0.3-0.2-0.8-0.3-1.5-0.3c-1.6,0-2.5,1.2-2.5,2.7c0,1.7,1,2.7,2.5,2.7c0.8,0,1.2-0.2,1.6-0.3L162.3,87.4z"/>
 </g>
 <rect x="246" y="15" width="12" height="3"/>
 <path d="M258,10.5V12h-12v-1.5H258z M252,4.5l6,6h-12L252,4.5z"/>
@@ -158,27 +158,27 @@
 <rect id="rect4165_48_" x="273" y="15" width="4.5" height="1.5"/>
 <rect id="rect4165_49_" x="279" y="12" width="4.5" height="1.5"/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:1.5;stroke-miterlimit:10;" points="337.5,8.2 342.1,8.2 349.3,17.2 
-		354,17.2 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:1.5;stroke-miterlimit:10;" points="337.5,7.4 342.1,7.4 349.3,16.5 
+		354,16.5 	"/>
 </g>
-<rect id="rect4165_103_" x="316.5" y="78" style="fill:#C8C8C8;" width="15" height="1.5"/>
-<rect id="rect4165_102_" x="316.5" y="82.5" style="fill:#C8C8C8;" width="15" height="1.5"/>
-<rect id="rect4165_97_" x="316.5" y="87" style="fill:#C8C8C8;" width="7.5" height="1.5"/>
-<polygon style="fill:#C8C8C8;" points="331.5,88.5 327,91.5 327,85.5 "/>
+<rect id="rect4165_103_" x="316.5" y="78.8" style="fill:#C8C8C8;" width="15" height="1.5"/>
+<rect id="rect4165_102_" x="316.5" y="83.2" style="fill:#C8C8C8;" width="15" height="1.5"/>
+<rect id="rect4165_97_" x="316.5" y="87.8" style="fill:#C8C8C8;" width="7.5" height="1.5"/>
+<polygon style="fill:#C8C8C8;" points="331.5,89.2 327,92.2 327,86.2 "/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="326.2" y1="62.2" x2="330.7" y2="66.7"/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="326.2" y1="66.7" x2="330.7" y2="62.2"/>
-<rect id="rect4165_17_" x="316.5" y="54" style="fill:#C8C8C8;" width="15" height="1.5"/>
-<rect id="rect4165_16_" x="316.5" y="58.5" style="fill:#C8C8C8;" width="15" height="1.5"/>
-<rect id="rect4165_10_" x="316.5" y="63" style="fill:#C8C8C8;" width="7.5" height="1.5"/>
-<rect id="rect4165_105_" x="316.5" y="30" width="15" height="1.5"/>
-<rect id="rect4165_104_" x="316.5" y="34.5" width="15" height="1.5"/>
-<rect id="rect4165_101_" x="316.5" y="39" width="7.5" height="1.5"/>
-<polygon points="331.5,40.5 327,43.5 327,37.5 "/>
+<rect id="rect4165_17_" x="316.5" y="54.8" style="fill:#C8C8C8;" width="15" height="1.5"/>
+<rect id="rect4165_16_" x="316.5" y="59.2" style="fill:#C8C8C8;" width="15" height="1.5"/>
+<rect id="rect4165_10_" x="316.5" y="63.8" style="fill:#C8C8C8;" width="7.5" height="1.5"/>
+<rect id="rect4165_105_" x="316.5" y="30.8" width="15" height="1.5"/>
+<rect id="rect4165_104_" x="316.5" y="35.2" width="15" height="1.5"/>
+<rect id="rect4165_101_" x="316.5" y="39.8" width="7.5" height="1.5"/>
+<polygon points="331.5,41.2 327,44.2 327,38.2 "/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="326.2" y1="14.2" x2="330.7" y2="18.7"/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="326.2" y1="18.7" x2="330.7" y2="14.2"/>
-<rect id="rect4165_100_" x="316.5" y="6" width="15" height="1.5"/>
-<rect id="rect4165_99_" x="316.5" y="10.5" width="15" height="1.5"/>
-<rect id="rect4165_98_" x="316.5" y="15" width="7.5" height="1.5"/>
+<rect id="rect4165_100_" x="316.5" y="6.8" width="15" height="1.5"/>
+<rect id="rect4165_99_" x="316.5" y="11.2" width="15" height="1.5"/>
+<rect id="rect4165_98_" x="316.5" y="15.8" width="7.5" height="1.5"/>
 <rect id="rect4165_67_" x="292.5" y="42" width="6" height="1.5"/>
 <rect id="rect4165_66_" x="292.5" y="37.5" width="1.5" height="6"/>
 <rect id="rect4165_73_" x="292.5" y="28.5" width="1.5" height="6"/>
@@ -269,26 +269,26 @@
 <path style="fill:#C8C8C8;" d="M258,58.5V60h-12v-1.5H258z M252,52.5l6,6h-12L252,52.5z"/>
 <rect x="246" y="87" style="fill:#646464;" width="12" height="3"/>
 <path style="fill:#646464;" d="M258,82.5V84h-12v-1.5H258z M252,76.5l6,6h-12L252,76.5z"/>
-<polygon points="358.5,17.2 354,21 354,13.5 "/>
+<polygon points="358.5,16.5 354,20.2 354,12.8 "/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:1.5;stroke-miterlimit:10;" points="354,8.2 349.3,8.2 342.1,17.2 
-		337.5,17.2 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:1.5;stroke-miterlimit:10;" points="354,7.4 349.3,7.4 342.1,16.5 
+		337.5,16.5 	"/>
 </g>
-<polygon points="354,12 354,4.5 358.5,8.2 "/>
+<polygon points="354,11.2 354,3.8 358.5,7.4 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:1.5;stroke-miterlimit:10;" points="337.5,56.2 342.1,56.2 349.3,65.2 
-		354,65.2 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:1.5;stroke-miterlimit:10;" points="337.5,55.5 342.1,55.5 349.3,64.4 
+		354,64.4 	"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="358.5,65.2 354,69 354,61.5 "/>
+<polygon style="fill:#C8C8C8;" points="358.5,64.4 354,68.2 354,60.8 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:1.5;stroke-miterlimit:10;" points="354,56.2 349.3,56.2 342.1,65.2 
-		337.5,65.2 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:1.5;stroke-miterlimit:10;" points="354,55.5 349.3,55.5 342.1,64.4 
+		337.5,64.4 	"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="354,60 354,52.5 358.5,56.2 "/>
-<path d="M337.5,31.5H354V33h-16.5V31.5z M354,36v-7.5l4.5,3.8L354,36z"/>
-<path d="M337.5,40.5H354V42h-16.5V40.5z M358.5,41.2L354,45v-7.5L358.5,41.2z"/>
-<path style="fill:#C8C8C8;" d="M337.5,79.5H354V81h-16.5V79.5z M354,84v-7.5l4.5,3.8L354,84z"/>
-<path style="fill:#C8C8C8;" d="M337.5,88.5H354V90h-16.5V88.5z M358.5,89.2L354,93v-7.5L358.5,89.2z"/>
+<polygon style="fill:#C8C8C8;" points="354,59.2 354,51.8 358.5,55.5 "/>
+<path d="M337.5,30.8H354v1.5h-16.5V30.8z M354,35.2v-7.5l4.5,3.8L354,35.2z"/>
+<path d="M337.5,39.8H354v1.5h-16.5V39.8z M358.5,40.5l-4.5,3.8v-7.5L358.5,40.5z"/>
+<path style="fill:#C8C8C8;" d="M337.5,78.8H354v1.5h-16.5V78.8z M354,83.2v-7.5l4.5,3.8L354,83.2z"/>
+<path style="fill:#C8C8C8;" d="M337.5,87.8H354v1.5h-16.5V87.8z M358.5,88.4l-4.5,3.8v-7.5L358.5,88.4z"/>
 <path d="M370.5,16.5H381V18h-10.5V16.5z M379.5,7.5h1.5v9h-1.5V7.5z M378,6h3v1.5h-3V6z M370.5,13.5V21l-4.5-3.8L370.5,13.5z"/>
 <path d="M363,16.5h3V18h-3V16.5z M363,6h10.5v1.5H363V6z M373.5,10.5V3l4.5,3.7L373.5,10.5z M363,7.5h1.5v9H363V7.5z"/>
 <path style="fill:#C8C8C8;" d="M370.5,64.5H381V66h-10.5V64.5z M379.5,55.5h1.5v9h-1.5V55.5z M378,54h3v1.5h-3V54z M370.5,61.5V69
@@ -311,37 +311,37 @@
 <polygon style="fill:#C8C8C8;" points="373.5,82.5 373.5,75 378,78.7 "/>
 <polygon style="fill:#C8C8C8;" points="370.5,85.5 370.5,93 366,89.2 "/>
 <rect id="rect4165_112_" x="363" y="79.5" style="fill:#C8C8C8;" width="1.5" height="9"/>
-<rect id="rect4165_44_" x="123" y="7.5" width="1.5" height="7.5"/>
-<rect id="rect4165_45_" x="126" y="4.5" width="1.5" height="13.5"/>
-<rect id="rect4165_163_" x="132" y="1.5" width="1.5" height="19.5"/>
-<rect id="rect4165_162_" x="129" y="6" width="1.5" height="10.5"/>
-<rect id="rect4165_46_" x="135" y="6" width="1.5" height="10.5"/>
-<rect id="rect4165_164_" x="138" y="4.5" width="1.5" height="13.5"/>
-<rect id="rect4165_168_" x="141" y="7.5" width="1.5" height="7.5"/>
-<rect id="rect4165_169_" x="120" y="57" style="fill:#C8C8C8;" width="1.5" height="4.5"/>
-<rect id="rect4165_167_" x="123" y="55.5" style="fill:#C8C8C8;" width="1.5" height="7.5"/>
-<rect id="rect4165_166_" x="126" y="52.5" style="fill:#C8C8C8;" width="1.5" height="13.5"/>
-<rect id="rect4165_165_" x="132" y="49.5" style="fill:#C8C8C8;" width="1.5" height="19.5"/>
-<rect id="rect4165_39_" x="129" y="54" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
-<rect id="rect4165_38_" x="135" y="54" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
-<rect id="rect4165_37_" x="138" y="52.5" style="fill:#C8C8C8;" width="1.5" height="13.5"/>
-<rect id="rect4165_36_" x="141" y="55.5" style="fill:#C8C8C8;" width="1.5" height="7.5"/>
-<rect id="rect4165_43_" x="120" y="33" style="fill:#7F7F7F;" width="1.5" height="4.5"/>
-<rect id="rect4165_42_" x="123" y="31.5" style="fill:#7F7F7F;" width="1.5" height="7.5"/>
-<rect id="rect4165_41_" x="126" y="28.5" style="fill:#7F7F7F;" width="1.5" height="13.5"/>
-<rect id="rect4165_40_" x="132" y="25.5" style="fill:#7F7F7F;" width="1.5" height="19.5"/>
-<rect id="rect4165_31_" x="129" y="30" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
-<rect id="rect4165_30_" x="135" y="30" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
-<rect id="rect4165_3_" x="138" y="28.5" style="fill:#7F7F7F;" width="1.5" height="13.5"/>
-<rect id="rect4165_2_" x="141" y="31.5" style="fill:#7F7F7F;" width="1.5" height="7.5"/>
-<rect id="rect4165_177_" x="120" y="81" style="fill:#646464;" width="1.5" height="4.5"/>
-<rect id="rect4165_176_" x="123" y="79.5" style="fill:#646464;" width="1.5" height="7.5"/>
-<rect id="rect4165_175_" x="126" y="76.5" style="fill:#646464;" width="1.5" height="13.5"/>
-<rect id="rect4165_174_" x="132" y="73.5" style="fill:#646464;" width="1.5" height="19.5"/>
-<rect id="rect4165_173_" x="129" y="78" style="fill:#646464;" width="1.5" height="10.5"/>
-<rect id="rect4165_172_" x="135" y="78" style="fill:#646464;" width="1.5" height="10.5"/>
-<rect id="rect4165_171_" x="138" y="76.5" style="fill:#646464;" width="1.5" height="13.5"/>
-<rect id="rect4165_170_" x="141" y="79.5" style="fill:#646464;" width="1.5" height="7.5"/>
+<rect id="rect4165_44_" x="123" y="8.2" width="1.5" height="7.5"/>
+<rect id="rect4165_45_" x="126" y="5.2" width="1.5" height="13.5"/>
+<rect id="rect4165_163_" x="132" y="2.2" width="1.5" height="19.5"/>
+<rect id="rect4165_162_" x="129" y="6.8" width="1.5" height="10.5"/>
+<rect id="rect4165_46_" x="135" y="6.8" width="1.5" height="10.5"/>
+<rect id="rect4165_164_" x="138" y="5.2" width="1.5" height="13.5"/>
+<rect id="rect4165_168_" x="141" y="8.2" width="1.5" height="7.5"/>
+<rect id="rect4165_169_" x="120" y="57.8" style="fill:#C8C8C8;" width="1.5" height="4.5"/>
+<rect id="rect4165_167_" x="123" y="56.2" style="fill:#C8C8C8;" width="1.5" height="7.5"/>
+<rect id="rect4165_166_" x="126" y="53.2" style="fill:#C8C8C8;" width="1.5" height="13.5"/>
+<rect id="rect4165_165_" x="132" y="50.2" style="fill:#C8C8C8;" width="1.5" height="19.5"/>
+<rect id="rect4165_39_" x="129" y="54.8" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
+<rect id="rect4165_38_" x="135" y="54.8" style="fill:#C8C8C8;" width="1.5" height="10.5"/>
+<rect id="rect4165_37_" x="138" y="53.2" style="fill:#C8C8C8;" width="1.5" height="13.5"/>
+<rect id="rect4165_36_" x="141" y="56.2" style="fill:#C8C8C8;" width="1.5" height="7.5"/>
+<rect id="rect4165_43_" x="120" y="33.8" style="fill:#7F7F7F;" width="1.5" height="4.5"/>
+<rect id="rect4165_42_" x="123" y="32.2" style="fill:#7F7F7F;" width="1.5" height="7.5"/>
+<rect id="rect4165_41_" x="126" y="29.2" style="fill:#7F7F7F;" width="1.5" height="13.5"/>
+<rect id="rect4165_40_" x="132" y="26.2" style="fill:#7F7F7F;" width="1.5" height="19.5"/>
+<rect id="rect4165_31_" x="129" y="30.8" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
+<rect id="rect4165_30_" x="135" y="30.8" style="fill:#7F7F7F;" width="1.5" height="10.5"/>
+<rect id="rect4165_3_" x="138" y="29.2" style="fill:#7F7F7F;" width="1.5" height="13.5"/>
+<rect id="rect4165_2_" x="141" y="32.2" style="fill:#7F7F7F;" width="1.5" height="7.5"/>
+<rect id="rect4165_177_" x="120" y="81.8" style="fill:#646464;" width="1.5" height="4.5"/>
+<rect id="rect4165_176_" x="123" y="80.2" style="fill:#646464;" width="1.5" height="7.5"/>
+<rect id="rect4165_175_" x="126" y="77.2" style="fill:#646464;" width="1.5" height="13.5"/>
+<rect id="rect4165_174_" x="132" y="74.2" style="fill:#646464;" width="1.5" height="19.5"/>
+<rect id="rect4165_173_" x="129" y="78.8" style="fill:#646464;" width="1.5" height="10.5"/>
+<rect id="rect4165_172_" x="135" y="78.8" style="fill:#646464;" width="1.5" height="10.5"/>
+<rect id="rect4165_171_" x="138" y="77.2" style="fill:#646464;" width="1.5" height="13.5"/>
+<rect id="rect4165_170_" x="141" y="80.2" style="fill:#646464;" width="1.5" height="7.5"/>
 <path d="M409.5,6H429v1.5h-19.5V6z M424.5,10.5h7.5l-3.8,4.5L424.5,10.5z M409.5,7.5h1.5V15h-1.5V7.5z M427.5,7.5h1.5v3h-1.5V7.5z"
 	/>
 <rect id="rect4165_181_" x="409.5" y="16.5" width="1.5" height="1.5"/>

--- a/src/mpc-hc/res/buttons32.svg
+++ b/src/mpc-hc/res/buttons32.svg
@@ -8,30 +8,30 @@
 	<inkscape:grid  id="grid3353" type="xygrid"></inkscape:grid>
 </sodipodi:namedview>
 <path id="path4159" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M6,90V68l22,11L6,90z"/>
-<rect id="rect4161" x="40" y="70" style="fill:#C8C8C8;" width="6" height="18"/>
-<rect id="rect4163" x="50" y="70" style="fill:#C8C8C8;" width="6" height="18"/>
-<rect id="rect4165" x="72" y="70" style="fill:#C8C8C8;" width="16" height="18"/>
-<rect id="rect4167" x="100" y="72" style="fill:#C8C8C8;" width="2" height="14"/>
+	M6,91V69l22,11L6,91z"/>
+<rect id="rect4161" x="40" y="71" style="fill:#C8C8C8;" width="6" height="18"/>
+<rect id="rect4163" x="50" y="71" style="fill:#C8C8C8;" width="6" height="18"/>
+<rect id="rect4165" x="72" y="71" style="fill:#C8C8C8;" width="16" height="18"/>
+<rect id="rect4167" x="100" y="73" style="fill:#C8C8C8;" width="2" height="14"/>
 <path id="path4169" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M104,79l8-7v14L104,79z"/>
+	M104,80l8-7v14L104,80z"/>
 <path id="path4171" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M114,79l8-7v14L114,79z"/>
+	M114,80l8-7v14L114,80z"/>
 <path id="path4173" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M230,79l8-7v14L230,79z"/>
+	M230,80l8-7v14L230,80z"/>
 <path id="path4175" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M240,79l8-7v14L240,79z"/>
-<rect id="rect4177" x="152" y="72" style="fill:#C8C8C8;" width="2" height="14"/>
+	M240,80l8-7v14L240,80z"/>
+<rect id="rect4177" x="152" y="73" style="fill:#C8C8C8;" width="2" height="14"/>
 <path id="path4179" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M150,79l-8,7V72L150,79z"/>
+	M150,80l-8,7V73L150,80z"/>
 <path id="path4181" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M140,79l-8,7V72L140,79z"/>
+	M140,80l-8,7V73L140,80z"/>
 <path id="path4183" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M282,79l-8,7V72L282,79z"/>
+	M282,80l-8,7V73L282,80z"/>
 <path id="path4185" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M272,79l-8,7V72L272,79z"/>
-<rect id="rect4187" x="296" y="72" style="fill:#C8C8C8;" width="4" height="14"/>
-<path style="fill:#C8C8C8;" d="M304,72h2v14h-2V72z M314,79l-8,7V72L314,79z"/>
+	M272,80l-8,7V73L272,80z"/>
+<rect id="rect4187" x="296" y="73" style="fill:#C8C8C8;" width="4" height="14"/>
+<path style="fill:#C8C8C8;" d="M304,73h2v14h-2V73z M314,80l-8,7V73L314,80z"/>
 <path id="path4179-5" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
 	M768,80l16-14v28L768,80z"/>
 <rect id="rect4187-3" x="768" y="74" style="fill:#C8C8C8;" width="8" height="12"/>
@@ -49,46 +49,46 @@
 <path style="fill:#C8C8C8;" d="M808,112l16-14v28L808,112z M808,106h8v12h-8V106z"/>
 <path id="path4276" inkscape:connector-curvature="0" style="fill:none;stroke:#FF0000;stroke-width:2;" d="M804,68l24,24"/>
 <path id="path4159_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M6,122v-22l22,11L6,122z"/>
-<rect id="rect4161_1_" x="40" y="102" style="fill:#646464;" width="6" height="18"/>
-<rect id="rect4163_1_" x="50" y="102" style="fill:#646464;" width="6" height="18"/>
-<rect id="rect4165_1_" x="72" y="102" style="fill:#646464;" width="16" height="18"/>
-<rect id="rect4167_1_" x="100" y="104" style="fill:#646464;" width="2" height="14"/>
+	M6,123v-22l22,11L6,123z"/>
+<rect id="rect4161_1_" x="40" y="103" style="fill:#646464;" width="6" height="18"/>
+<rect id="rect4163_1_" x="50" y="103" style="fill:#646464;" width="6" height="18"/>
+<rect id="rect4165_1_" x="72" y="103" style="fill:#646464;" width="16" height="18"/>
+<rect id="rect4167_1_" x="100" y="105" style="fill:#646464;" width="2" height="14"/>
 <path id="path4169_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M104,111l8-7v14L104,111z"/>
+	M104,112l8-7v14L104,112z"/>
 <path id="path4171_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M114,111l8-7v14L114,111z"/>
+	M114,112l8-7v14L114,112z"/>
 <path id="path4173_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M230,111l8-7v14L230,111z"/>
+	M230,112l8-7v14L230,112z"/>
 <path id="path4175_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M240,111l8-7v14L240,111z"/>
-<rect id="rect4177_1_" x="152" y="104" style="fill:#646464;" width="2" height="14"/>
+	M240,112l8-7v14L240,112z"/>
+<rect id="rect4177_1_" x="152" y="105" style="fill:#646464;" width="2" height="14"/>
 <path id="path4179_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M150,111l-8,7v-14L150,111z"/>
+	M150,112l-8,7v-14L150,112z"/>
 <path id="path4181_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M140,111l-8,7v-14L140,111z"/>
+	M140,112l-8,7v-14L140,112z"/>
 <path id="path4183_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M282,111l-8,7v-14L282,111z"/>
+	M282,112l-8,7v-14L282,112z"/>
 <path id="path4185_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M272,111l-8,7v-14L272,111z"/>
-<rect id="rect4187_1_" x="296" y="104" style="fill:#646464;" width="4" height="14"/>
-<path style="fill:#646464;" d="M304,104h2v14h-2V104z M314,111l-8,7v-14L314,111z"/>
-<polygon points="6,26 6,4 28,15 "/>
-<rect x="40" y="6" width="6" height="18"/>
-<rect x="50" y="6" width="6" height="18"/>
-<rect x="72" y="6" width="16" height="18"/>
-<rect x="100" y="8" width="2" height="14"/>
-<polygon points="104,15 112,8 112,22 "/>
-<polygon points="114,15 122,8 122,22 "/>
-<polygon points="230,15 238,8 238,22 "/>
-<polygon points="240,15 248,8 248,22 "/>
-<rect x="152" y="8" width="2" height="14"/>
-<polygon points="150,15 142,22 142,8 "/>
-<polygon points="140,15 132,22 132,8 "/>
-<polygon points="282,15 274,22 274,8 "/>
-<polygon points="272,15 264,22 264,8 "/>
-<rect x="296" y="8" width="4" height="14"/>
-<path d="M306,22h-2V8h2V22z M314,15l-8,7V8L314,15z"/>
+	M272,112l-8,7v-14L272,112z"/>
+<rect id="rect4187_1_" x="296" y="105" style="fill:#646464;" width="4" height="14"/>
+<path style="fill:#646464;" d="M304,105h2v14h-2V105z M314,112l-8,7v-14L314,112z"/>
+<polygon points="6,27 6,5 28,16 "/>
+<rect x="40" y="7" width="6" height="18"/>
+<rect x="50" y="7" width="6" height="18"/>
+<rect x="72" y="7" width="16" height="18"/>
+<rect x="100" y="9" width="2" height="14"/>
+<polygon points="104,16 112,9 112,23 "/>
+<polygon points="114,16 122,9 122,23 "/>
+<polygon points="230,16 238,9 238,23 "/>
+<polygon points="240,16 248,9 248,23 "/>
+<rect x="152" y="9" width="2" height="14"/>
+<polygon points="150,16 142,23 142,9 "/>
+<polygon points="140,16 132,23 132,9 "/>
+<polygon points="282,16 274,23 274,9 "/>
+<polygon points="272,16 264,23 264,9 "/>
+<rect x="296" y="9" width="4" height="14"/>
+<path d="M306,23h-2V9h2V23z M314,16l-8,7V9L314,16z"/>
 <polygon points="768,16 784,2 784,30 "/>
 <path d="M776,22h-8V10h8V22z"/>
 <path style="fill:none;stroke:#000000;stroke-width:0.5;" d="M785,13.8c1.2,0,2,1,2,2.2s-0.8,2-2,2.2"/>
@@ -98,24 +98,24 @@
 <rect x="808" y="10" width="8" height="12"/>
 <path d="M808,48l16-14v28L808,48z M816,54h-8V42h8V54z"/>
 <path style="fill:none;stroke:#FF0000;stroke-width:2;" d="M804,4l24,24"/>
-<polygon style="fill:#7F7F7F;" points="6,58 6,36 28,47 "/>
-<rect x="40" y="38" style="fill:#7F7F7F;" width="6" height="18"/>
-<rect x="50" y="38" style="fill:#7F7F7F;" width="6" height="18"/>
-<rect x="72" y="38" style="fill:#7F7F7F;" width="16" height="18"/>
-<rect x="100" y="40" style="fill:#7F7F7F;" width="2" height="14"/>
-<polygon style="fill:#7F7F7F;" points="104,47 112,40 112,54 "/>
-<polygon style="fill:#7F7F7F;" points="114,47 122,40 122,54 "/>
-<polygon style="fill:#7F7F7F;" points="230,47 238,40 238,54 "/>
-<polygon style="fill:#7F7F7F;" points="240,47 248,40 248,54 "/>
-<rect x="152" y="40" style="fill:#7F7F7F;" width="2" height="14"/>
-<polygon style="fill:#7F7F7F;" points="150,47 142,54 142,40 "/>
-<polygon style="fill:#7F7F7F;" points="140,47 132,54 132,40 "/>
-<polygon style="fill:#7F7F7F;" points="282,47 274,54 274,40 "/>
-<polygon style="fill:#7F7F7F;" points="272,47 264,54 264,40 "/>
-<rect x="296" y="40" style="fill:#7F7F7F;" width="4" height="14"/>
-<path style="fill:#7F7F7F;" d="M306,54h-2V40h2V54z M314,47l-8,7V40L314,47z"/>
+<polygon style="fill:#7F7F7F;" points="6,59 6,37 28,48 "/>
+<rect x="40" y="39" style="fill:#7F7F7F;" width="6" height="18"/>
+<rect x="50" y="39" style="fill:#7F7F7F;" width="6" height="18"/>
+<rect x="72" y="39" style="fill:#7F7F7F;" width="16" height="18"/>
+<rect x="100" y="41" style="fill:#7F7F7F;" width="2" height="14"/>
+<polygon style="fill:#7F7F7F;" points="104,48 112,41 112,55 "/>
+<polygon style="fill:#7F7F7F;" points="114,48 122,41 122,55 "/>
+<polygon style="fill:#7F7F7F;" points="230,48 238,41 238,55 "/>
+<polygon style="fill:#7F7F7F;" points="240,48 248,41 248,55 "/>
+<rect x="152" y="41" style="fill:#7F7F7F;" width="2" height="14"/>
+<polygon style="fill:#7F7F7F;" points="150,48 142,55 142,41 "/>
+<polygon style="fill:#7F7F7F;" points="140,48 132,55 132,41 "/>
+<polygon style="fill:#7F7F7F;" points="282,48 274,55 274,41 "/>
+<polygon style="fill:#7F7F7F;" points="272,48 264,55 264,41 "/>
+<rect x="296" y="41" style="fill:#7F7F7F;" width="4" height="14"/>
+<path style="fill:#7F7F7F;" d="M306,55h-2V41h2V55z M314,48l-8,7V41L314,48z"/>
 <rect x="512" y="-32" width="32" height="32"/>
-<rect id="rect4165_47_" x="160" y="12" width="2" height="6"/>
+<rect id="rect4165_47_" x="160" y="13" width="2" height="6"/>
 <polygon style="fill:#7F7F7F;" points="768,48 784,34 784,62 "/>
 <path style="fill:#7F7F7F;" d="M776,54h-8V42h8V54z"/>
 <path style="fill:none;stroke:#7F7F7F;stroke-width:0.5;" d="M785,45.8c1.2,0,2,1,2,2.2s-0.8,2-2,2.2"/>
@@ -128,28 +128,28 @@
 <path id="path4230-0_1_" sodipodi:cx="201.32703" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="2.2667139" sodipodi:ry="2.1307797" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#646464;stroke-width:0.6;" d="
 	M787,107.6c2.4,0.2,4.2,2,4.2,4.2s-1.8,4-4.2,4.2"/>
 <g>
-	<path d="M207.4,19.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4c-0.4-0.2-1-0.4-2-0.4
-		c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,19.6z"/>
-	<path d="M216.4,19.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4c-0.4-0.2-1-0.4-2-0.4
-		c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,19.6z"/>
+	<path d="M207.4,20.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4c-0.4-0.2-1-0.4-2-0.4
+		c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,20.6z"/>
+	<path d="M216.4,20.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4c-0.4-0.2-1-0.4-2-0.4
+		c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,20.6z"/>
 </g>
 <g>
-	<path style="fill:#7F7F7F;" d="M207.4,51.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
-		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,51.6z"/>
-	<path style="fill:#7F7F7F;" d="M216.4,51.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
-		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,51.6z"/>
+	<path style="fill:#7F7F7F;" d="M207.4,52.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
+		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,52.6z"/>
+	<path style="fill:#7F7F7F;" d="M216.4,52.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
+		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,52.6z"/>
 </g>
 <g>
-	<path style="fill:#C8C8C8;" d="M207.4,83.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
-		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,83.6z"/>
-	<path style="fill:#C8C8C8;" d="M216.4,83.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
-		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,83.6z"/>
+	<path style="fill:#C8C8C8;" d="M207.4,84.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
+		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,84.6z"/>
+	<path style="fill:#C8C8C8;" d="M216.4,84.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
+		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,84.6z"/>
 </g>
 <g>
-	<path style="fill:#646464;" d="M207.4,115.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
-		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,115.6z"/>
-	<path style="fill:#646464;" d="M216.4,115.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
-		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,115.6z"/>
+	<path style="fill:#646464;" d="M207.4,116.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
+		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L207.4,116.6z"/>
+	<path style="fill:#646464;" d="M216.4,116.6c-0.4,0.2-1.4,0.6-2.8,0.6c-3,0-4.8-2-4.8-5s2-5.2,5.2-5.2c1,0,2,0.2,2.4,0.4l-0.4,1.4
+		c-0.4-0.2-1-0.4-2-0.4c-2.2,0-3.4,1.6-3.4,3.6c0,2.2,1.4,3.6,3.4,3.6c1,0,1.6-0.2,2.2-0.4L216.4,116.6z"/>
 </g>
 <rect x="328" y="20" width="16" height="4"/>
 <path d="M344,14v2h-16v-2H344z M336,6l8,8h-16L336,6z"/>
@@ -158,26 +158,26 @@
 <rect id="rect4165_48_" x="364" y="20" width="6" height="2"/>
 <rect id="rect4165_49_" x="372" y="16" width="6" height="2"/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:10;" points="450,11 456.2,11 465.8,23 472,23 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:10;" points="450,10 456.2,10 465.8,22 472,22 	"/>
 </g>
-<rect id="rect4165_103_" x="422" y="104" style="fill:#C8C8C8;" width="20" height="2"/>
-<rect id="rect4165_102_" x="422" y="110" style="fill:#C8C8C8;" width="20" height="2"/>
-<rect id="rect4165_97_" x="422" y="116" style="fill:#C8C8C8;" width="10" height="2"/>
-<polygon style="fill:#C8C8C8;" points="442,118 436,122 436,114 "/>
+<rect id="rect4165_103_" x="422" y="105" style="fill:#C8C8C8;" width="20" height="2"/>
+<rect id="rect4165_102_" x="422" y="111" style="fill:#C8C8C8;" width="20" height="2"/>
+<rect id="rect4165_97_" x="422" y="117" style="fill:#C8C8C8;" width="10" height="2"/>
+<polygon style="fill:#C8C8C8;" points="442,119 436,123 436,115 "/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="435" y1="83" x2="441" y2="89"/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="435" y1="89" x2="441" y2="83"/>
-<rect id="rect4165_17_" x="422" y="72" style="fill:#C8C8C8;" width="20" height="2"/>
-<rect id="rect4165_16_" x="422" y="78" style="fill:#C8C8C8;" width="20" height="2"/>
-<rect id="rect4165_10_" x="422" y="84" style="fill:#C8C8C8;" width="10" height="2"/>
-<rect id="rect4165_105_" x="422" y="40" width="20" height="2"/>
-<rect id="rect4165_104_" x="422" y="46" width="20" height="2"/>
-<rect id="rect4165_101_" x="422" y="52" width="10" height="2"/>
-<polygon points="442,54 436,58 436,50 "/>
+<rect id="rect4165_17_" x="422" y="73" style="fill:#C8C8C8;" width="20" height="2"/>
+<rect id="rect4165_16_" x="422" y="79" style="fill:#C8C8C8;" width="20" height="2"/>
+<rect id="rect4165_10_" x="422" y="85" style="fill:#C8C8C8;" width="10" height="2"/>
+<rect id="rect4165_105_" x="422" y="41" width="20" height="2"/>
+<rect id="rect4165_104_" x="422" y="47" width="20" height="2"/>
+<rect id="rect4165_101_" x="422" y="53" width="10" height="2"/>
+<polygon points="442,55 436,59 436,51 "/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="435" y1="19" x2="441" y2="25"/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="435" y1="25" x2="441" y2="19"/>
-<rect id="rect4165_100_" x="422" y="8" width="20" height="2"/>
-<rect id="rect4165_99_" x="422" y="14" width="20" height="2"/>
-<rect id="rect4165_98_" x="422" y="20" width="10" height="2"/>
+<rect id="rect4165_100_" x="422" y="9" width="20" height="2"/>
+<rect id="rect4165_99_" x="422" y="15" width="20" height="2"/>
+<rect id="rect4165_98_" x="422" y="21" width="10" height="2"/>
 <rect id="rect4165_67_" x="390" y="56" width="8" height="2"/>
 <rect id="rect4165_66_" x="390" y="50" width="2" height="8"/>
 <rect id="rect4165_73_" x="390" y="38" width="2" height="8"/>
@@ -268,23 +268,23 @@
 <path style="fill:#C8C8C8;" d="M344,78v2h-16v-2H344z M336,70l8,8h-16L336,70z"/>
 <rect x="328" y="116" style="fill:#646464;" width="16" height="4"/>
 <path style="fill:#646464;" d="M344,110v2h-16v-2H344z M336,102l8,8h-16L336,102z"/>
-<polygon points="478,23 472,28 472,18 "/>
+<polygon points="478,22 472,27 472,17 "/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:10;" points="472,11 465.8,11 456.2,23 450,23 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:10;" points="472,10 465.8,10 456.2,22 450,22 	"/>
 </g>
-<polygon points="472,16 472,6 478,11 "/>
+<polygon points="472,15 472,5 478,10 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:2;stroke-miterlimit:10;" points="450,75 456.2,75 465.8,87 472,87 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:2;stroke-miterlimit:10;" points="450,74 456.2,74 465.8,86 472,86 	"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="478,87 472,92 472,82 "/>
+<polygon style="fill:#C8C8C8;" points="478,86 472,91 472,81 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:2;stroke-miterlimit:10;" points="472,75 465.8,75 456.2,87 450,87 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:2;stroke-miterlimit:10;" points="472,74 465.8,74 456.2,86 450,86 	"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="472,80 472,70 478,75 "/>
-<path d="M450,42h22v2h-22V42z M472,48V38l6,5L472,48z"/>
-<path d="M450,54h22v2h-22V54z M478,55l-6,5V50L478,55z"/>
-<path style="fill:#C8C8C8;" d="M450,106h22v2h-22V106z M472,112v-10l6,5L472,112z"/>
-<path style="fill:#C8C8C8;" d="M450,118h22v2h-22V118z M478,119l-6,5v-10L478,119z"/>
+<polygon style="fill:#C8C8C8;" points="472,79 472,69 478,74 "/>
+<path d="M450,41h22v2h-22V41z M472,47V37l6,5L472,47z"/>
+<path d="M450,53h22v2h-22V53z M478,54l-6,5V49L478,54z"/>
+<path style="fill:#C8C8C8;" d="M450,105h22v2h-22V105z M472,111v-10l6,5L472,111z"/>
+<path style="fill:#C8C8C8;" d="M450,117h22v2h-22V117z M478,118l-6,5v-10L478,118z"/>
 <path d="M494,22h14v2h-14V22z M506,10h2v12h-2V10z M504,8h4v2h-4V8z M494,18v10l-6-5L494,18z"/>
 <path d="M484,22h4v2h-4V22z M484,8h14v2h-14V8z M498,14V4l6,5L498,14z M484,10h2v12h-2V10z"/>
 <path style="fill:#C8C8C8;" d="M494,86h14v2h-14V86z M506,74h2v12h-2V74z M504,72h4v2h-4V72z M494,82v10l-6-5L494,82z"/>
@@ -305,37 +305,37 @@
 <polygon style="fill:#C8C8C8;" points="498,110 498,100 504,105 "/>
 <polygon style="fill:#C8C8C8;" points="494,114 494,124 488,119 "/>
 <rect id="rect4165_112_" x="484" y="106" style="fill:#C8C8C8;" width="2" height="12"/>
-<rect id="rect4165_44_" x="164" y="10" width="2" height="10"/>
-<rect id="rect4165_45_" x="168" y="6" width="2" height="18"/>
-<rect id="rect4165_163_" x="176" y="2" width="2" height="26"/>
-<rect id="rect4165_162_" x="172" y="8" width="2" height="14"/>
-<rect id="rect4165_46_" x="180" y="8" width="2" height="14"/>
-<rect id="rect4165_164_" x="184" y="6" width="2" height="18"/>
-<rect id="rect4165_168_" x="188" y="10" width="2" height="10"/>
-<rect id="rect4165_169_" x="160" y="76" style="fill:#C8C8C8;" width="2" height="6"/>
-<rect id="rect4165_167_" x="164" y="74" style="fill:#C8C8C8;" width="2" height="10"/>
-<rect id="rect4165_166_" x="168" y="70" style="fill:#C8C8C8;" width="2" height="18"/>
-<rect id="rect4165_165_" x="176" y="66" style="fill:#C8C8C8;" width="2" height="26"/>
-<rect id="rect4165_39_" x="172" y="72" style="fill:#C8C8C8;" width="2" height="14"/>
-<rect id="rect4165_38_" x="180" y="72" style="fill:#C8C8C8;" width="2" height="14"/>
-<rect id="rect4165_37_" x="184" y="70" style="fill:#C8C8C8;" width="2" height="18"/>
-<rect id="rect4165_36_" x="188" y="74" style="fill:#C8C8C8;" width="2" height="10"/>
-<rect id="rect4165_43_" x="160" y="44" style="fill:#7F7F7F;" width="2" height="6"/>
-<rect id="rect4165_42_" x="164" y="42" style="fill:#7F7F7F;" width="2" height="10"/>
-<rect id="rect4165_41_" x="168" y="38" style="fill:#7F7F7F;" width="2" height="18"/>
-<rect id="rect4165_40_" x="176" y="34" style="fill:#7F7F7F;" width="2" height="26"/>
-<rect id="rect4165_31_" x="172" y="40" style="fill:#7F7F7F;" width="2" height="14"/>
-<rect id="rect4165_30_" x="180" y="40" style="fill:#7F7F7F;" width="2" height="14"/>
-<rect id="rect4165_3_" x="184" y="38" style="fill:#7F7F7F;" width="2" height="18"/>
-<rect id="rect4165_2_" x="188" y="42" style="fill:#7F7F7F;" width="2" height="10"/>
-<rect id="rect4165_177_" x="160" y="108" style="fill:#646464;" width="2" height="6"/>
-<rect id="rect4165_176_" x="164" y="106" style="fill:#646464;" width="2" height="10"/>
-<rect id="rect4165_175_" x="168" y="102" style="fill:#646464;" width="2" height="18"/>
-<rect id="rect4165_174_" x="176" y="98" style="fill:#646464;" width="2" height="26"/>
-<rect id="rect4165_173_" x="172" y="104" style="fill:#646464;" width="2" height="14"/>
-<rect id="rect4165_172_" x="180" y="104" style="fill:#646464;" width="2" height="14"/>
-<rect id="rect4165_171_" x="184" y="102" style="fill:#646464;" width="2" height="18"/>
-<rect id="rect4165_170_" x="188" y="106" style="fill:#646464;" width="2" height="10"/>
+<rect id="rect4165_44_" x="164" y="11" width="2" height="10"/>
+<rect id="rect4165_45_" x="168" y="7" width="2" height="18"/>
+<rect id="rect4165_163_" x="176" y="3" width="2" height="26"/>
+<rect id="rect4165_162_" x="172" y="9" width="2" height="14"/>
+<rect id="rect4165_46_" x="180" y="9" width="2" height="14"/>
+<rect id="rect4165_164_" x="184" y="7" width="2" height="18"/>
+<rect id="rect4165_168_" x="188" y="11" width="2" height="10"/>
+<rect id="rect4165_169_" x="160" y="77" style="fill:#C8C8C8;" width="2" height="6"/>
+<rect id="rect4165_167_" x="164" y="75" style="fill:#C8C8C8;" width="2" height="10"/>
+<rect id="rect4165_166_" x="168" y="71" style="fill:#C8C8C8;" width="2" height="18"/>
+<rect id="rect4165_165_" x="176" y="67" style="fill:#C8C8C8;" width="2" height="26"/>
+<rect id="rect4165_39_" x="172" y="73" style="fill:#C8C8C8;" width="2" height="14"/>
+<rect id="rect4165_38_" x="180" y="73" style="fill:#C8C8C8;" width="2" height="14"/>
+<rect id="rect4165_37_" x="184" y="71" style="fill:#C8C8C8;" width="2" height="18"/>
+<rect id="rect4165_36_" x="188" y="75" style="fill:#C8C8C8;" width="2" height="10"/>
+<rect id="rect4165_43_" x="160" y="45" style="fill:#7F7F7F;" width="2" height="6"/>
+<rect id="rect4165_42_" x="164" y="43" style="fill:#7F7F7F;" width="2" height="10"/>
+<rect id="rect4165_41_" x="168" y="39" style="fill:#7F7F7F;" width="2" height="18"/>
+<rect id="rect4165_40_" x="176" y="35" style="fill:#7F7F7F;" width="2" height="26"/>
+<rect id="rect4165_31_" x="172" y="41" style="fill:#7F7F7F;" width="2" height="14"/>
+<rect id="rect4165_30_" x="180" y="41" style="fill:#7F7F7F;" width="2" height="14"/>
+<rect id="rect4165_3_" x="184" y="39" style="fill:#7F7F7F;" width="2" height="18"/>
+<rect id="rect4165_2_" x="188" y="43" style="fill:#7F7F7F;" width="2" height="10"/>
+<rect id="rect4165_177_" x="160" y="109" style="fill:#646464;" width="2" height="6"/>
+<rect id="rect4165_176_" x="164" y="107" style="fill:#646464;" width="2" height="10"/>
+<rect id="rect4165_175_" x="168" y="103" style="fill:#646464;" width="2" height="18"/>
+<rect id="rect4165_174_" x="176" y="99" style="fill:#646464;" width="2" height="26"/>
+<rect id="rect4165_173_" x="172" y="105" style="fill:#646464;" width="2" height="14"/>
+<rect id="rect4165_172_" x="180" y="105" style="fill:#646464;" width="2" height="14"/>
+<rect id="rect4165_171_" x="184" y="103" style="fill:#646464;" width="2" height="18"/>
+<rect id="rect4165_170_" x="188" y="107" style="fill:#646464;" width="2" height="10"/>
 <path d="M546,8h26v2h-26V8z M566,14h10l-5,6L566,14z M546,10h2v10h-2V10z M570,10h2v4h-2V10z"/>
 <rect id="rect4165_181_" x="546" y="22" width="2" height="2"/>
 <rect id="rect4165_182_" x="550" y="22" width="2" height="2"/>

--- a/src/mpc-hc/res/buttons48.svg
+++ b/src/mpc-hc/res/buttons48.svg
@@ -8,30 +8,30 @@
 	<inkscape:grid  id="grid3353" type="xygrid"></inkscape:grid>
 </sodipodi:namedview>
 <path id="path4159" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M9,135v-33l33,16.5L9,135z"/>
-<rect id="rect4161" x="60" y="105" style="fill:#C8C8C8;" width="9" height="27"/>
-<rect id="rect4163" x="75" y="105" style="fill:#C8C8C8;" width="9" height="27"/>
-<rect id="rect4165" x="108" y="105" style="fill:#C8C8C8;" width="24" height="27"/>
-<rect id="rect4167" x="150" y="108" style="fill:#C8C8C8;" width="3" height="21"/>
+	M9,136.5v-33L42,120L9,136.5z"/>
+<rect id="rect4161" x="60" y="106.5" style="fill:#C8C8C8;" width="9" height="27"/>
+<rect id="rect4163" x="75" y="106.5" style="fill:#C8C8C8;" width="9" height="27"/>
+<rect id="rect4165" x="108" y="106.5" style="fill:#C8C8C8;" width="24" height="27"/>
+<rect id="rect4167" x="150" y="109.5" style="fill:#C8C8C8;" width="3" height="21"/>
 <path id="path4169" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M156,118.5l12-10.5v21L156,118.5z"/>
+	M156,120l12-10.5v21L156,120z"/>
 <path id="path4171" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M171,118.5l12-10.5v21L171,118.5z"/>
+	M171,120l12-10.5v21L171,120z"/>
 <path id="path4173" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M345,118.5l12-10.5v21L345,118.5z"/>
+	M345,120l12-10.5v21L345,120z"/>
 <path id="path4175" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M360,118.5l12-10.5v21L360,118.5z"/>
-<rect id="rect4177" x="228" y="108" style="fill:#C8C8C8;" width="3" height="21"/>
+	M360,120l12-10.5v21L360,120z"/>
+<rect id="rect4177" x="228" y="109.5" style="fill:#C8C8C8;" width="3" height="21"/>
 <path id="path4179" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M225,118.5L213,129v-21L225,118.5z"/>
+	M225,120l-12,10.5v-21L225,120z"/>
 <path id="path4181" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M210,118.5L198,129v-21L210,118.5z"/>
+	M210,120l-12,10.5v-21L210,120z"/>
 <path id="path4183" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M423,118.5L411,129v-21L423,118.5z"/>
+	M423,120l-12,10.5v-21L423,120z"/>
 <path id="path4185" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M408,118.5L396,129v-21L408,118.5z"/>
-<rect id="rect4187" x="444" y="108" style="fill:#C8C8C8;" width="6" height="21"/>
-<path style="fill:#C8C8C8;" d="M456,108h3v21h-3V108z M471,118.5L459,129v-21L471,118.5z"/>
+	M408,120l-12,10.5v-21L408,120z"/>
+<rect id="rect4187" x="444" y="109.5" style="fill:#C8C8C8;" width="6" height="21"/>
+<path style="fill:#C8C8C8;" d="M456,109.5h3v21h-3V109.5z M471,120l-12,10.5v-21L471,120z"/>
 <path id="path4179-5" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
 	M1152,120l24-21v42L1152,120z"/>
 <rect id="rect4187-3" x="1152" y="111" style="fill:#C8C8C8;" width="12" height="18"/>
@@ -42,80 +42,80 @@
 <path id="path4230-0" sodipodi:cx="201.32703" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="2.2667139" sodipodi:ry="2.1307797" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#C8C8C8;stroke-width:0.6;" d="
 	M1180.5,113.4c3.6,0.3,6.3,3,6.3,6.3s-2.7,6-6.3,6.3"/>
 <path id="path4230-0-7" sodipodi:cx="201.63358" sodipodi:cy="1044.3519" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="4.5334277" sodipodi:ry="4.2615595" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#C8C8C8;stroke-width:0.7;" d="
-	M1182,107.1c6.9,0.6,12.3,6,12.3,12.6c0,6.6-5.4,12.3-12.3,12.6"/>
+	M1182,107.1c6.9,0.6,12.3,6,12.3,12.6s-5.4,12.3-12.3,12.6"/>
 <path id="path4262" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
 	M1212,120l24-21v42L1212,120z"/>
 <rect id="rect4264" x="1212" y="111" style="fill:#C8C8C8;" width="12" height="18"/>
 <path style="fill:#C8C8C8;" d="M1212,168l24-21v42L1212,168z M1212,159h12v18h-12V159z"/>
 <path id="path4276" inkscape:connector-curvature="0" style="fill:none;stroke:#FF0000;stroke-width:3;" d="M1206,102l36,36"/>
 <path id="path4159_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M9,183v-33l33,16.5L9,183z"/>
-<rect id="rect4161_1_" x="60" y="153" style="fill:#646464;" width="9" height="27"/>
-<rect id="rect4163_1_" x="75" y="153" style="fill:#646464;" width="9" height="27"/>
-<rect id="rect4165_1_" x="108" y="153" style="fill:#646464;" width="24" height="27"/>
-<rect id="rect4167_1_" x="150" y="156" style="fill:#646464;" width="3" height="21"/>
+	M9,184.5v-33L42,168L9,184.5z"/>
+<rect id="rect4161_1_" x="60" y="154.5" style="fill:#646464;" width="9" height="27"/>
+<rect id="rect4163_1_" x="75" y="154.5" style="fill:#646464;" width="9" height="27"/>
+<rect id="rect4165_1_" x="108" y="154.5" style="fill:#646464;" width="24" height="27"/>
+<rect id="rect4167_1_" x="150" y="157.5" style="fill:#646464;" width="3" height="21"/>
 <path id="path4169_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M156,166.5l12-10.5v21L156,166.5z"/>
+	M156,168l12-10.5v21L156,168z"/>
 <path id="path4171_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M171,166.5l12-10.5v21L171,166.5z"/>
+	M171,168l12-10.5v21L171,168z"/>
 <path id="path4173_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M345,166.5l12-10.5v21L345,166.5z"/>
+	M345,168l12-10.5v21L345,168z"/>
 <path id="path4175_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M360,166.5l12-10.5v21L360,166.5z"/>
-<rect id="rect4177_1_" x="228" y="156" style="fill:#646464;" width="3" height="21"/>
+	M360,168l12-10.5v21L360,168z"/>
+<rect id="rect4177_1_" x="228" y="157.5" style="fill:#646464;" width="3" height="21"/>
 <path id="path4179_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M225,166.5L213,177v-21L225,166.5z"/>
+	M225,168l-12,10.5v-21L225,168z"/>
 <path id="path4181_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M210,166.5L198,177v-21L210,166.5z"/>
+	M210,168l-12,10.5v-21L210,168z"/>
 <path id="path4183_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M423,166.5L411,177v-21L423,166.5z"/>
+	M423,168l-12,10.5v-21L423,168z"/>
 <path id="path4185_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M408,166.5L396,177v-21L408,166.5z"/>
-<rect id="rect4187_1_" x="444" y="156" style="fill:#646464;" width="6" height="21"/>
-<path style="fill:#646464;" d="M456,156h3v21h-3V156z M471,166.5L459,177v-21L471,166.5z"/>
-<polygon points="9,39 9,6 42,22.5 "/>
-<rect x="60" y="9" width="9" height="27"/>
-<rect x="75" y="9" width="9" height="27"/>
-<rect x="108" y="9" width="24" height="27"/>
-<rect x="150" y="12" width="3" height="21"/>
-<polygon points="156,22.5 168,12 168,33 "/>
-<polygon points="171,22.5 183,12 183,33 "/>
-<polygon points="345,22.5 357,12 357,33 "/>
-<polygon points="360,22.5 372,12 372,33 "/>
-<rect x="228" y="12" width="3" height="21"/>
-<polygon points="225,22.5 213,33 213,12 "/>
-<polygon points="210,22.5 198,33 198,12 "/>
-<polygon points="423,22.5 411,33 411,12 "/>
-<polygon points="408,22.5 396,33 396,12 "/>
-<rect x="444" y="12" width="6" height="21"/>
-<path d="M459,33h-3V12h3V33z M471,22.5L459,33V12L471,22.5z"/>
+	M408,168l-12,10.5v-21L408,168z"/>
+<rect id="rect4187_1_" x="444" y="157.5" style="fill:#646464;" width="6" height="21"/>
+<path style="fill:#646464;" d="M456,157.5h3v21h-3V157.5z M471,168l-12,10.5v-21L471,168z"/>
+<polygon points="9,40.5 9,7.5 42,24 "/>
+<rect x="60" y="10.5" width="9" height="27"/>
+<rect x="75" y="10.5" width="9" height="27"/>
+<rect x="108" y="10.5" width="24" height="27"/>
+<rect x="150" y="13.5" width="3" height="21"/>
+<polygon points="156,24 168,13.5 168,34.5 "/>
+<polygon points="171,24 183,13.5 183,34.5 "/>
+<polygon points="345,24 357,13.5 357,34.5 "/>
+<polygon points="360,24 372,13.5 372,34.5 "/>
+<rect x="228" y="13.5" width="3" height="21"/>
+<polygon points="225,24 213,34.5 213,13.5 "/>
+<polygon points="210,24 198,34.5 198,13.5 "/>
+<polygon points="423,24 411,34.5 411,13.5 "/>
+<polygon points="408,24 396,34.5 396,13.5 "/>
+<rect x="444" y="13.5" width="6" height="21"/>
+<path d="M459,34.5h-3v-21h3V34.5z M471,24l-12,10.5v-21L471,24z"/>
 <polygon points="1152,24 1176,3 1176,45 "/>
 <path d="M1164,33h-12V15h12V33z"/>
-<path style="fill:none;stroke:#000000;stroke-width:0.5;" d="M1177.5,20.7c1.8,0,3,1.5,3,3.3c0,1.8-1.2,3-3,3.3"/>
+<path style="fill:none;stroke:#000000;stroke-width:0.5;" d="M1177.5,20.7c1.8,0,3,1.5,3,3.3s-1.2,3-3,3.3"/>
 <path style="fill:none;stroke:#000000;stroke-width:0.6;" d="M1180.5,17.7c3.6,0.3,6.3,3,6.3,6.3s-2.7,6-6.3,6.3"/>
 <path style="fill:none;stroke:#000000;stroke-width:0.7;" d="M1182,11.1c6.9,0.6,12.3,6,12.3,12.6s-5.4,12.3-12.3,12.6"/>
 <path d="M1212,24l24-21v42L1212,24z"/>
 <rect x="1212" y="15" width="12" height="18"/>
 <path d="M1212,72l24-21v42L1212,72z M1224,81h-12V63h12V81z"/>
 <path style="fill:none;stroke:#FF0000;stroke-width:3;" d="M1206,6l36,36"/>
-<polygon style="fill:#7F7F7F;" points="9,87 9,54 42,70.5 "/>
-<rect x="60" y="57" style="fill:#7F7F7F;" width="9" height="27"/>
-<rect x="75" y="57" style="fill:#7F7F7F;" width="9" height="27"/>
-<rect x="108" y="57" style="fill:#7F7F7F;" width="24" height="27"/>
-<rect x="150" y="60" style="fill:#7F7F7F;" width="3" height="21"/>
-<polygon style="fill:#7F7F7F;" points="156,70.5 168,60 168,81 "/>
-<polygon style="fill:#7F7F7F;" points="171,70.5 183,60 183,81 "/>
-<polygon style="fill:#7F7F7F;" points="345,70.5 357,60 357,81 "/>
-<polygon style="fill:#7F7F7F;" points="360,70.5 372,60 372,81 "/>
-<rect x="228" y="60" style="fill:#7F7F7F;" width="3" height="21"/>
-<polygon style="fill:#7F7F7F;" points="225,70.5 213,81 213,60 "/>
-<polygon style="fill:#7F7F7F;" points="210,70.5 198,81 198,60 "/>
-<polygon style="fill:#7F7F7F;" points="423,70.5 411,81 411,60 "/>
-<polygon style="fill:#7F7F7F;" points="408,70.5 396,81 396,60 "/>
-<rect x="444" y="60" style="fill:#7F7F7F;" width="6" height="21"/>
-<path style="fill:#7F7F7F;" d="M459,81h-3V60h3V81z M471,70.5L459,81V60L471,70.5z"/>
+<polygon style="fill:#7F7F7F;" points="9,88.5 9,55.5 42,72 "/>
+<rect x="60" y="58.5" style="fill:#7F7F7F;" width="9" height="27"/>
+<rect x="75" y="58.5" style="fill:#7F7F7F;" width="9" height="27"/>
+<rect x="108" y="58.5" style="fill:#7F7F7F;" width="24" height="27"/>
+<rect x="150" y="61.5" style="fill:#7F7F7F;" width="3" height="21"/>
+<polygon style="fill:#7F7F7F;" points="156,72 168,61.5 168,82.5 "/>
+<polygon style="fill:#7F7F7F;" points="171,72 183,61.5 183,82.5 "/>
+<polygon style="fill:#7F7F7F;" points="345,72 357,61.5 357,82.5 "/>
+<polygon style="fill:#7F7F7F;" points="360,72 372,61.5 372,82.5 "/>
+<rect x="228" y="61.5" style="fill:#7F7F7F;" width="3" height="21"/>
+<polygon style="fill:#7F7F7F;" points="225,72 213,82.5 213,61.5 "/>
+<polygon style="fill:#7F7F7F;" points="210,72 198,82.5 198,61.5 "/>
+<polygon style="fill:#7F7F7F;" points="423,72 411,82.5 411,61.5 "/>
+<polygon style="fill:#7F7F7F;" points="408,72 396,82.5 396,61.5 "/>
+<rect x="444" y="61.5" style="fill:#7F7F7F;" width="6" height="21"/>
+<path style="fill:#7F7F7F;" d="M459,82.5h-3v-21h3V82.5z M471,72l-12,10.5v-21L471,72z"/>
 <rect x="768" y="-48" width="48" height="48"/>
-<rect id="rect4165_47_" x="240" y="18" width="3" height="9"/>
+<rect id="rect4165_47_" x="240" y="19.5" width="3" height="9"/>
 <polygon style="fill:#7F7F7F;" points="1152,72 1176,51 1176,93 "/>
 <path style="fill:#7F7F7F;" d="M1164,81h-12V63h12V81z"/>
 <path style="fill:none;stroke:#7F7F7F;stroke-width:0.5;" d="M1177.5,68.7c1.8,0,3,1.5,3,3.3s-1.2,3-3,3.3"/>
@@ -124,32 +124,32 @@
 	M1152,168l24-21v42L1152,168z"/>
 <rect id="rect4187-3_1_" x="1152" y="159" style="fill:#646464;" width="12" height="18"/>
 <path id="path4230_1_" sodipodi:cx="200.42171" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="1.1333569" sodipodi:ry="1.0653899" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#646464;stroke-width:0.5;" d="
-	M1177.5,164.7c1.8,0,3,1.5,3,3.3c0,1.8-1.2,3-3,3.3"/>
+	M1177.5,164.7c1.8,0,3,1.5,3,3.3s-1.2,3-3,3.3"/>
 <path id="path4230-0_1_" sodipodi:cx="201.32703" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="2.2667139" sodipodi:ry="2.1307797" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#646464;stroke-width:0.6;" d="
-	M1180.5,161.4c3.6,0.3,6.3,3,6.3,6.3c0,3.3-2.7,6-6.3,6.3"/>
+	M1180.5,161.4c3.6,0.3,6.3,3,6.3,6.3s-2.7,6-6.3,6.3"/>
 <g>
-	<path d="M311.1,29.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6l-0.6,2.1
-		c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,29.4z"/>
-	<path d="M324.6,29.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6l-0.6,2.1
-		c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,29.4z"/>
+	<path d="M311.1,30.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6l-0.6,2.1
+		c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,30.9z"/>
+	<path d="M324.6,30.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6l-0.6,2.1
+		c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,30.9z"/>
 </g>
 <g>
-	<path style="fill:#7F7F7F;" d="M311.1,77.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
-		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,77.4z"/>
-	<path style="fill:#7F7F7F;" d="M324.6,77.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
-		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,77.4z"/>
+	<path style="fill:#7F7F7F;" d="M311.1,78.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
+		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,78.9z"/>
+	<path style="fill:#7F7F7F;" d="M324.6,78.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
+		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,78.9z"/>
 </g>
 <g>
-	<path style="fill:#C8C8C8;" d="M311.1,125.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
-		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,125.4z"/>
-	<path style="fill:#C8C8C8;" d="M324.6,125.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
-		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,125.4z"/>
+	<path style="fill:#C8C8C8;" d="M311.1,126.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
+		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,126.9z"/>
+	<path style="fill:#C8C8C8;" d="M324.6,126.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
+		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,126.9z"/>
 </g>
 <g>
-	<path style="fill:#646464;" d="M311.1,173.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
-		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,173.4z"/>
-	<path style="fill:#646464;" d="M324.6,173.4c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
-		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,173.4z"/>
+	<path style="fill:#646464;" d="M311.1,174.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
+		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L311.1,174.9z"/>
+	<path style="fill:#646464;" d="M324.6,174.9c-0.6,0.3-2.1,0.9-4.2,0.9c-4.5,0-7.2-3-7.2-7.5s3-7.8,7.8-7.8c1.5,0,3,0.3,3.6,0.6
+		l-0.6,2.1c-0.6-0.3-1.5-0.6-3-0.6c-3.3,0-5.1,2.4-5.1,5.4c0,3.3,2.1,5.4,5.1,5.4c1.5,0,2.4-0.3,3.3-0.6L324.6,174.9z"/>
 </g>
 <rect x="492" y="30" width="24" height="6"/>
 <path d="M516,21v3h-24v-3H516z M504,9l12,12h-24L504,9z"/>
@@ -158,27 +158,26 @@
 <rect id="rect4165_48_" x="546" y="30" width="9" height="3"/>
 <rect id="rect4165_49_" x="558" y="24" width="9" height="3"/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:3;stroke-miterlimit:10;" points="675,16.5 684.3,16.5 698.7,34.5 
-		708,34.5 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:3;stroke-miterlimit:10;" points="675,15 684.3,15 698.7,33 708,33 	"/>
 </g>
-<rect id="rect4165_103_" x="633" y="156" style="fill:#C8C8C8;" width="30" height="3"/>
-<rect id="rect4165_102_" x="633" y="165" style="fill:#C8C8C8;" width="30" height="3"/>
-<rect id="rect4165_97_" x="633" y="174" style="fill:#C8C8C8;" width="15" height="3"/>
-<polygon style="fill:#C8C8C8;" points="663,177 654,183 654,171 "/>
+<rect id="rect4165_103_" x="633" y="157.5" style="fill:#C8C8C8;" width="30" height="3"/>
+<rect id="rect4165_102_" x="633" y="166.5" style="fill:#C8C8C8;" width="30" height="3"/>
+<rect id="rect4165_97_" x="633" y="175.5" style="fill:#C8C8C8;" width="15" height="3"/>
+<polygon style="fill:#C8C8C8;" points="663,178.5 654,184.5 654,172.5 "/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="652.5" y1="124.5" x2="661.5" y2="133.5"/>
 <line style="fill:none;stroke:#C8C8C8;stroke-miterlimit:10;" x1="652.5" y1="133.5" x2="661.5" y2="124.5"/>
-<rect id="rect4165_17_" x="633" y="108" style="fill:#C8C8C8;" width="30" height="3"/>
-<rect id="rect4165_16_" x="633" y="117" style="fill:#C8C8C8;" width="30" height="3"/>
-<rect id="rect4165_10_" x="633" y="126" style="fill:#C8C8C8;" width="15" height="3"/>
-<rect id="rect4165_105_" x="633" y="60" width="30" height="3"/>
-<rect id="rect4165_104_" x="633" y="69" width="30" height="3"/>
-<rect id="rect4165_101_" x="633" y="78" width="15" height="3"/>
-<polygon points="663,81 654,87 654,75 "/>
+<rect id="rect4165_17_" x="633" y="109.5" style="fill:#C8C8C8;" width="30" height="3"/>
+<rect id="rect4165_16_" x="633" y="118.5" style="fill:#C8C8C8;" width="30" height="3"/>
+<rect id="rect4165_10_" x="633" y="127.5" style="fill:#C8C8C8;" width="15" height="3"/>
+<rect id="rect4165_105_" x="633" y="61.5" width="30" height="3"/>
+<rect id="rect4165_104_" x="633" y="70.5" width="30" height="3"/>
+<rect id="rect4165_101_" x="633" y="79.5" width="15" height="3"/>
+<polygon points="663,82.5 654,88.5 654,76.5 "/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="652.5" y1="28.5" x2="661.5" y2="37.5"/>
 <line style="fill:none;stroke:#000000;stroke-miterlimit:10;" x1="652.5" y1="37.5" x2="661.5" y2="28.5"/>
-<rect id="rect4165_100_" x="633" y="12" width="30" height="3"/>
-<rect id="rect4165_99_" x="633" y="21" width="30" height="3"/>
-<rect id="rect4165_98_" x="633" y="30" width="15" height="3"/>
+<rect id="rect4165_100_" x="633" y="13.5" width="30" height="3"/>
+<rect id="rect4165_99_" x="633" y="22.5" width="30" height="3"/>
+<rect id="rect4165_98_" x="633" y="31.5" width="15" height="3"/>
 <rect id="rect4165_67_" x="585" y="84" width="12" height="3"/>
 <rect id="rect4165_66_" x="585" y="75" width="3" height="12"/>
 <rect id="rect4165_73_" x="585" y="57" width="3" height="12"/>
@@ -269,26 +268,25 @@
 <path style="fill:#C8C8C8;" d="M516,117v3h-24v-3H516z M504,105l12,12h-24L504,105z"/>
 <rect x="492" y="174" style="fill:#646464;" width="24" height="6"/>
 <path style="fill:#646464;" d="M516,165v3h-24v-3H516z M504,153l12,12h-24L504,153z"/>
-<polygon points="717,34.5 708,42 708,27 "/>
+<polygon points="717,33 708,40.5 708,25.5 "/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:3;stroke-miterlimit:10;" points="708,16.5 698.7,16.5 684.3,34.5 
-		675,34.5 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:3;stroke-miterlimit:10;" points="708,15 698.7,15 684.3,33 675,33 	"/>
 </g>
-<polygon points="708,24 708,9 717,16.5 "/>
+<polygon points="708,22.5 708,7.5 717,15 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:3;stroke-miterlimit:10;" points="675,112.5 684.3,112.5 698.7,130.5 
-		708,130.5 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:3;stroke-miterlimit:10;" points="675,111 684.3,111 698.7,129 708,129 	
+		"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="717,130.5 708,138 708,123 "/>
+<polygon style="fill:#C8C8C8;" points="717,129 708,136.5 708,121.5 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:3;stroke-miterlimit:10;" points="708,112.5 698.7,112.5 684.3,130.5 
-		675,130.5 	"/>
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:3;stroke-miterlimit:10;" points="708,111 698.7,111 684.3,129 675,129 	
+		"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="708,120 708,105 717,112.5 "/>
-<path d="M675,63h33v3h-33V63z M708,72V57l9,7.5L708,72z"/>
-<path d="M675,81h33v3h-33V81z M717,82.5l-9,7.5V75L717,82.5z"/>
-<path style="fill:#C8C8C8;" d="M675,159h33v3h-33V159z M708,168v-15l9,7.5L708,168z"/>
-<path style="fill:#C8C8C8;" d="M675,177h33v3h-33V177z M717,178.5l-9,7.5v-15L717,178.5z"/>
+<polygon style="fill:#C8C8C8;" points="708,118.5 708,103.5 717,111 "/>
+<path d="M675,61.5h33v3h-33V61.5z M708,70.5v-15l9,7.5L708,70.5z"/>
+<path d="M675,79.5h33v3h-33V79.5z M717,81l-9,7.5v-15L717,81z"/>
+<path style="fill:#C8C8C8;" d="M675,157.5h33v3h-33V157.5z M708,166.5v-15l9,7.5L708,166.5z"/>
+<path style="fill:#C8C8C8;" d="M675,175.5h33v3h-33V175.5z M717,177l-9,7.5v-15L717,177z"/>
 <path d="M741,33h21v3h-21V33z M759,15h3v18h-3V15z M756,12h6v3h-6V12z M741,27v15l-9-7.5L741,27z"/>
 <path d="M726,33h6v3h-6V33z M726,12h21v3h-21V12z M747,21V6l9,7.5L747,21z M726,15h3v18h-3V15z"/>
 <path style="fill:#C8C8C8;" d="M741,129h21v3h-21V129z M759,111h3v18h-3V111z M756,108h6v3h-6V108z M741,123v15l-9-7.5L741,123z"/>
@@ -309,37 +307,37 @@
 <polygon style="fill:#C8C8C8;" points="747,165 747,150 756,157.5 "/>
 <polygon style="fill:#C8C8C8;" points="741,171 741,186 732,178.5 "/>
 <rect id="rect4165_112_" x="726" y="159" style="fill:#C8C8C8;" width="3" height="18"/>
-<rect id="rect4165_44_" x="246" y="15" width="3" height="15"/>
-<rect id="rect4165_45_" x="252" y="9" width="3" height="27"/>
-<rect id="rect4165_163_" x="264" y="3" width="3" height="39"/>
-<rect id="rect4165_162_" x="258" y="12" width="3" height="21"/>
-<rect id="rect4165_46_" x="270" y="12" width="3" height="21"/>
-<rect id="rect4165_164_" x="276" y="9" width="3" height="27"/>
-<rect id="rect4165_168_" x="282" y="15" width="3" height="15"/>
-<rect id="rect4165_169_" x="240" y="114" style="fill:#C8C8C8;" width="3" height="9"/>
-<rect id="rect4165_167_" x="246" y="111" style="fill:#C8C8C8;" width="3" height="15"/>
-<rect id="rect4165_166_" x="252" y="105" style="fill:#C8C8C8;" width="3" height="27"/>
-<rect id="rect4165_165_" x="264" y="99" style="fill:#C8C8C8;" width="3" height="39"/>
-<rect id="rect4165_39_" x="258" y="108" style="fill:#C8C8C8;" width="3" height="21"/>
-<rect id="rect4165_38_" x="270" y="108" style="fill:#C8C8C8;" width="3" height="21"/>
-<rect id="rect4165_37_" x="276" y="105" style="fill:#C8C8C8;" width="3" height="27"/>
-<rect id="rect4165_36_" x="282" y="111" style="fill:#C8C8C8;" width="3" height="15"/>
-<rect id="rect4165_43_" x="240" y="66" style="fill:#7F7F7F;" width="3" height="9"/>
-<rect id="rect4165_42_" x="246" y="63" style="fill:#7F7F7F;" width="3" height="15"/>
-<rect id="rect4165_41_" x="252" y="57" style="fill:#7F7F7F;" width="3" height="27"/>
-<rect id="rect4165_40_" x="264" y="51" style="fill:#7F7F7F;" width="3" height="39"/>
-<rect id="rect4165_31_" x="258" y="60" style="fill:#7F7F7F;" width="3" height="21"/>
-<rect id="rect4165_30_" x="270" y="60" style="fill:#7F7F7F;" width="3" height="21"/>
-<rect id="rect4165_3_" x="276" y="57" style="fill:#7F7F7F;" width="3" height="27"/>
-<rect id="rect4165_2_" x="282" y="63" style="fill:#7F7F7F;" width="3" height="15"/>
-<rect id="rect4165_177_" x="240" y="162" style="fill:#646464;" width="3" height="9"/>
-<rect id="rect4165_176_" x="246" y="159" style="fill:#646464;" width="3" height="15"/>
-<rect id="rect4165_175_" x="252" y="153" style="fill:#646464;" width="3" height="27"/>
-<rect id="rect4165_174_" x="264" y="147" style="fill:#646464;" width="3" height="39"/>
-<rect id="rect4165_173_" x="258" y="156" style="fill:#646464;" width="3" height="21"/>
-<rect id="rect4165_172_" x="270" y="156" style="fill:#646464;" width="3" height="21"/>
-<rect id="rect4165_171_" x="276" y="153" style="fill:#646464;" width="3" height="27"/>
-<rect id="rect4165_170_" x="282" y="159" style="fill:#646464;" width="3" height="15"/>
+<rect id="rect4165_44_" x="246" y="16.5" width="3" height="15"/>
+<rect id="rect4165_45_" x="252" y="10.5" width="3" height="27"/>
+<rect id="rect4165_163_" x="264" y="4.5" width="3" height="39"/>
+<rect id="rect4165_162_" x="258" y="13.5" width="3" height="21"/>
+<rect id="rect4165_46_" x="270" y="13.5" width="3" height="21"/>
+<rect id="rect4165_164_" x="276" y="10.5" width="3" height="27"/>
+<rect id="rect4165_168_" x="282" y="16.5" width="3" height="15"/>
+<rect id="rect4165_169_" x="240" y="115.5" style="fill:#C8C8C8;" width="3" height="9"/>
+<rect id="rect4165_167_" x="246" y="112.5" style="fill:#C8C8C8;" width="3" height="15"/>
+<rect id="rect4165_166_" x="252" y="106.5" style="fill:#C8C8C8;" width="3" height="27"/>
+<rect id="rect4165_165_" x="264" y="100.5" style="fill:#C8C8C8;" width="3" height="39"/>
+<rect id="rect4165_39_" x="258" y="109.5" style="fill:#C8C8C8;" width="3" height="21"/>
+<rect id="rect4165_38_" x="270" y="109.5" style="fill:#C8C8C8;" width="3" height="21"/>
+<rect id="rect4165_37_" x="276" y="106.5" style="fill:#C8C8C8;" width="3" height="27"/>
+<rect id="rect4165_36_" x="282" y="112.5" style="fill:#C8C8C8;" width="3" height="15"/>
+<rect id="rect4165_43_" x="240" y="67.5" style="fill:#7F7F7F;" width="3" height="9"/>
+<rect id="rect4165_42_" x="246" y="64.5" style="fill:#7F7F7F;" width="3" height="15"/>
+<rect id="rect4165_41_" x="252" y="58.5" style="fill:#7F7F7F;" width="3" height="27"/>
+<rect id="rect4165_40_" x="264" y="52.5" style="fill:#7F7F7F;" width="3" height="39"/>
+<rect id="rect4165_31_" x="258" y="61.5" style="fill:#7F7F7F;" width="3" height="21"/>
+<rect id="rect4165_30_" x="270" y="61.5" style="fill:#7F7F7F;" width="3" height="21"/>
+<rect id="rect4165_3_" x="276" y="58.5" style="fill:#7F7F7F;" width="3" height="27"/>
+<rect id="rect4165_2_" x="282" y="64.5" style="fill:#7F7F7F;" width="3" height="15"/>
+<rect id="rect4165_177_" x="240" y="163.5" style="fill:#646464;" width="3" height="9"/>
+<rect id="rect4165_176_" x="246" y="160.5" style="fill:#646464;" width="3" height="15"/>
+<rect id="rect4165_175_" x="252" y="154.5" style="fill:#646464;" width="3" height="27"/>
+<rect id="rect4165_174_" x="264" y="148.5" style="fill:#646464;" width="3" height="39"/>
+<rect id="rect4165_173_" x="258" y="157.5" style="fill:#646464;" width="3" height="21"/>
+<rect id="rect4165_172_" x="270" y="157.5" style="fill:#646464;" width="3" height="21"/>
+<rect id="rect4165_171_" x="276" y="154.5" style="fill:#646464;" width="3" height="27"/>
+<rect id="rect4165_170_" x="282" y="160.5" style="fill:#646464;" width="3" height="15"/>
 <path d="M819,12h39v3h-39V12z M849,21h15l-7.5,9L849,21z M819,15h3v15h-3V15z M855,15h3v6h-3V15z"/>
 <rect id="rect4165_181_" x="819" y="33" width="3" height="3"/>
 <rect id="rect4165_182_" x="825" y="33" width="3" height="3"/>

--- a/src/mpc-hc/res/buttons64.svg
+++ b/src/mpc-hc/res/buttons64.svg
@@ -8,30 +8,30 @@
 	<inkscape:grid  id="grid3353" type="xygrid"></inkscape:grid>
 </sodipodi:namedview>
 <path id="path4159" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M12,180v-44l44,22L12,180z"/>
-<rect id="rect4161" x="80" y="140" style="fill:#C8C8C8;" width="12" height="36"/>
-<rect id="rect4163" x="100" y="140" style="fill:#C8C8C8;" width="12" height="36"/>
-<rect id="rect4165" x="144" y="140" style="fill:#C8C8C8;" width="32" height="36"/>
-<rect id="rect4167" x="200" y="144" style="fill:#C8C8C8;" width="4" height="28"/>
+	M12,182v-44l44,22L12,182z"/>
+<rect id="rect4161" x="80" y="142" style="fill:#C8C8C8;" width="12" height="36"/>
+<rect id="rect4163" x="100" y="142" style="fill:#C8C8C8;" width="12" height="36"/>
+<rect id="rect4165" x="144" y="142" style="fill:#C8C8C8;" width="32" height="36"/>
+<rect id="rect4167" x="200" y="146" style="fill:#C8C8C8;" width="4" height="28"/>
 <path id="path4169" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M208,158l16-14v28L208,158z"/>
+	M208,160l16-14v28L208,160z"/>
 <path id="path4171" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M228,158l16-14v28L228,158z"/>
+	M228,160l16-14v28L228,160z"/>
 <path id="path4173" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M460,158l16-14v28L460,158z"/>
+	M460,160l16-14v28L460,160z"/>
 <path id="path4175" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M480,158l16-14v28L480,158z"/>
-<rect id="rect4177" x="304" y="144" style="fill:#C8C8C8;" width="4" height="28"/>
+	M480,160l16-14v28L480,160z"/>
+<rect id="rect4177" x="304" y="146" style="fill:#C8C8C8;" width="4" height="28"/>
 <path id="path4179" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M300,158l-16,14v-28L300,158z"/>
+	M300,160l-16,14v-28L300,160z"/>
 <path id="path4181" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M280,158l-16,14v-28L280,158z"/>
+	M280,160l-16,14v-28L280,160z"/>
 <path id="path4183" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M564,158l-16,14v-28L564,158z"/>
+	M564,160l-16,14v-28L564,160z"/>
 <path id="path4185" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
-	M544,158l-16,14v-28L544,158z"/>
-<rect id="rect4187" x="592" y="144" style="fill:#C8C8C8;" width="8" height="28"/>
-<path style="fill:#C8C8C8;" d="M608,144h4v28h-4V144z M628,158l-16,14v-28L628,158z"/>
+	M544,160l-16,14v-28L544,160z"/>
+<rect id="rect4187" x="592" y="146" style="fill:#C8C8C8;" width="8" height="28"/>
+<path style="fill:#C8C8C8;" d="M608,146h4v28h-4V146z M628,160l-16,14v-28L628,160z"/>
 <path id="path4179-5" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="1.3333156" inkscape:transform-center-y="-0.00016308799" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#C8C8C8;" d="
 	M1536,160l32-28v56L1536,160z"/>
 <rect id="rect4187-3" x="1536" y="148" style="fill:#C8C8C8;" width="16" height="24"/>
@@ -49,46 +49,46 @@
 <path style="fill:#C8C8C8;" d="M1616,224l32-28v56L1616,224z M1616,212h16v24h-16V212z"/>
 <path id="path4276" inkscape:connector-curvature="0" style="fill:none;stroke:#FF0000;stroke-width:4;" d="M1608,136l48,48"/>
 <path id="path4159_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-1.833329" inkscape:transform-center-y="-6.7848101e-005" sodipodi:arg1="2.0943951" sodipodi:arg2="3.1415927" sodipodi:cx="3" sodipodi:cy="1039.3621" sodipodi:r1="4.472136" sodipodi:r2="2.236068" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M12,244v-44l44,22L12,244z"/>
-<rect id="rect4161_1_" x="80" y="204" style="fill:#646464;" width="12" height="36"/>
-<rect id="rect4163_1_" x="100" y="204" style="fill:#646464;" width="12" height="36"/>
-<rect id="rect4165_1_" x="144" y="204" style="fill:#646464;" width="32" height="36"/>
-<rect id="rect4167_1_" x="200" y="208" style="fill:#646464;" width="4" height="28"/>
+	M12,246v-44l44,22L12,246z"/>
+<rect id="rect4161_1_" x="80" y="206" style="fill:#646464;" width="12" height="36"/>
+<rect id="rect4163_1_" x="100" y="206" style="fill:#646464;" width="12" height="36"/>
+<rect id="rect4165_1_" x="144" y="206" style="fill:#646464;" width="32" height="36"/>
+<rect id="rect4167_1_" x="200" y="210" style="fill:#646464;" width="4" height="28"/>
 <path id="path4169_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M208,222l16-14v28L208,222z"/>
+	M208,224l16-14v28L208,224z"/>
 <path id="path4171_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M228,222l16-14v28L228,222z"/>
+	M228,224l16-14v28L228,224z"/>
 <path id="path4173_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M460,222l16-14v28L460,222z"/>
+	M460,224l16-14v28L460,224z"/>
 <path id="path4175_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="0.66666139" inkscape:transform-center-y="-3.0343961e-005" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M480,222l16-14v28L480,222z"/>
-<rect id="rect4177_1_" x="304" y="208" style="fill:#646464;" width="4" height="28"/>
+	M480,224l16-14v28L480,224z"/>
+<rect id="rect4177_1_" x="304" y="210" style="fill:#646464;" width="4" height="28"/>
 <path id="path4179_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M300,222l-16,14v-28L300,222z"/>
+	M300,224l-16,14v-28L300,224z"/>
 <path id="path4181_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M280,222l-16,14v-28L280,222z"/>
+	M280,224l-16,14v-28L280,224z"/>
 <path id="path4183_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M564,222l-16,14v-28L564,222z"/>
+	M564,224l-16,14v-28L564,224z"/>
 <path id="path4185_1_" inkscape:flatsided="true" inkscape:randomized="0" inkscape:rounded="0" inkscape:transform-center-x="-0.666658" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:cx="73" sodipodi:cy="1040.3621" sodipodi:r1="2" sodipodi:r2="1" sodipodi:sides="3" sodipodi:type="star" style="fill:#646464;" d="
-	M544,222l-16,14v-28L544,222z"/>
-<rect id="rect4187_1_" x="592" y="208" style="fill:#646464;" width="8" height="28"/>
-<path style="fill:#646464;" d="M608,208h4v28h-4V208z M628,222l-16,14v-28L628,222z"/>
-<polygon points="12,52 12,8 56,30 "/>
-<rect x="80" y="12" width="12" height="36"/>
-<rect x="100" y="12" width="12" height="36"/>
-<rect x="144" y="12" width="32" height="36"/>
-<rect x="200" y="16" width="4" height="28"/>
-<polygon points="208,30 224,16 224,44 "/>
-<polygon points="228,30 244,16 244,44 "/>
-<polygon points="460,30 476,16 476,44 "/>
-<polygon points="480,30 496,16 496,44 "/>
-<rect x="304" y="16" width="4" height="28"/>
-<polygon points="300,30 284,44 284,16 "/>
-<polygon points="280,30 264,44 264,16 "/>
-<polygon points="564,30 548,44 548,16 "/>
-<polygon points="544,30 528,44 528,16 "/>
-<rect x="592" y="16" width="8" height="28"/>
-<path d="M612,44h-4V16h4V44z M628,30l-16,14V16L628,30z"/>
+	M544,224l-16,14v-28L544,224z"/>
+<rect id="rect4187_1_" x="592" y="210" style="fill:#646464;" width="8" height="28"/>
+<path style="fill:#646464;" d="M608,210h4v28h-4V210z M628,224l-16,14v-28L628,224z"/>
+<polygon points="12,54 12,10 56,32 "/>
+<rect x="80" y="14" width="12" height="36"/>
+<rect x="100" y="14" width="12" height="36"/>
+<rect x="144" y="14" width="32" height="36"/>
+<rect x="200" y="18" width="4" height="28"/>
+<polygon points="208,32 224,18 224,46 "/>
+<polygon points="228,32 244,18 244,46 "/>
+<polygon points="460,32 476,18 476,46 "/>
+<polygon points="480,32 496,18 496,46 "/>
+<rect x="304" y="18" width="4" height="28"/>
+<polygon points="300,32 284,46 284,18 "/>
+<polygon points="280,32 264,46 264,18 "/>
+<polygon points="564,32 548,46 548,18 "/>
+<polygon points="544,32 528,46 528,18 "/>
+<rect x="592" y="18" width="8" height="28"/>
+<path d="M612,46h-4V18h4V46z M628,32l-16,14V18L628,32z"/>
 <polygon points="1536,32 1568,4 1568,60 "/>
 <path d="M1552,44h-16V20h16V44z"/>
 <path style="fill:none;stroke:#000000;stroke-width:0.5;" d="M1570,27.6c2.4,0,4,2,4,4.4s-1.6,4-4,4.4"/>
@@ -98,24 +98,24 @@
 <rect x="1616" y="20" width="16" height="24"/>
 <path d="M1616,96l32-28v56L1616,96z M1632,108h-16V84h16V108z"/>
 <path style="fill:none;stroke:#FF0000;stroke-width:4;" d="M1608,8l48,48"/>
-<polygon style="fill:#7F7F7F;" points="12,116 12,72 56,94 "/>
-<rect x="80" y="76" style="fill:#7F7F7F;" width="12" height="36"/>
-<rect x="100" y="76" style="fill:#7F7F7F;" width="12" height="36"/>
-<rect x="144" y="76" style="fill:#7F7F7F;" width="32" height="36"/>
-<rect x="200" y="80" style="fill:#7F7F7F;" width="4" height="28"/>
-<polygon style="fill:#7F7F7F;" points="208,94 224,80 224,108 "/>
-<polygon style="fill:#7F7F7F;" points="228,94 244,80 244,108 "/>
-<polygon style="fill:#7F7F7F;" points="460,94 476,80 476,108 "/>
-<polygon style="fill:#7F7F7F;" points="480,94 496,80 496,108 "/>
-<rect x="304" y="80" style="fill:#7F7F7F;" width="4" height="28"/>
-<polygon style="fill:#7F7F7F;" points="300,94 284,108 284,80 "/>
-<polygon style="fill:#7F7F7F;" points="280,94 264,108 264,80 "/>
-<polygon style="fill:#7F7F7F;" points="564,94 548,108 548,80 "/>
-<polygon style="fill:#7F7F7F;" points="544,94 528,108 528,80 "/>
-<rect x="592" y="80" style="fill:#7F7F7F;" width="8" height="28"/>
-<path style="fill:#7F7F7F;" d="M612,108h-4V80h4V108z M628,94l-16,14V80L628,94z"/>
+<polygon style="fill:#7F7F7F;" points="12,118 12,74 56,96 "/>
+<rect x="80" y="78" style="fill:#7F7F7F;" width="12" height="36"/>
+<rect x="100" y="78" style="fill:#7F7F7F;" width="12" height="36"/>
+<rect x="144" y="78" style="fill:#7F7F7F;" width="32" height="36"/>
+<rect x="200" y="82" style="fill:#7F7F7F;" width="4" height="28"/>
+<polygon style="fill:#7F7F7F;" points="208,96 224,82 224,110 "/>
+<polygon style="fill:#7F7F7F;" points="228,96 244,82 244,110 "/>
+<polygon style="fill:#7F7F7F;" points="460,96 476,82 476,110 "/>
+<polygon style="fill:#7F7F7F;" points="480,96 496,82 496,110 "/>
+<rect x="304" y="82" style="fill:#7F7F7F;" width="4" height="28"/>
+<polygon style="fill:#7F7F7F;" points="300,96 284,110 284,82 "/>
+<polygon style="fill:#7F7F7F;" points="280,96 264,110 264,82 "/>
+<polygon style="fill:#7F7F7F;" points="564,96 548,110 548,82 "/>
+<polygon style="fill:#7F7F7F;" points="544,96 528,110 528,82 "/>
+<rect x="592" y="82" style="fill:#7F7F7F;" width="8" height="28"/>
+<path style="fill:#7F7F7F;" d="M612,110h-4V82h4V110z M628,96l-16,14V82L628,96z"/>
 <rect x="1024" y="-64" width="64" height="64"/>
-<rect id="rect4165_47_" x="320" y="24" width="4" height="12"/>
+<rect id="rect4165_47_" x="320" y="26" width="4" height="12"/>
 <polygon style="fill:#7F7F7F;" points="1536,96 1568,68 1568,124 "/>
 <path style="fill:#7F7F7F;" d="M1552,108h-16V84h16V108z"/>
 <path style="fill:none;stroke:#7F7F7F;stroke-width:0.5;" d="M1570,91.6c2.4,0,4,2,4,4.4s-1.6,4-4,4.4"/>
@@ -128,28 +128,28 @@
 <path id="path4230-0_1_" sodipodi:cx="201.32703" sodipodi:cy="1044.3516" sodipodi:end="1.4835299" sodipodi:open="true" sodipodi:rx="2.2667139" sodipodi:ry="2.1307797" sodipodi:start="4.7996554" sodipodi:type="arc" style="fill:none;stroke:#646464;stroke-width:0.6;" d="
 	M1574,215.2c4.8,0.4,8.4,4,8.4,8.4s-3.6,8-8.4,8.4"/>
 <g>
-	<path d="M414.8,39.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S403.6,20,410,20c2,0,4,0.4,4.8,0.8l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8
-		c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,39.2z"/>
-	<path d="M432.8,39.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S421.6,20,428,20c2,0,4,0.4,4.8,0.8l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8
-		c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,39.2z"/>
+	<path d="M414.8,41.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S403.6,22,410,22c2,0,4,0.4,4.8,0.8l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8
+		c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,41.2z"/>
+	<path d="M432.8,41.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S421.6,22,428,22c2,0,4,0.4,4.8,0.8l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8
+		c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,41.2z"/>
 </g>
 <g>
-	<path style="fill:#7F7F7F;" d="M414.8,103.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S403.6,84,410,84c2,0,4,0.4,4.8,0.8
-		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,103.2z"/>
-	<path style="fill:#7F7F7F;" d="M432.8,103.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S421.6,84,428,84c2,0,4,0.4,4.8,0.8
-		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,103.2z"/>
+	<path style="fill:#7F7F7F;" d="M414.8,105.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S403.6,86,410,86c2,0,4,0.4,4.8,0.8
+		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,105.2z"/>
+	<path style="fill:#7F7F7F;" d="M432.8,105.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10S421.6,86,428,86c2,0,4,0.4,4.8,0.8
+		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,105.2z"/>
 </g>
 <g>
-	<path style="fill:#C8C8C8;" d="M414.8,167.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
-		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,167.2z"/>
-	<path style="fill:#C8C8C8;" d="M432.8,167.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
-		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,167.2z"/>
+	<path style="fill:#C8C8C8;" d="M414.8,169.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
+		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,169.2z"/>
+	<path style="fill:#C8C8C8;" d="M432.8,169.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
+		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,169.2z"/>
 </g>
 <g>
-	<path style="fill:#646464;" d="M414.8,231.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
-		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,231.2z"/>
-	<path style="fill:#646464;" d="M432.8,231.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
-		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,231.2z"/>
+	<path style="fill:#646464;" d="M414.8,233.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
+		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L414.8,233.2z"/>
+	<path style="fill:#646464;" d="M432.8,233.2c-0.8,0.4-2.8,1.2-5.6,1.2c-6,0-9.6-4-9.6-10s4-10.4,10.4-10.4c2,0,4,0.4,4.8,0.8
+		l-0.8,2.8c-0.8-0.4-2-0.8-4-0.8c-4.4,0-6.8,3.2-6.8,7.2c0,4.4,2.8,7.2,6.8,7.2c2,0,3.2-0.4,4.4-0.8L432.8,233.2z"/>
 </g>
 <rect x="656" y="40" width="32" height="8"/>
 <path d="M688,28v4h-32v-4H688z M672,12l16,16h-32L672,12z"/>
@@ -158,26 +158,26 @@
 <rect id="rect4165_48_" x="728" y="40" width="12" height="4"/>
 <rect id="rect4165_49_" x="744" y="32" width="12" height="4"/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:4;stroke-miterlimit:10;" points="900,22 912.4,22 931.6,46 944,46 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:4;stroke-miterlimit:10;" points="900,20 912.4,20 931.6,44 944,44 	"/>
 </g>
-<rect id="rect4165_103_" x="844" y="208" style="fill:#C8C8C8;" width="40" height="4"/>
-<rect id="rect4165_102_" x="844" y="220" style="fill:#C8C8C8;" width="40" height="4"/>
-<rect id="rect4165_97_" x="844" y="232" style="fill:#C8C8C8;" width="20" height="4"/>
-<polygon style="fill:#C8C8C8;" points="884,236 872,244 872,228 "/>
+<rect id="rect4165_103_" x="844" y="210" style="fill:#C8C8C8;" width="40" height="4"/>
+<rect id="rect4165_102_" x="844" y="222" style="fill:#C8C8C8;" width="40" height="4"/>
+<rect id="rect4165_97_" x="844" y="234" style="fill:#C8C8C8;" width="20" height="4"/>
+<polygon style="fill:#C8C8C8;" points="884,238 872,246 872,230 "/>
 <line style="fill:none;stroke:#C8C8C8;stroke-width:2;stroke-miterlimit:10;" x1="870" y1="166" x2="882" y2="178"/>
 <line style="fill:none;stroke:#C8C8C8;stroke-width:2;stroke-miterlimit:10;" x1="870" y1="178" x2="882" y2="166"/>
-<rect id="rect4165_17_" x="844" y="144" style="fill:#C8C8C8;" width="40" height="4"/>
-<rect id="rect4165_16_" x="844" y="156" style="fill:#C8C8C8;" width="40" height="4"/>
-<rect id="rect4165_10_" x="844" y="168" style="fill:#C8C8C8;" width="20" height="4"/>
-<rect id="rect4165_105_" x="844" y="80" width="40" height="4"/>
-<rect id="rect4165_104_" x="844" y="92" width="40" height="4"/>
-<rect id="rect4165_101_" x="844" y="104" width="20" height="4"/>
-<polygon points="884,108 872,116 872,100 "/>
+<rect id="rect4165_17_" x="844" y="146" style="fill:#C8C8C8;" width="40" height="4"/>
+<rect id="rect4165_16_" x="844" y="158" style="fill:#C8C8C8;" width="40" height="4"/>
+<rect id="rect4165_10_" x="844" y="170" style="fill:#C8C8C8;" width="20" height="4"/>
+<rect id="rect4165_105_" x="844" y="82" width="40" height="4"/>
+<rect id="rect4165_104_" x="844" y="94" width="40" height="4"/>
+<rect id="rect4165_101_" x="844" y="106" width="20" height="4"/>
+<polygon points="884,110 872,118 872,102 "/>
 <line style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:10;" x1="870" y1="38" x2="882" y2="50"/>
 <line style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:10;" x1="870" y1="50" x2="882" y2="38"/>
-<rect id="rect4165_100_" x="844" y="16" width="40" height="4"/>
-<rect id="rect4165_99_" x="844" y="28" width="40" height="4"/>
-<rect id="rect4165_98_" x="844" y="40" width="20" height="4"/>
+<rect id="rect4165_100_" x="844" y="18" width="40" height="4"/>
+<rect id="rect4165_99_" x="844" y="30" width="40" height="4"/>
+<rect id="rect4165_98_" x="844" y="42" width="20" height="4"/>
 <rect id="rect4165_67_" x="780" y="112" width="16" height="4"/>
 <rect id="rect4165_66_" x="780" y="100" width="4" height="16"/>
 <rect id="rect4165_73_" x="780" y="76" width="4" height="16"/>
@@ -268,25 +268,25 @@
 <path style="fill:#C8C8C8;" d="M688,156v4h-32v-4H688z M672,140l16,16h-32L672,140z"/>
 <rect x="656" y="232" style="fill:#646464;" width="32" height="8"/>
 <path style="fill:#646464;" d="M688,220v4h-32v-4H688z M672,204l16,16h-32L672,204z"/>
-<polygon points="956,46 944,56 944,36 "/>
+<polygon points="956,44 944,54 944,34 "/>
 <g>
-	<polyline style="fill:none;stroke:#000000;stroke-width:4;stroke-miterlimit:10;" points="944,22 931.6,22 912.4,46 900,46 	"/>
+	<polyline style="fill:none;stroke:#000000;stroke-width:4;stroke-miterlimit:10;" points="944,20 931.6,20 912.4,44 900,44 	"/>
 </g>
-<polygon points="944,32 944,12 956,22 "/>
+<polygon points="944,30 944,10 956,20 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:4;stroke-miterlimit:10;" points="900,150 912.4,150 931.6,174 944,174 	
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:4;stroke-miterlimit:10;" points="900,148 912.4,148 931.6,172 944,172 	
 		"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="956,174 944,184 944,164 "/>
+<polygon style="fill:#C8C8C8;" points="956,172 944,182 944,162 "/>
 <g>
-	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:4;stroke-miterlimit:10;" points="944,150 931.6,150 912.4,174 900,174 	
+	<polyline style="fill:none;stroke:#C8C8C8;stroke-width:4;stroke-miterlimit:10;" points="944,148 931.6,148 912.4,172 900,172 	
 		"/>
 </g>
-<polygon style="fill:#C8C8C8;" points="944,160 944,140 956,150 "/>
-<path d="M900,84h44v4h-44V84z M944,96V76l12,10L944,96z"/>
-<path d="M900,108h44v4h-44V108z M956,110l-12,10v-20L956,110z"/>
-<path style="fill:#C8C8C8;" d="M900,212h44v4h-44V212z M944,224v-20l12,10L944,224z"/>
-<path style="fill:#C8C8C8;" d="M900,236h44v4h-44V236z M956,238l-12,10v-20L956,238z"/>
+<polygon style="fill:#C8C8C8;" points="944,158 944,138 956,148 "/>
+<path d="M900,82h44v4h-44V82z M944,94V74l12,10L944,94z"/>
+<path d="M900,106h44v4h-44V106z M956,108l-12,10V98L956,108z"/>
+<path style="fill:#C8C8C8;" d="M900,210h44v4h-44V210z M944,222v-20l12,10L944,222z"/>
+<path style="fill:#C8C8C8;" d="M900,234h44v4h-44V234z M956,236l-12,10v-20L956,236z"/>
 <path d="M988,44h28v4h-28V44z M1012,20h4v24h-4V20z M1008,16h8v4h-8V16z M988,36v20l-12-10L988,36z"/>
 <path d="M968,44h8v4h-8V44z M968,16h28v4h-28V16z M996,28V8l12,10L996,28z M968,20h4v24h-4V20z"/>
 <path style="fill:#C8C8C8;" d="M988,172h28v4h-28V172z M1012,148h4v24h-4V148z M1008,144h8v4h-8V144z M988,164v20l-12-10L988,164z"
@@ -308,37 +308,37 @@
 <polygon style="fill:#C8C8C8;" points="996,220 996,200 1008,210 "/>
 <polygon style="fill:#C8C8C8;" points="988,228 988,248 976,238 "/>
 <rect id="rect4165_112_" x="968" y="212" style="fill:#C8C8C8;" width="4" height="24"/>
-<rect id="rect4165_44_" x="328" y="20" width="4" height="20"/>
-<rect id="rect4165_45_" x="336" y="12" width="4" height="36"/>
-<rect id="rect4165_163_" x="352" y="4" width="4" height="52"/>
-<rect id="rect4165_162_" x="344" y="16" width="4" height="28"/>
-<rect id="rect4165_46_" x="360" y="16" width="4" height="28"/>
-<rect id="rect4165_164_" x="368" y="12" width="4" height="36"/>
-<rect id="rect4165_168_" x="376" y="20" width="4" height="20"/>
-<rect id="rect4165_169_" x="320" y="152" style="fill:#C8C8C8;" width="4" height="12"/>
-<rect id="rect4165_167_" x="328" y="148" style="fill:#C8C8C8;" width="4" height="20"/>
-<rect id="rect4165_166_" x="336" y="140" style="fill:#C8C8C8;" width="4" height="36"/>
-<rect id="rect4165_165_" x="352" y="132" style="fill:#C8C8C8;" width="4" height="52"/>
-<rect id="rect4165_39_" x="344" y="144" style="fill:#C8C8C8;" width="4" height="28"/>
-<rect id="rect4165_38_" x="360" y="144" style="fill:#C8C8C8;" width="4" height="28"/>
-<rect id="rect4165_37_" x="368" y="140" style="fill:#C8C8C8;" width="4" height="36"/>
-<rect id="rect4165_36_" x="376" y="148" style="fill:#C8C8C8;" width="4" height="20"/>
-<rect id="rect4165_43_" x="320" y="88" style="fill:#7F7F7F;" width="4" height="12"/>
-<rect id="rect4165_42_" x="328" y="84" style="fill:#7F7F7F;" width="4" height="20"/>
-<rect id="rect4165_41_" x="336" y="76" style="fill:#7F7F7F;" width="4" height="36"/>
-<rect id="rect4165_40_" x="352" y="68" style="fill:#7F7F7F;" width="4" height="52"/>
-<rect id="rect4165_31_" x="344" y="80" style="fill:#7F7F7F;" width="4" height="28"/>
-<rect id="rect4165_30_" x="360" y="80" style="fill:#7F7F7F;" width="4" height="28"/>
-<rect id="rect4165_3_" x="368" y="76" style="fill:#7F7F7F;" width="4" height="36"/>
-<rect id="rect4165_2_" x="376" y="84" style="fill:#7F7F7F;" width="4" height="20"/>
-<rect id="rect4165_177_" x="320" y="216" style="fill:#646464;" width="4" height="12"/>
-<rect id="rect4165_176_" x="328" y="212" style="fill:#646464;" width="4" height="20"/>
-<rect id="rect4165_175_" x="336" y="204" style="fill:#646464;" width="4" height="36"/>
-<rect id="rect4165_174_" x="352" y="196" style="fill:#646464;" width="4" height="52"/>
-<rect id="rect4165_173_" x="344" y="208" style="fill:#646464;" width="4" height="28"/>
-<rect id="rect4165_172_" x="360" y="208" style="fill:#646464;" width="4" height="28"/>
-<rect id="rect4165_171_" x="368" y="204" style="fill:#646464;" width="4" height="36"/>
-<rect id="rect4165_170_" x="376" y="212" style="fill:#646464;" width="4" height="20"/>
+<rect id="rect4165_44_" x="328" y="22" width="4" height="20"/>
+<rect id="rect4165_45_" x="336" y="14" width="4" height="36"/>
+<rect id="rect4165_163_" x="352" y="6" width="4" height="52"/>
+<rect id="rect4165_162_" x="344" y="18" width="4" height="28"/>
+<rect id="rect4165_46_" x="360" y="18" width="4" height="28"/>
+<rect id="rect4165_164_" x="368" y="14" width="4" height="36"/>
+<rect id="rect4165_168_" x="376" y="22" width="4" height="20"/>
+<rect id="rect4165_169_" x="320" y="154" style="fill:#C8C8C8;" width="4" height="12"/>
+<rect id="rect4165_167_" x="328" y="150" style="fill:#C8C8C8;" width="4" height="20"/>
+<rect id="rect4165_166_" x="336" y="142" style="fill:#C8C8C8;" width="4" height="36"/>
+<rect id="rect4165_165_" x="352" y="134" style="fill:#C8C8C8;" width="4" height="52"/>
+<rect id="rect4165_39_" x="344" y="146" style="fill:#C8C8C8;" width="4" height="28"/>
+<rect id="rect4165_38_" x="360" y="146" style="fill:#C8C8C8;" width="4" height="28"/>
+<rect id="rect4165_37_" x="368" y="142" style="fill:#C8C8C8;" width="4" height="36"/>
+<rect id="rect4165_36_" x="376" y="150" style="fill:#C8C8C8;" width="4" height="20"/>
+<rect id="rect4165_43_" x="320" y="90" style="fill:#7F7F7F;" width="4" height="12"/>
+<rect id="rect4165_42_" x="328" y="86" style="fill:#7F7F7F;" width="4" height="20"/>
+<rect id="rect4165_41_" x="336" y="78" style="fill:#7F7F7F;" width="4" height="36"/>
+<rect id="rect4165_40_" x="352" y="70" style="fill:#7F7F7F;" width="4" height="52"/>
+<rect id="rect4165_31_" x="344" y="82" style="fill:#7F7F7F;" width="4" height="28"/>
+<rect id="rect4165_30_" x="360" y="82" style="fill:#7F7F7F;" width="4" height="28"/>
+<rect id="rect4165_3_" x="368" y="78" style="fill:#7F7F7F;" width="4" height="36"/>
+<rect id="rect4165_2_" x="376" y="86" style="fill:#7F7F7F;" width="4" height="20"/>
+<rect id="rect4165_177_" x="320" y="218" style="fill:#646464;" width="4" height="12"/>
+<rect id="rect4165_176_" x="328" y="214" style="fill:#646464;" width="4" height="20"/>
+<rect id="rect4165_175_" x="336" y="206" style="fill:#646464;" width="4" height="36"/>
+<rect id="rect4165_174_" x="352" y="198" style="fill:#646464;" width="4" height="52"/>
+<rect id="rect4165_173_" x="344" y="210" style="fill:#646464;" width="4" height="28"/>
+<rect id="rect4165_172_" x="360" y="210" style="fill:#646464;" width="4" height="28"/>
+<rect id="rect4165_171_" x="368" y="206" style="fill:#646464;" width="4" height="36"/>
+<rect id="rect4165_170_" x="376" y="214" style="fill:#646464;" width="4" height="20"/>
 <path d="M1092,16h52v4h-52V16z M1132,28h20l-10,12L1132,28z M1092,20h4v20h-4V20z M1140,20h4v8h-4V20z"/>
 <rect id="rect4165_181_" x="1092" y="44" width="4" height="4"/>
 <rect id="rect4165_182_" x="1100" y="44" width="4" height="4"/>


### PR DESCRIPTION
Some of the old toolbar.svg buttons were not centered vertically.

permanent download: https://mega.co.nz/#!8YxxiAyL!fp_cF040MZFycTIpyBQzYzWDmcgLWYu8Gi887ffC9RE
github patch release: https://github.com/adipose/mpc-hc/releases/tag/patch544-toolbaricons01