### PR TITLE
redesign favorites dialog UI

### DIFF
--- a/src/mpc-hc/FavoriteOrganizeDlg.cpp
+++ b/src/mpc-hc/FavoriteOrganizeDlg.cpp
@@ -118,6 +118,9 @@ BEGIN_MESSAGE_MAP(CFavoriteOrganizeDlg, CModelessResizableDialog)
     ON_UPDATE_COMMAND_UI(IDC_BUTTON4, OnUpdateDownBn)
     ON_NOTIFY(TCN_SELCHANGING, IDC_TAB1, OnTcnSelchangingTab1)
     ON_BN_CLICKED(IDOK, OnBnClickedOk)
+    ON_BN_CLICKED(ID_APPLY_NOW, OnBnClickedApply)
+    ON_UPDATE_COMMAND_UI(ID_APPLY_NOW, OnUpdateApplyBn)
+    ON_WM_SHOWWINDOW()
     ON_WM_ACTIVATE()
     ON_NOTIFY(LVN_ENDLABELEDIT, IDC_LIST2, OnLvnEndlabeleditList2)
     ON_NOTIFY(NM_DBLCLK, IDC_LIST2, OnPlayFavorite)
@@ -160,6 +163,8 @@ BOOL CFavoriteOrganizeDlg::OnInitDialog()
     AddAnchor(IDC_BUTTON3, TOP_RIGHT);
     AddAnchor(IDC_BUTTON4, TOP_RIGHT);
     AddAnchor(IDOK, BOTTOM_RIGHT);
+    AddAnchor(IDCANCEL, BOTTOM_RIGHT);
+    AddAnchor(ID_APPLY_NOW, BOTTOM_RIGHT);
     EnableSaveRestoreKey(IDS_R_DLG_ORGANIZE_FAV);
     fulfillThemeReqs();
     return TRUE;  // return TRUE unless you set the focus to a control
@@ -173,6 +178,30 @@ void CFavoriteOrganizeDlg::LoadList() {
     s.GetFav(FAV_DEVICE, m_sl[2]);
 
     SetupList(false);
+    m_bModified = false;
+}
+
+void CFavoriteOrganizeDlg::AddItemToVisualList(int tabIndex, const CString& favoriteString) {
+    // Add to the in-memory list
+    m_sl[tabIndex].AddTail(favoriteString);
+
+    // If we're currently on this tab, refresh the list
+    if (m_tab.GetCurSel() == tabIndex) {
+        SetupList(false);
+
+        // Select and scroll to the newly added item (it's at the end)
+        int newItemIndex = m_list.GetItemCount() - 1;
+        if (newItemIndex >= 0) {
+            m_list.SetItemState(newItemIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+            m_list.EnsureVisible(newItemIndex, FALSE);
+        }
+    }
+
+    // Mark as modified so changes can be saved
+    m_bModified = true;
+
+    // Update dialog controls to enable Apply button
+    UpdateDialogControls(this, TRUE);
 }
 
 BOOL CFavoriteOrganizeDlg::PreTranslateMessage(MSG* pMsg)
@@ -295,6 +324,7 @@ void CFavoriteOrganizeDlg::OnLvnEndlabeleditList2(NMHDR* pNMHDR, LRESULT* pResul
     NMLVDISPINFO* pDispInfo = reinterpret_cast<NMLVDISPINFO*>(pNMHDR);
     if (pDispInfo->item.iItem >= 0 && pDispInfo->item.pszText) {
         m_list.SetItemText(pDispInfo->item.iItem, 0, pDispInfo->item.pszText);
+        m_bModified = true;
     }
     UpdateColumnsSizes();
 
@@ -383,6 +413,7 @@ void CFavoriteOrganizeDlg::OnDeleteBnClicked()
         }
 
         m_list.DeleteItem(nItem);
+        m_bModified = true;
     }
 
     nItem = std::min(nItem, m_list.GetItemCount() - 1);
@@ -408,6 +439,7 @@ void CFavoriteOrganizeDlg::MoveItem(int nItem, int offset)
     m_list.SetItemData(nItem, data);
     m_list.SetItemText(nItem, 1, strPos);
     m_list.SetItemState(nItem, LVIS_SELECTED, LVIS_SELECTED);
+    m_bModified = true;
 }
 
 void CFavoriteOrganizeDlg::OnUpBnClicked()
@@ -460,7 +492,7 @@ void CFavoriteOrganizeDlg::OnTcnSelchangingTab1(NMHDR* pNMHDR, LRESULT* pResult)
     *pResult = 0;
 }
 
-void CFavoriteOrganizeDlg::OnBnClickedOk()
+void CFavoriteOrganizeDlg::SaveChanges()
 {
     SetupList(true);
 
@@ -469,7 +501,50 @@ void CFavoriteOrganizeDlg::OnBnClickedOk()
     s.SetFav(FAV_DVD, m_sl[1]);
     s.SetFav(FAV_DEVICE, m_sl[2]);
 
+    m_bModified = false;
+}
+
+void CFavoriteOrganizeDlg::OnBnClickedOk()
+{
+    SaveChanges();
     OnOK();
+}
+
+void CFavoriteOrganizeDlg::OnBnClickedApply()
+{
+    SaveChanges();
+}
+
+void CFavoriteOrganizeDlg::OnUpdateApplyBn(CCmdUI* pCmdUI)
+{
+    pCmdUI->Enable(m_bModified);
+}
+
+void CFavoriteOrganizeDlg::OnCancel()
+{
+    if (m_bModified) {
+        int nRet = AfxMessageBox(IDS_FAVORITES_UNSAVED_CHANGES, MB_YESNOCANCEL | MB_ICONQUESTION);
+        if (nRet == IDYES) {
+            SaveChanges();
+        } else if (nRet == IDCANCEL) {
+            return;
+        } else {
+            // IDNO - discard changes by reloading from settings
+            LoadList();
+        }
+    }
+
+    __super::OnCancel();
+}
+
+void CFavoriteOrganizeDlg::OnShowWindow(BOOL bShow, UINT nStatus)
+{
+    __super::OnShowWindow(bShow, nStatus);
+
+    if (bShow) {
+        // Always reload data from settings when showing the dialog
+        LoadList();
+    }
 }
 
 void CFavoriteOrganizeDlg::OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized)

--- a/src/mpc-hc/FavoriteOrganizeDlg.cpp
+++ b/src/mpc-hc/FavoriteOrganizeDlg.cpp
@@ -449,6 +449,7 @@ void CFavoriteOrganizeDlg::MoveItem(int nItem, int offset)
     m_list.SetItemData(nItem, data);
     m_list.SetItemText(nItem, 1, strPos);
     m_list.SetItemState(nItem, LVIS_SELECTED, LVIS_SELECTED);
+    m_list.EnsureVisible(nItem, FALSE);
     m_bModified = true;
 }
 

--- a/src/mpc-hc/FavoriteOrganizeDlg.cpp
+++ b/src/mpc-hc/FavoriteOrganizeDlg.cpp
@@ -325,6 +325,7 @@ void CFavoriteOrganizeDlg::OnLvnEndlabeleditList2(NMHDR* pNMHDR, LRESULT* pResul
     if (pDispInfo->item.iItem >= 0 && pDispInfo->item.pszText) {
         m_list.SetItemText(pDispInfo->item.iItem, 0, pDispInfo->item.pszText);
         m_bModified = true;
+        UpdateDialogControls(this, TRUE);
     }
     UpdateColumnsSizes();
 
@@ -418,6 +419,7 @@ void CFavoriteOrganizeDlg::OnDeleteBnClicked()
 
     nItem = std::min(nItem, m_list.GetItemCount() - 1);
     m_list.SetItemState(nItem, LVIS_SELECTED, LVIS_SELECTED);
+    UpdateDialogControls(this, TRUE);
 }
 
 void CFavoriteOrganizeDlg::OnUpdateDeleteBn(CCmdUI* pCmdUI)
@@ -454,6 +456,7 @@ void CFavoriteOrganizeDlg::OnUpBnClicked()
 
         MoveItem(nItem, -1);
     }
+    UpdateDialogControls(this, TRUE);
 }
 
 void CFavoriteOrganizeDlg::OnUpdateUpBn(CCmdUI* pCmdUI)
@@ -478,6 +481,7 @@ void CFavoriteOrganizeDlg::OnDownBnClicked()
     for (INT_PTR i = selectedItems.GetSize() - 1; i >= 0; i--) {
         MoveItem(selectedItems[i], +1);
     }
+    UpdateDialogControls(this, TRUE);
 }
 
 void CFavoriteOrganizeDlg::OnUpdateDownBn(CCmdUI* pCmdUI)
@@ -513,6 +517,7 @@ void CFavoriteOrganizeDlg::OnBnClickedOk()
 void CFavoriteOrganizeDlg::OnBnClickedApply()
 {
     SaveChanges();
+    UpdateDialogControls(this, TRUE);
 }
 
 void CFavoriteOrganizeDlg::OnUpdateApplyBn(CCmdUI* pCmdUI)

--- a/src/mpc-hc/FavoriteOrganizeDlg.cpp
+++ b/src/mpc-hc/FavoriteOrganizeDlg.cpp
@@ -46,6 +46,7 @@ void CFavoriteOrganizeDlg::SetupList(bool fSave)
     int i = m_tab.GetCurSel();
 
     if (fSave) {
+        // Update the internal list to match the visual list order and names
         CAtlList<CString> sl;
 
         for (int j = 0; j < m_list.GetItemCount(); j++) {
@@ -57,7 +58,14 @@ void CFavoriteOrganizeDlg::SetupList(bool fSave)
         }
         m_sl[i].RemoveAll();
         m_sl[i].AddTailList(&sl);
-        SetupList(false); //reload the list to invalide the old itemdata
+
+        // Update itemdata pointers to point to new positions in the rebuilt list
+        POSITION pos = m_sl[i].GetHeadPosition();
+        for (int j = 0; j < m_list.GetItemCount() && pos; j++) {
+            POSITION tmp = pos;
+            m_sl[i].GetNext(pos);
+            m_list.SetItemData(j, (DWORD_PTR)tmp);
+        }
     } else {
         m_list.SetRedraw(FALSE);
         m_list.DeleteAllItems();

--- a/src/mpc-hc/FavoriteOrganizeDlg.h
+++ b/src/mpc-hc/FavoriteOrganizeDlg.h
@@ -47,13 +47,16 @@ public:
     CMPCThemePlayerListCtrl m_list;
     bool firstSize=false;
     int minSizeTime = 0;
+    bool m_bModified = false;
     void LoadList();
+    void AddItemToVisualList(int tabIndex, const CString& favoriteString);
 
 protected:
     virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
     virtual BOOL OnInitDialog();
 
     void SetupList(bool fSave);
+    void SaveChanges();
 
     void UpdateColumnsSizes();
     void MoveItem(int nItem, int offset);
@@ -75,6 +78,10 @@ public:
     afx_msg void OnUpdateDownBn(CCmdUI* pCmdUI);
     afx_msg void OnTcnSelchangingTab1(NMHDR* pNMHDR, LRESULT* pResult);
     afx_msg void OnBnClickedOk();
+    afx_msg void OnBnClickedApply();
+    afx_msg void OnUpdateApplyBn(CCmdUI* pCmdUI);
+    virtual void OnCancel();
+    afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
     afx_msg void OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized);
     afx_msg void OnLvnEndlabeleditList2(NMHDR* pNMHDR, LRESULT* pResult);
     afx_msg void OnPlayFavorite(NMHDR* pNMHDR, LRESULT* pResult);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -11070,6 +11070,15 @@ void CMainFrame::AddFavorite(bool fDisplayMessage, bool fShowDialog)
     WORD osdMsg = 0;
     const TCHAR sep = _T(';');
 
+    // Lambda to conditionally add favorite: to visual list if dialog is open, or persist immediately
+    auto addFavorite = [this, &s](favtype favType, const CString& str) {
+        if (::IsWindow(m_wndFavoriteOrganizeDialog.m_hWnd) && m_wndFavoriteOrganizeDialog.IsWindowVisible()) {
+            m_wndFavoriteOrganizeDialog.AddItemToVisualList(favType, str);
+        } else {
+            s.AddFav(favType, str);
+        }
+    };
+
     if (GetPlaybackMode() == PM_FILE) {
         bool is_BD = false;
         CString fn = m_wndPlaylistBar.GetCurFileNameTitle();
@@ -11138,13 +11147,7 @@ void CMainFrame::AddFavorite(bool fDisplayMessage, bool fShowDialog)
         }
 
         CString str = ImplodeEsc(args, sep);
-
-        // If organize dialog is visible, add to visual list only; otherwise persist immediately
-        if (::IsWindow(m_wndFavoriteOrganizeDialog.m_hWnd) && m_wndFavoriteOrganizeDialog.IsWindowVisible()) {
-            m_wndFavoriteOrganizeDialog.AddItemToVisualList(FAV_FILE, str);
-        } else {
-            s.AddFav(FAV_FILE, str);
-        }
+        addFavorite(FAV_FILE, str);
         osdMsg = IDS_FILE_FAV_ADDED;
     } else if (GetPlaybackMode() == PM_DVD) {
         WCHAR path[MAX_PATH];
@@ -11195,13 +11198,7 @@ void CMainFrame::AddFavorite(bool fDisplayMessage, bool fShowDialog)
             args.AddTail(fn);
 
             CString str = ImplodeEsc(args, sep);
-
-            // If organize dialog is visible, add to visual list only; otherwise persist immediately
-            if (::IsWindow(m_wndFavoriteOrganizeDialog.m_hWnd) && m_wndFavoriteOrganizeDialog.IsWindowVisible()) {
-                m_wndFavoriteOrganizeDialog.AddItemToVisualList(FAV_DVD, str);
-            } else {
-                s.AddFav(FAV_DVD, str);
-            }
+            addFavorite(FAV_DVD, str);
             osdMsg = IDS_DVD_FAV_ADDED;
         }
     } // TODO: PM_ANALOG_CAPTURE and PM_DIGITAL_CAPTURE

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -11138,7 +11138,13 @@ void CMainFrame::AddFavorite(bool fDisplayMessage, bool fShowDialog)
         }
 
         CString str = ImplodeEsc(args, sep);
-        s.AddFav(FAV_FILE, str);
+
+        // If organize dialog is visible, add to visual list only; otherwise persist immediately
+        if (::IsWindow(m_wndFavoriteOrganizeDialog.m_hWnd) && m_wndFavoriteOrganizeDialog.IsWindowVisible()) {
+            m_wndFavoriteOrganizeDialog.AddItemToVisualList(FAV_FILE, str);
+        } else {
+            s.AddFav(FAV_FILE, str);
+        }
         osdMsg = IDS_FILE_FAV_ADDED;
     } else if (GetPlaybackMode() == PM_DVD) {
         WCHAR path[MAX_PATH];
@@ -11189,7 +11195,13 @@ void CMainFrame::AddFavorite(bool fDisplayMessage, bool fShowDialog)
             args.AddTail(fn);
 
             CString str = ImplodeEsc(args, sep);
-            s.AddFav(FAV_DVD, str);
+
+            // If organize dialog is visible, add to visual list only; otherwise persist immediately
+            if (::IsWindow(m_wndFavoriteOrganizeDialog.m_hWnd) && m_wndFavoriteOrganizeDialog.IsWindowVisible()) {
+                m_wndFavoriteOrganizeDialog.AddItemToVisualList(FAV_DVD, str);
+            } else {
+                s.AddFav(FAV_DVD, str);
+            }
             osdMsg = IDS_DVD_FAV_ADDED;
         }
     } // TODO: PM_ANALOG_CAPTURE and PM_DIGITAL_CAPTURE
@@ -11198,9 +11210,6 @@ void CMainFrame::AddFavorite(bool fDisplayMessage, bool fShowDialog)
         CString osdMsgStr(StrRes(osdMsg));
         SendStatusMessage(osdMsgStr, 3000);
         m_OSD.DisplayMessage(OSD_TOPLEFT, osdMsgStr, 3000);
-    }
-    if (::IsWindow(m_wndFavoriteOrganizeDialog.m_hWnd)) {
-        m_wndFavoriteOrganizeDialog.LoadList();
     }
 }
 

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -514,7 +514,9 @@ BEGIN
     PUSHBUTTON      "Move Up",IDC_BUTTON3,214,43,58,14
     PUSHBUTTON      "Move Down",IDC_BUTTON4,214,58,58,14
     PUSHBUTTON      "Delete",IDC_BUTTON2,214,84,58,14
-    DEFPUSHBUTTON   "OK",IDOK,214,148,58,14
+    DEFPUSHBUTTON   "OK",IDOK,214,112,58,14
+    PUSHBUTTON      "Cancel",IDCANCEL,214,130,58,14
+    PUSHBUTTON      "Apply",ID_APPLY_NOW,214,148,58,14
 END
 
 IDD_PNSPRESET_DLG DIALOGEX 0, 0, 210, 120
@@ -4222,6 +4224,7 @@ BEGIN
     IDS_CUSTOM_ACTION4      "Custom Action 4"
     IDS_AUDIOS              "Audio Track"
     IDS_SUBTITLES           "Subtitle Track"
+    IDS_FAVORITES_UNSAVED_CHANGES   "Do you want to save changes to your favorites?"
     IDS_AG_EXIT_FULLSCREEN  "Exit Fullscreen"
     IDS_AG_SHOW_PLAYLIST    "Show Playlist"
     IDS_AG_HIDE_PLAYLIST    "Hide Playlist"

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -1793,6 +1793,7 @@
 #define IDS_CUSTOM_ACTION4              57727
 #define IDS_AUDIOS                      57728
 #define IDS_SUBTITLES                   57729
+#define IDS_FAVORITES_UNSAVED_CHANGES   57730
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
The saving of the favorites had several issues:

1. There was no apply button, making it unclear whether the favorites were persisted (to memory) or not
2. Closing the dialog silently failed to persist.  However, the list contents were actually maintained, so reopening the dialog appeared to indicate persistence.
3. Add favorites dialog can be opened at the same time, raising the question of how to merge favorites added to the organize dialog and those added via the "add" dialog.

This solves all issues by: 
1. Loading the persisted list whenever opening the organize dialog
2. adding an apply button
3. saving on apply or ok
4. offering to save when cancelling or "X"ing
5. When the organize dailog is open, handling anything added via the addfavorite dialog as if it were added to the organize dialog manually.
6. Add dialog works normally when organize is closed (it adds and persists immediately)
