### PR TITLE
check monitor specific metrics after any windows move during dpi change

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1981,12 +1981,14 @@ LRESULT CMainFrame::OnDpiChanged(WPARAM wParam, LPARAM lParam)
 {
     m_dpi.Override(LOWORD(wParam), HIWORD(wParam));
     m_eventc.FireEvent(MpcEvent::DPI_CHANGED);
-    CMPCThemeUtil::GetMetrics(true); //force reset metrics used by util class
-    CMPCThemeMenu::clearDimensions();
-    ReloadMenus();
+
     if (!restoringWindowRect) { //do not adjust for DPI if restoring saved window position
         MoveWindow(reinterpret_cast<RECT*>(lParam));
     }
+    CMPCThemeUtil::GetMetrics(true); //force reset metrics used by util class
+    CMPCThemeMenu::clearDimensions();
+    ReloadMenus();
+
     RecalcLayout();
     m_wndPreView.ScaleFont();
     return 0;


### PR DESCRIPTION
Windows 11 behavior has changed.  When dpi has changed, the window is not yet associated with the new monitor.  Processing the pending "movewindow" seems to fix it.

permanent download: https://mega.co.nz/#!RdggQbYa!Sv-wenLYbEiThC5eZaDpqn8QFgBEuC8OlWTS1UEo6K0
github patch release: https://github.com/adipose/mpc-hc/releases/tag/patch548-dpichange01