### PR TITLE
Feat: auto-copy subtitles to clipboard

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -180,6 +180,7 @@ CAppSettings::CAppSettings()
     , nAutoDownloadScoreSeries(0x18)
     , bAutoUploadSubtitles(false)
     , bPreferHearingImpairedSubtitles(false)
+    , bAutoCopySubtitleToClipboard(false)
     , bMPCTheme(true)
     , bWindows10DarkThemeActive(false)
     , bWindows10AccentColorsEnabled(false)
@@ -717,6 +718,7 @@ static constexpr wmcmd_base default_wmcmds[] = {
     { ID_STREAM_SUB_NEXT,                 'S', 0,                 IDS_AG_NEXT_SUBTITLE },
     { ID_STREAM_SUB_PREV,                 'S', FSHIFT,            IDS_AG_PREV_SUBTITLE },
     { ID_STREAM_SUB_ONOFF,                'W', 0,                 IDS_MPLAYERC_85 },
+    { ID_SUBTITLES_AUTOCOPY,                0, 0,                 IDS_AG_AUTOCOPY_SUBTITLE },
     { ID_SUBTITLES_SUBITEM_START + 2,       0, 0,                 IDS_MPLAYERC_86 },
     { ID_DVD_ANGLE_NEXT,                    0, 0,                 IDS_MPLAYERC_91 },
     { ID_DVD_ANGLE_PREV,                    0, 0,                 IDS_MPLAYERC_92 },
@@ -1045,6 +1047,7 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_AUTODOWNLOADSUBTITLESEXCLUDE, strAutoDownloadSubtitlesExclude);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOUPLOADSUBTITLES, bAutoUploadSubtitles);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_PREFERHEARINGIMPAIREDSUBTITLES, bPreferHearingImpairedSubtitles);
+    pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOCOPYSUBTITLE, bAutoCopySubtitleToClipboard);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_MPCTHEME, bMPCTheme);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_MODERNSEEKBARHEIGHT, iModernSeekbarHeight);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_MODERNTHEMEMODE, static_cast<int>(eModernThemeMode));
@@ -1873,6 +1876,7 @@ void CAppSettings::LoadSettings()
     strAutoDownloadSubtitlesExclude = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_AUTODOWNLOADSUBTITLESEXCLUDE);
     bAutoUploadSubtitles = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOUPLOADSUBTITLES, FALSE);
     bPreferHearingImpairedSubtitles = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_PREFERHEARINGIMPAIREDSUBTITLES, FALSE);
+    bAutoCopySubtitleToClipboard = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_AUTOCOPYSUBTITLE, FALSE);
     bMPCTheme = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_MPCTHEME, TRUE);
     if (IsWindows10OrGreater()) {
         CRegKey key;

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -272,7 +272,7 @@ struct AutoChangeFullscreenMode {
     unsigned                    uDelay = 0u;
 };
 
-#define ACCEL_LIST_SIZE 202
+#define ACCEL_LIST_SIZE 203
 
 struct wmcmd_base : public ACCEL {
     BYTE mouse;
@@ -824,6 +824,7 @@ public:
     CString         strAutoDownloadSubtitlesExclude;
     bool            bAutoUploadSubtitles;
     bool            bPreferHearingImpairedSubtitles;
+    bool            bAutoCopySubtitleToClipboard;
 #if USE_LIBASS
     bool            bRenderSSAUsingLibass;
     bool            bRenderSRTUsingLibass;

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -2227,12 +2227,20 @@ void CMainFrame::OnTimer(UINT_PTR nIDEvent)
                                             for (size_t i = 0; i < pSeg->subs.GetCount(); i++) {
                                                 int subIndex = pSeg->subs[i];
                                                 if (subIndex >= 0 && subIndex < (int)pRTS->GetCount()) {
+                                                    CStringW strLine = pRTS->GetStrW(subIndex, false);
+                                                    // Strip remaining HTML tags <...>
+                                                    int iStart, iEnd;
+                                                    while ((iStart = strLine.Find(L'<')) >= 0) {
+                                                        iEnd = strLine.Find(L'>', iStart);
+                                                        if (iEnd < 0) break;
+                                                        strLine.Delete(iStart, iEnd - iStart + 1);
+                                                    }
                                                     if (!strText.IsEmpty()) strText += L"\r\n";
-                                                    strText += pRTS->GetStrW(subIndex, false);
+                                                    strText += strLine;
                                                 }
                                             }
 
-                                            if (!strText.IsEmpty() && strText != m_strLastCopiedSubText) {
+                                            if (!strText.IsEmpty()) {
                                                 CClipboard clipboard(this);
                                                 VERIFY(clipboard.SetText(CString(strText)));
                                                 m_nLastCopiedSubSegment = iSegment;

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -2215,43 +2215,7 @@ void CMainFrame::OnTimer(UINT_PTR nIDEvent)
 
                             m_wndStatusBar.SetStatusTimer(rtNow, rtDur, IsSubresyncBarVisible(), GetTimeFormat());
 
-                            if (AfxGetAppSettings().bAutoCopySubtitleToClipboard) { // Auto-copy subtitle to clipboard
-                                CAutoLock cAutoLock(&m_csSubLock);
-                                if (m_pCurrentSubInput.pSubStream) {
-                                    if (auto pRTS = dynamic_cast<CRenderedTextSubtitle*>((ISubStream*)m_pCurrentSubInput.pSubStream)) {
-                                        int iSegment = -1;
-                                        const STSSegment* pSeg = pRTS->SearchSubs(rtNow, 25.0, &iSegment, nullptr);
-
-                                        if (pSeg && iSegment != m_nLastCopiedSubSegment) {
-                                            CStringW strText;
-                                            for (size_t i = 0; i < pSeg->subs.GetCount(); i++) {
-                                                int subIndex = pSeg->subs[i];
-                                                if (subIndex >= 0 && subIndex < (int)pRTS->GetCount()) {
-                                                    CStringW strLine = pRTS->GetStrW(subIndex, false);
-                                                    // Strip remaining HTML tags <...>
-                                                    int iStart, iEnd;
-                                                    while ((iStart = strLine.Find(L'<')) >= 0) {
-                                                        iEnd = strLine.Find(L'>', iStart);
-                                                        if (iEnd < 0) break;
-                                                        strLine.Delete(iStart, iEnd - iStart + 1);
-                                                    }
-                                                    if (!strText.IsEmpty()) strText += L"\r\n";
-                                                    strText += strLine;
-                                                }
-                                            }
-
-                                            if (!strText.IsEmpty()) {
-                                                CClipboard clipboard(this);
-                                                VERIFY(clipboard.SetText(CString(strText)));
-                                                m_nLastCopiedSubSegment = iSegment;
-                                                m_strLastCopiedSubText = strText;
-                                            }
-                                        } else if (!pSeg) {
-                                            m_nLastCopiedSubSegment = -1;
-                                        }
-                                    }
-                                }
-                            }
+                            CopyCurrentSubtitleToClipboard(rtNow);
                         }
                         break;
                     case PM_DVD:
@@ -4619,7 +4583,6 @@ void CMainFrame::OnSubtitlesAutoCopy()
     CAppSettings& s = AfxGetAppSettings();
     s.bAutoCopySubtitleToClipboard = !s.bAutoCopySubtitleToClipboard;
     m_nLastCopiedSubSegment = -1;
-    m_strLastCopiedSubText.Empty();
     m_OSD.DisplayMessage(OSD_TOPLEFT,
         ResStr(IDS_AG_AUTOCOPY_SUBTITLE) + (s.bAutoCopySubtitleToClipboard ? _T(" On") : _T(" Off")));
 }
@@ -6911,6 +6874,55 @@ void CMainFrame::SubtitlesSave(const TCHAR* directory, bool silent)
         auto subPath = pSubInput->pSubStream->GetPath();
         if (!subPath.IsEmpty()) {
             s.MRU.AddSubToCurrent(subPath);
+        }
+    }
+}
+
+void CMainFrame::CopyCurrentSubtitleToClipboard(REFERENCE_TIME rtNow)
+{
+    if (!AfxGetAppSettings().bAutoCopySubtitleToClipboard) {
+        return;
+    }
+
+    CAutoLock cAutoLock(&m_csSubLock);
+    if (!m_pCurrentSubInput.pSubStream) {
+        return;
+    }
+
+    auto pRTS = dynamic_cast<CRenderedTextSubtitle*>((ISubStream*)m_pCurrentSubInput.pSubStream);
+    if (!pRTS) {
+        return;
+    }
+
+    int iSegment = -1;
+    const STSSegment* pSeg = pRTS->SearchSubs(rtNow, 25.0, &iSegment, nullptr);
+    if (!pSeg) {
+        m_nLastCopiedSubSegment = -1;
+        return;
+    }
+
+    if (iSegment != m_nLastCopiedSubSegment) {
+        CStringW strText;
+        for (size_t i = 0; i < pSeg->subs.GetCount(); i++) {
+            int subIndex = pSeg->subs[i];
+            if (subIndex >= 0 && subIndex < (int)pRTS->GetCount()) {
+                CStringW strLine = pRTS->GetStrW(subIndex, false);
+                // Strip HTML tags <...>
+                int iStart, iEnd;
+                while ((iStart = strLine.Find(L'<')) >= 0) {
+                    iEnd = strLine.Find(L'>', iStart);
+                    if (iEnd < 0) break;
+                    strLine.Delete(iStart, iEnd - iStart + 1);
+                }
+                if (!strText.IsEmpty()) strText += L"\r\n";
+                strText += strLine;
+            }
+        }
+
+        if (!strText.IsEmpty()) {
+            CClipboard clipboard(this);
+            VERIFY(clipboard.SetText(CString(strText)));
+            m_nLastCopiedSubSegment = iSegment;
         }
     }
 }
@@ -16020,7 +16032,6 @@ void CMainFrame::CloseMediaPrivate()
     m_bUsingDXVA = false;
     m_audioTrackCount = 0;
     m_nLastCopiedSubSegment = -1;
-    m_strLastCopiedSubText.Empty();
     if (m_pDVBState) {
         m_pDVBState->Join();
         m_pDVBState = nullptr;
@@ -18066,7 +18077,6 @@ void CMainFrame::SetSubtitle(const SubtitleInput& subInput, bool skip_lcid /* = 
 
     // Reset auto-copy subtitle tracking when subtitle stream changes
     m_nLastCopiedSubSegment = -1;
-    m_strLastCopiedSubText.Empty();
 
     {
         CAutoLock cAutoLock(&m_csSubLock);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -319,6 +319,8 @@ BEGIN_MESSAGE_MAP(CMainFrame, CFrameWnd)
     ON_COMMAND_RANGE(ID_STREAM_SUB_NEXT, ID_STREAM_SUB_PREV, OnStreamSub)
     ON_COMMAND(ID_AUDIOSHIFT_ONOFF, OnAudioShiftOnOff)
     ON_COMMAND(ID_STREAM_SUB_ONOFF, OnStreamSubOnOff)
+    ON_COMMAND(ID_SUBTITLES_AUTOCOPY, OnSubtitlesAutoCopy)
+    ON_UPDATE_COMMAND_UI(ID_SUBTITLES_AUTOCOPY, OnUpdateSubtitlesAutoCopy)
     ON_COMMAND_RANGE(ID_DVD_ANGLE_NEXT, ID_DVD_ANGLE_PREV, OnDvdAngle)
     ON_COMMAND_RANGE(ID_DVD_AUDIO_NEXT, ID_DVD_AUDIO_PREV, OnDvdAudio)
     ON_COMMAND_RANGE(ID_DVD_SUB_NEXT, ID_DVD_SUB_PREV, OnDvdSub)
@@ -890,6 +892,7 @@ CMainFrame::CMainFrame()
     , m_nCurSubtitle(-1)
     , m_lSubtitleShift(0)
     , m_rtCurSubPos(0)
+    , m_nLastCopiedSubSegment(-1)
     , m_bScanDlgOpened(false)
     , m_bStopTunerScan(false)
     , m_bLockedZoomVideoWindow(false)
@@ -2211,6 +2214,36 @@ void CMainFrame::OnTimer(UINT_PTR nIDEvent)
                             }
 
                             m_wndStatusBar.SetStatusTimer(rtNow, rtDur, IsSubresyncBarVisible(), GetTimeFormat());
+
+                            if (AfxGetAppSettings().bAutoCopySubtitleToClipboard) { // Auto-copy subtitle to clipboard
+                                CAutoLock cAutoLock(&m_csSubLock);
+                                if (m_pCurrentSubInput.pSubStream) {
+                                    if (auto pRTS = dynamic_cast<CRenderedTextSubtitle*>((ISubStream*)m_pCurrentSubInput.pSubStream)) {
+                                        int iSegment = -1;
+                                        const STSSegment* pSeg = pRTS->SearchSubs(rtNow, 25.0, &iSegment, nullptr);
+
+                                        if (pSeg && iSegment != m_nLastCopiedSubSegment) {
+                                            CStringW strText;
+                                            for (size_t i = 0; i < pSeg->subs.GetCount(); i++) {
+                                                int subIndex = pSeg->subs[i];
+                                                if (subIndex >= 0 && subIndex < (int)pRTS->GetCount()) {
+                                                    if (!strText.IsEmpty()) strText += L"\r\n";
+                                                    strText += pRTS->GetStrW(subIndex, false);
+                                                }
+                                            }
+
+                                            if (!strText.IsEmpty() && strText != m_strLastCopiedSubText) {
+                                                CClipboard clipboard(this);
+                                                VERIFY(clipboard.SetText(CString(strText)));
+                                                m_nLastCopiedSubSegment = iSegment;
+                                                m_strLastCopiedSubText = strText;
+                                            }
+                                        } else if (!pSeg) {
+                                            m_nLastCopiedSubSegment = -1;
+                                        }
+                                    }
+                                }
+                            }
                         }
                         break;
                     case PM_DVD:
@@ -2379,7 +2412,7 @@ void CMainFrame::OnTimer(UINT_PTR nIDEvent)
 
                     for (int i = 0, j = m_pBI->GetCount(); i < j; i++) {
                         int samples, size;
-                        if (S_OK == m_pBI->GetStatus(i, samples, size) && (i < 2 || size > 0)) { // third pin is usually subs 
+                        if (S_OK == m_pBI->GetStatus(i, samples, size) && (i < 2 || size > 0)) { // third pin is usually subs
                             sInfo.AppendFormat(_T("[P%d] %03d samples / %d KB   "), i, samples, size / 1024);
                         }
                     }
@@ -3382,7 +3415,7 @@ LRESULT CMainFrame::OnGraphNotify(WPARAM wParam, LPARAM lParam)
 
     if (!AfxGetMyApp()->m_fClosingState) {
         lockGraphAccess.Unlock();
-    }    
+    }
 
     return hr;
 }
@@ -3409,7 +3442,7 @@ LRESULT CMainFrame::OnResetDevice(WPARAM wParam, LPARAM lParam)
     }
 
     if (fs == State_Running && m_pMC) {
-        MediaControlRun();        
+        MediaControlRun();
 
         // When restarting DVB capture, we need to set again the channel.
         if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
@@ -3451,7 +3484,7 @@ void CMainFrame::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 {
     // pScrollBar is null when making horizontal scroll with pen tablet
     if (!pScrollBar) return;
-    
+
     if (pScrollBar->IsKindOf(RUNTIME_CLASS(CVolumeCtrl))) {
         OnPlayVolume(0);
     } else if (pScrollBar->IsKindOf(RUNTIME_CLASS(CPlayerSeekBar)) && GetLoadState() == MLS::LOADED) {
@@ -3960,7 +3993,7 @@ void CMainFrame::OnUpdatePlayerStatus(CCmdUI* pCmdUI)
             CString videoinfo;
             CString fpsinfo;
             CStringW audioinfo;
-            if (s.bShowVideoInfoInStatusbar && (!m_statusbarVideoFormat.IsEmpty() || !m_statusbarVideoSize.IsEmpty())) {                  
+            if (s.bShowVideoInfoInStatusbar && (!m_statusbarVideoFormat.IsEmpty() || !m_statusbarVideoSize.IsEmpty())) {
                 if(!m_statusbarVideoFormat.IsEmpty()) {
                     videoinfo.Append(m_statusbarVideoFormat);
                 }
@@ -4230,7 +4263,7 @@ LRESULT CMainFrame::OnFilePostOpenmedia(WPARAM wParam, LPARAM lParam)
             OnCommand(ID_PLAY_PAUSE, 0);
         }
     }
-    s.nCLSwitches &= ~CLSW_OPEN;  
+    s.nCLSwitches &= ~CLSW_OPEN;
 
     LoadDynamicMenus();
 
@@ -4476,7 +4509,7 @@ void CMainFrame::ToolbarContextMenu(int iItem, int nIndex, CRect buttonRect) {
     } else if (iItem == ID_MENU_PLAYER_SHORT) {
         subMenu = GetShortMenu();
     }
-    
+
 
     if (subMenu) {
         if (AppNeedsThemedControls()) {
@@ -4571,6 +4604,21 @@ void CMainFrame::OnStreamSubOnOff()
     } else if (GetPlaybackMode() == PM_DVD) {
         SendMessage(WM_COMMAND, ID_DVD_SUB_ONOFF);
     }
+}
+
+void CMainFrame::OnSubtitlesAutoCopy()
+{
+    CAppSettings& s = AfxGetAppSettings();
+    s.bAutoCopySubtitleToClipboard = !s.bAutoCopySubtitleToClipboard;
+    m_nLastCopiedSubSegment = -1;
+    m_strLastCopiedSubText.Empty();
+    m_OSD.DisplayMessage(OSD_TOPLEFT,
+        ResStr(IDS_AG_AUTOCOPY_SUBTITLE) + (s.bAutoCopySubtitleToClipboard ? _T(" On") : _T(" Off")));
+}
+
+void CMainFrame::OnUpdateSubtitlesAutoCopy(CCmdUI* pCmdUI)
+{
+    pCmdUI->SetCheck(AfxGetAppSettings().bAutoCopySubtitleToClipboard);
 }
 
 void CMainFrame::OnDvdAngle(UINT nID)
@@ -5044,7 +5092,7 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
             }
             m_dwLastRun = tcnow;
 
-            if ((s.nCLSwitches & CLSW_ADD) && !IsPlaylistEmpty()) {             
+            if ((s.nCLSwitches & CLSW_ADD) && !IsPlaylistEmpty()) {
                 POSITION pos2 = sl.GetHeadPosition();
                 while (pos2) {
                     CString fn = sl.GetNext(pos2);
@@ -5950,7 +5998,7 @@ HRESULT CMainFrame::RenderCurrentSubtitles(BYTE* pData) {
         }
 
         SubPicDesc spdRender;
-        
+
         spdRender.type = MSP_RGB32;
         spdRender.w = subWidth;
         spdRender.h = subHeight;
@@ -5958,7 +6006,7 @@ HRESULT CMainFrame::RenderCurrentSubtitles(BYTE* pData) {
         spdRender.pitch = subWidth * 4;
         spdRender.vidrect = { 0, 0, width, height };
         spdRender.bits = DEBUG_NEW BYTE[spdRender.pitch * spdRender.h];
-        
+
         CComPtr<CMemSubPicAllocator> pSubPicAllocator = DEBUG_NEW CMemSubPicAllocator(spdRender.type, CSize(spdRender.w, spdRender.h));
 
         CMemSubPic memSubPic(spdRender, pSubPicAllocator);
@@ -6257,7 +6305,7 @@ void CMainFrame::SaveThumbnails(LPCTSTR fn)
         for (int y = 0; y < szThumbnail.cy; y++, dst += spd.pitch, tsrc += tsrcPitch) {
             memcpy(dst, tsrc, abs(tsrcPitch));
         }
-        
+
         rts.Render(spd, 10000, 25, bbox); // Draw the thumbnail time
 
         delete [] pData;
@@ -6317,7 +6365,7 @@ void CMainFrame::SaveThumbnails(LPCTSTR fn)
                 szByteSize.Format(_T("%I64d"), size);
                 fs.Format(IDS_THUMBNAILS_INFO_FILESIZE, szFileSize, FormatNumber(szByteSize).GetString());
             }
-        }        
+        }
 
         CStringW ar;
         if (szAR.cx > 0 && szAR.cy > 0 && szAR.cx != szVideo.cx && szAR.cy != szVideo.cy) {
@@ -6473,7 +6521,7 @@ void CMainFrame::OnFileSaveImage()
     if (!s.strSnapshotPath.IsEmpty() && PathUtils::IsDir(s.strSnapshotPath)) {
         psrc.Combine(s.strSnapshotPath.GetString(), MakeSnapshotFileName(FALSE));
     } else {
-        psrc = CPath(MakeSnapshotFileName(FALSE));        
+        psrc = CPath(MakeSnapshotFileName(FALSE));
     }
 
     bool subtitleOptionSupported = !m_pMVRFG && s.fEnableSubtitles && s.IsISRAutoLoadEnabled();
@@ -8220,7 +8268,7 @@ void CMainFrame::OnViewModifySize(UINT nID) {
     CRect workRect, maxRect;
     GetWorkAreaRect(workRect);
     maxRect = GetZoomWindowRect(CSize(INT_MAX, INT_MAX), true);
-    
+
     CSize targetSize;
     CRect zoomRect;
 
@@ -8615,7 +8663,7 @@ bool CMainFrame::PerformFlipRotate()
             Vector defAngle = Vector(0, 0, Vector::DegToRad((nZ - m_iDefRotation + 360) % 360));
             m_pCAP2->SetDefaultVideoAngle(defAngle);
         }
-        
+
         hr = m_pCAP->SetVideoAngle(Vector(Vector::DegToRad(m_AngleX), Vector::DegToRad(m_AngleY), Vector::DegToRad(z)));
     }
 
@@ -8997,7 +9045,7 @@ void CMainFrame::OnPlayPlaypause()
             SendMessage(WM_COMMAND, ID_PLAY_PLAY);
         }
     } else if (GetLoadState() == MLS::CLOSED && !IsPlaylistEmpty()) {
-        SendMessage(WM_COMMAND, ID_PLAY_PLAY);        
+        SendMessage(WM_COMMAND, ID_PLAY_PLAY);
     }
 }
 
@@ -9235,7 +9283,7 @@ void CMainFrame::OnPlayFramestep(UINT nID)
     } else { // nID == ID_PLAY_FRAMESTEP_BACK
         const REFERENCE_TIME rtAvgTimePerFrame = std::llround(GetAvgTimePerFrame() * 10000000LL);
         REFERENCE_TIME rtCurPos = 0;
-        
+
         if (m_nStepForwardCount) { // Exit of framestep forward, calculate current position
             m_pFS->CancelStep();
             rtCurPos = m_rtStepForwardStart + m_nStepForwardCount * rtAvgTimePerFrame;
@@ -9952,7 +10000,7 @@ void CMainFrame::OnPlayAudio(UINT nID)
                 if (m_iReloadAudioIdx < cStreams) {
                     sidx = m_iReloadAudioIdx;
                 }
-                m_iReloadAudioIdx = -1;                
+                m_iReloadAudioIdx = -1;
             }
             if (sidx >= cStreams) { //invalid stream?
                 return;
@@ -11600,7 +11648,7 @@ void CMainFrame::SetDefaultFullscreenState()
                 CMonitor fullscreenMonitor = monitors.GetMonitor(s.strFullScreenMonitorID, s.strFullScreenMonitorDeviceName);
                 if (fullscreenMonitor.IsMonitor()) {
                     launchingFullscreenSeparateControls = fullscreenMonitor != currentMonitor;
-                }                
+                }
             }
 
             if (launchingFullscreenSeparateControls) {
@@ -11954,7 +12002,7 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
     if (!fullscreenMonitor.IsMonitor()) {
         fullscreenMonitor = currentMonitor;
     }
-    bool fullScreenSeparate = s.bFullscreenSeparateControls && (m_pMFVDC || m_pVMRWC || m_pVW) && fullscreenMonitor.IsMonitor() && fullscreenMonitor != currentMonitor && (s.nCS & (CS_SEEKBAR | CS_TOOLBAR));   
+    bool fullScreenSeparate = s.bFullscreenSeparateControls && (m_pMFVDC || m_pVMRWC || m_pVW) && fullscreenMonitor.IsMonitor() && fullscreenMonitor != currentMonitor && (s.nCS & (CS_SEEKBAR | CS_TOOLBAR));
 
     const CWnd* pInsertAfter = nullptr;
     CRect windowRect;
@@ -12605,7 +12653,7 @@ void CMainFrame::SetPreviewVideoPosition() {
             w = int(minw + (maxw - minw) * scale);
             h = MulDiv(w, arxy.cy, arxy.cx);
         }
-     
+
         if (m_pMFVDC_preview) {
             m_pMFVDC_preview->SetVideoPosition(nullptr, wr);
             m_pMFVDC_preview->SetAspectRatioMode(MFVideoARMode_PreservePicture);
@@ -15336,7 +15384,7 @@ int CMainFrame::SetupAudioStreams()
                 DeleteMediaType(pmt);
                 return -1; // no need to select a specific track
             }
-        }        
+        }
     }
 
     return -1;
@@ -15963,6 +16011,8 @@ void CMainFrame::CloseMediaPrivate()
     m_rtDurationOverride = -1;
     m_bUsingDXVA = false;
     m_audioTrackCount = 0;
+    m_nLastCopiedSubSegment = -1;
+    m_strLastCopiedSubText.Empty();
     if (m_pDVBState) {
         m_pDVBState->Join();
         m_pDVBState = nullptr;
@@ -16060,7 +16110,7 @@ void CMainFrame::CloseMediaPrivate()
     m_fCustomGraph = m_fShockwaveGraph = false;
 
     m_lastOMD.Free();
-	
+
 	m_FontInstaller.UninstallFonts();
 }
 
@@ -17393,7 +17443,7 @@ void CMainFrame::SetupRecentFilesSubMenu()
     CMenu& subMenu = m_recentFilesMenu;
     // Empty the menu
     while (subMenu.RemoveMenu(0, MF_BYPOSITION));
-   
+
     if (!s.fKeepHistory) {
         return;
     }
@@ -17570,7 +17620,7 @@ bool CMainFrame::SetupShadersSubMenu()
     if (!(s.iDSVideoRendererType == VIDRNDT_DS_EVR_CUSTOM || s.iDSVideoRendererType == VIDRNDT_DS_SYNC
         || s.iDSVideoRendererType == VIDRNDT_DS_VMR9RENDERLESS || s.iDSVideoRendererType == VIDRNDT_DS_MADVR || s.iDSVideoRendererType == VIDRNDT_DS_MPCVR)) {
         return false;
-    }        
+    }
 
     subMenu.AppendMenu(MF_BYCOMMAND | MF_STRING | MF_ENABLED, ID_PRESIZE_SHADERS_TOGGLE, ResStr(IDS_PRESIZE_SHADERS_TOGGLE));
     subMenu.AppendMenu(MF_BYCOMMAND | MF_STRING | MF_ENABLED, ID_POSTSIZE_SHADERS_TOGGLE, ResStr(IDS_POSTSIZE_SHADERS_TOGGLE));
@@ -17761,7 +17811,7 @@ bool CMainFrame::LoadSubtitle(CString fn, SubtitleInput* pSubInput /*= nullptr*/
         if (::PathIsDirectory(path)) {
             WIN32_FIND_DATA fd = {0};
             HANDLE hFind;
-            
+
             hFind = FindFirstFile(path + L"*.?t?", &fd);
             if (hFind != INVALID_HANDLE_VALUE) {
                 do {
@@ -17770,7 +17820,7 @@ bool CMainFrame::LoadSubtitle(CString fn, SubtitleInput* pSubInput /*= nullptr*/
                         m_FontInstaller.InstallTempFontFile(path + fd.cFileName);
                     }
                 } while (FindNextFile(hFind, &fd));
-                
+
                 FindClose(hFind);
             }
         }
@@ -18005,6 +18055,10 @@ void CMainFrame::SetSubtitle(const SubtitleInput& subInput, bool skip_lcid /* = 
 
     CAppSettings& s = AfxGetAppSettings();
     ResetSubtitlePosAndSize(false);
+
+    // Reset auto-copy subtitle tracking when subtitle stream changes
+    m_nLastCopiedSubSegment = -1;
+    m_strLastCopiedSubText.Empty();
 
     {
         CAutoLock cAutoLock(&m_csSubLock);
@@ -22334,7 +22388,7 @@ bool CMainFrame::ProcessYoutubeDLURL(CString url, bool append, bool replace)
 
         int targetlen = title.GetLength() > 100 ? 50 : 150 - title.GetLength();
         CString short_url = ShortenURL(ydl_src, targetlen, true);
-        
+
         if (ydl_src == filenames.GetHead()) {
             // Processed URL is same as input, can happen for DASH manifest files. Clear source URL to avoid reprocessing.
             ydl_src = _T("");
@@ -22609,7 +22663,7 @@ void CMainFrame::MediaTransportControlSetMedia() {
                     ASSERT(ret == S_OK);
                     have_secondary_title = true;
                 }
-            }                
+            }
         }
 
         // Thumbnail

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -330,7 +330,7 @@ private:
 
     void SetVolumeBoost(UINT nAudioBoost);
     void SetBalance(int balance);
-	
+
 	// temp fonts loader
 	CFontInstaller m_FontInstaller;
 
@@ -346,7 +346,6 @@ private:
 
     // Auto-copy subtitle to clipboard tracking
     int m_nLastCopiedSubSegment;
-    CStringW m_strLastCopiedSubText;
 
     // StatusBar message text parts
     CString currentAudioLang;
@@ -742,7 +741,7 @@ public:
 
     // shaders
     void SetShaders(bool bSetPreResize = true, bool bSetPostResize = true);
-	
+
 	bool m_bToggleShader;
 	bool m_bToggleShaderScreenSpace;
 	std::list<ShaderC> m_ShaderCache;
@@ -1363,6 +1362,7 @@ protected:
     static BOOL AppendMenuEx(CMenu& menu, UINT nFlags, UINT nIDNewItem, CString& text);
 
     void SubtitlesSave(const TCHAR* directory = nullptr, bool silent = false);
+    void CopyCurrentSubtitleToClipboard(REFERENCE_TIME rtNow);
 
     void OnSizingFixWndToVideo(UINT nSide, LPRECT lpRect, bool bCtrl = false);
     void OnSizingSnapToScreen(UINT nSide, LPRECT lpRect, bool bCtrl = false);
@@ -1406,8 +1406,8 @@ public:
 
     /**
      * @brief Get title of file
-     * @param fTitleBarTextTitle 
-     * @return 
+     * @param fTitleBarTextTitle
+     * @return
     */
     CString getBestTitle(bool fTitleBarTextTitle = true);
     MediaTransControls m_media_trans_control;

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -344,6 +344,10 @@ private:
     POSITION m_posFirstExtSub;
     SubtitleInput m_pCurrentSubInput;
 
+    // Auto-copy subtitle to clipboard tracking
+    int m_nLastCopiedSubSegment;
+    CStringW m_strLastCopiedSubText;
+
     // StatusBar message text parts
     CString currentAudioLang;
     CString currentSubLang;
@@ -933,6 +937,8 @@ public:
     afx_msg void OnStreamAudio(UINT nID);
     afx_msg void OnStreamSub(UINT nID);
     afx_msg void OnStreamSubOnOff();
+    afx_msg void OnSubtitlesAutoCopy();
+    afx_msg void OnUpdateSubtitlesAutoCopy(CCmdUI* pCmdUI);
     afx_msg void OnAudioShiftOnOff();
     afx_msg void OnDvdAngle(UINT nID);
     afx_msg void OnDvdAudio(UINT nID);

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -75,6 +75,7 @@
 #define IDS_RS_AUTOUPLOADSUBTITLES          _T("AutoUploadSubtitles")
 #define IDS_RS_SUBTITLESPROVIDERS           _T("SubtitlesProviders")
 #define IDS_RS_PREFERHEARINGIMPAIREDSUBTITLES _T("PreferHearingImpairedSubtitles")
+#define IDS_RS_AUTOCOPYSUBTITLE             _T("AutoCopySubtitleToClipboard")
 #define IDS_RS_MPCTHEME                     _T("MPCTheme")
 #define IDS_RS_MODERNSEEKBARHEIGHT          _T("ModernSeekbarHeight")
 #define IDS_RS_MODERNTHEMEMODE              _T("ModernThemeMode")

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -3369,17 +3369,18 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_AG_NEXT_SUBTITLE    "Next Subtitle Track"
-    IDS_AG_PREV_SUBTITLE    "Prev Subtitle Track"
-    IDS_MPLAYERC_85         "On/Off Subtitle"
-    IDS_MPLAYERC_86         "Reload Subtitles"
-    IDS_MPLAYERC_91         "Next Angle (DVD)"
-    IDS_MPLAYERC_92         "Prev Angle (DVD)"
-    IDS_MPLAYERC_93         "Next Audio Track (DVD)"
-    IDS_MPLAYERC_94         "Prev Audio Track (DVD)"
-    IDS_MPLAYERC_95         "Next Subtitle Track (DVD)"
-    IDS_MPLAYERC_96         "Prev Subtitle Track (DVD)"
-    IDS_MPLAYERC_97         "On/Off Subtitle (DVD)"
+    IDS_AG_NEXT_SUBTITLE     "Next Subtitle Track"
+    IDS_AG_PREV_SUBTITLE     "Prev Subtitle Track"
+    IDS_AG_AUTOCOPY_SUBTITLE "Auto-Copy Subtitle to Clipboard"
+    IDS_MPLAYERC_85          "On/Off Subtitle"
+    IDS_MPLAYERC_86          "Reload Subtitles"
+    IDS_MPLAYERC_91          "Next Angle (DVD)"
+    IDS_MPLAYERC_92          "Prev Angle (DVD)"
+    IDS_MPLAYERC_93          "Next Audio Track (DVD)"
+    IDS_MPLAYERC_94          "Prev Audio Track (DVD)"
+    IDS_MPLAYERC_95          "Next Subtitle Track (DVD)"
+    IDS_MPLAYERC_96          "Prev Subtitle Track (DVD)"
+    IDS_MPLAYERC_97          "On/Off Subtitle (DVD)"
     IDS_OSD_DISPLAY_CURRENT_TIME "OSD: Display Current Time"
 END
 

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -235,6 +235,7 @@
 #define ID_STREAM_SUB_PREV              955
 #define ID_STREAM_SUB_ONOFF             956
 #define ID_LEFTSEPARATOR                957
+#define ID_SUBTITLES_AUTOCOPY           958
 #define ID_AUDIOSHIFT_ONOFF             960
 #define ID_DVD_ANGLE_NEXT               961
 #define ID_DVD_ANGLE_PREV               962
@@ -888,6 +889,7 @@
 #define IDS_AG_PREV_AUDIO               32959
 #define IDS_AG_NEXT_SUBTITLE            32960
 #define IDS_AG_PREV_SUBTITLE            32961
+#define IDS_AG_AUTOCOPY_SUBTITLE        32964
 #define IDS_MPLAYERC_85                 32962
 #define IDS_MPLAYERC_86                 32963
 #define IDS_MPLAYERC_91                 32968


### PR DESCRIPTION
# Summary

Adds a toggleable feature that automatically copies the current subtitle line to the system clipboard when it changes during playback. Useful for language learning workflows with tools like Clipboard Inserter.

## How to enable it
By default, the new feature has no default keybind to minimize impact. Users that want to use this feature can perform the following steps.

1. Go to **Options → Keys**
2. Find **"Auto-Copy Subtitle to ClipboardClipboard"**
3. Assign a hotkey
4. Press the hotkey during playback to toggle (OSD shows On/Off status)

## How I implemented it

The implemention uses `SearchSubs()` to find current subtitle segment, extracts text via `GetStrW()` (stripping SSA by passing `false` to this function do some minor HTML tag stripping after), before copying the result to the clipboard. It acquires the `m_csSubLock` lock before reading the current subtitle text (read notes).

## Notes
I tried to follow existing coding standards and patterns as much as possible, but I'm not a C++ expert so there is most likely things I could have done better. If you spot any issues or points that I can improve, please let me know.

### Things I'm unsure about and/or might need to change
- I hardcoded `25` as the FPS of the current file when calling `SearchSubs`, since I didn't know exactly how to get it from the player.
- I'm also not sure if the logic I added should actually be somewhere else and just invoked in that place or not.
- I saw that the code acquires the lock `m_csSubLock` (subtitle lock) on `OnGetSubtitles` function before interacting with `pRTS`. I'm not sure if locking was necessary in the new logic I added, but just to be safe I added it there.
- Should I have added an option in the options menu to enable/disable this feature, or is it too niche to be worth it and keeping it as a "keybind-only option" is fine?
- When I tried running the `sync.bat` script to sync the resources, it erased all their data for some reason, keeping only the first ~20 lines of each resource file. I have no idea why this happened, so I reverted its changes.
- When commiting, Git or my IDE updated some lines that apparently had different line breaks, so that is why there are some "empty lines/no change lines" in the changes. Yes, I did set `git config core.autocrlf true` before creating the commits.

## Video

I recorded a short video showing the feature in action.

https://www.youtube.com/watch?v=hA3oJpeMTNE

# History

I'm opening this PR to add a feature that I've personally been missing in MPC-HC for a _long_ time.

881 days ago, I opened an [issue](https://github.com/clsid2/mpc-hc/issues/2201) requesting this feature I didn't have enough C++ knowledge to develop. Now I've have gathered enough knowledge to be able to code it myself.

This feature existed in some other video players, but MPC-HC is the one I like the most and the one I'm most familiar with. I thought it'd make sense to not only add this feature to MPC-HC in a personal build, but also share it so others people that are learning other languages like me can also use it instead of having to fallback to other (inferior) video players.