### PR TITLE
Fixes for list control and inline edits

### DIFF
--- a/src/mpc-hc/CMPCThemeInlineEdit.cpp
+++ b/src/mpc-hc/CMPCThemeInlineEdit.cpp
@@ -11,22 +11,22 @@ CMPCThemeInlineEdit::CMPCThemeInlineEdit():
     m_brBkgnd.CreateSolidBrush(CMPCTheme::ContentBGColor);
 }
 
-
 CMPCThemeInlineEdit::~CMPCThemeInlineEdit()
 {
     m_brBkgnd.DeleteObject();
 }
+
 void CMPCThemeInlineEdit::setOverridePos(int x, int maxWidth) {
     overrideX = x;
     overrideMaxWidth = maxWidth;
     offsetEnabled = true;
 }
+
 BEGIN_MESSAGE_MAP(CMPCThemeInlineEdit, CEdit)
     ON_WM_CTLCOLOR_REFLECT()
     ON_WM_WINDOWPOSCHANGED()
     ON_WM_PAINT()
 END_MESSAGE_MAP()
-
 
 HBRUSH CMPCThemeInlineEdit::CtlColor(CDC* pDC, UINT nCtlColor)
 {
@@ -34,11 +34,9 @@ HBRUSH CMPCThemeInlineEdit::CtlColor(CDC* pDC, UINT nCtlColor)
         pDC->SetTextColor(CMPCTheme::TextFGColor);
         pDC->SetBkColor(CMPCTheme::ContentBGColor);
         return m_brBkgnd;
-    } else {
-        return NULL;
     }
+    return nullptr;
 }
-
 
 void CMPCThemeInlineEdit::OnWindowPosChanged(WINDOWPOS* lpwndpos) {
     if (offsetEnabled && overrideX != lpwndpos->x) {
@@ -50,19 +48,18 @@ void CMPCThemeInlineEdit::OnWindowPosChanged(WINDOWPOS* lpwndpos) {
 
 void CMPCThemeInlineEdit::OnPaint() {
     if (AppIsThemeLoaded()) {
-        CPaintDC dc(this);
-
-        CRect rect;
-        GetClientRect(&rect);
-
-        CBrush brush;
-        brush.CreateSolidBrush(CMPCTheme::InlineEditBorderColor);
-        dc.FrameRect(&rect, &brush);
-        brush.DeleteObject();
-
-        rect.DeflateRect(1, 1);
-        CBrush bgBrush(CMPCTheme::ContentBGColor);
-        dc.FrameRect(rect, &bgBrush);
+        Default();
+        CDC* pDC = GetDC();
+        if (pDC) {
+            CRect rect;
+            GetClientRect(&rect);
+            CBrush outerBrush(CMPCTheme::InlineEditBorderColor);
+            pDC->FrameRect(&rect, &outerBrush);
+            rect.DeflateRect(1, 1);
+            CBrush innerBrush(CMPCTheme::ContentBGColor);
+            pDC->FrameRect(rect, &innerBrush);
+            ReleaseDC(pDC);
+        }
     } else {
         __super::OnPaint();
     }

--- a/src/mpc-hc/CMPCThemeInlineEdit.h
+++ b/src/mpc-hc/CMPCThemeInlineEdit.h
@@ -9,13 +9,10 @@ public:
     CBrush m_brBkgnd;
     void setOverridePos(int x, int maxWidth);
     DECLARE_MESSAGE_MAP()
-    afx_msg void OnNcPaint();
     afx_msg HBRUSH CtlColor(CDC* /*pDC*/, UINT /*nCtlColor*/);
     afx_msg void OnWindowPosChanged(WINDOWPOS* lpwndpos);
+    afx_msg void OnPaint();
 private:
     int overrideX, overrideMaxWidth;
     bool offsetEnabled;
-public:
-    afx_msg void OnPaint();
 };
-

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -8161,9 +8161,6 @@ void CMainFrame::OnViewPlaylist()
     m_controls.ToggleControl(CMainFrameControls::Panel::PLAYLIST);
     m_wndPlaylistBar.SetHiddenDueToFullscreen(false);
     UpdatePlaylistButton();
-    if (m_controls.ControlChecked(CMainFrameControls::Panel::PLAYLIST)) {
-        m_wndPlaylistBar.EnsureCurrentVisible();
-    }
 }
 
 void CMainFrame::OnUpdateViewPlaylist(CCmdUI* pCmdUI)

--- a/src/mpc-hc/PlayerListCtrl.cpp
+++ b/src/mpc-hc/PlayerListCtrl.cpp
@@ -978,7 +978,6 @@ BEGIN_MESSAGE_MAP(CPlayerListCtrl, CMPCThemePlayerListCtrl)
     ON_WM_XBUTTONDBLCLK()
     ON_WM_SETCURSOR()
     ON_NOTIFY_REFLECT_EX(LVN_ENDLABELEDIT, &CPlayerListCtrl::OnLvnEndlabeledit)
-    ON_MESSAGE(LVM_EDITLABEL, OnLvmEditLabel)
 END_MESSAGE_MAP()
 
 // CPlayerListCtrl message handlers
@@ -1034,22 +1033,6 @@ LRESULT CPlayerListCtrl::SendLabelEditNotify(CWnd* pList, UINT code, int nItem, 
     return pList->GetParent()->SendMessage(WM_NOTIFY, pList->GetDlgCtrlID(), (LPARAM)&dispinfo);
 }
 
-LRESULT CPlayerListCtrl::OnLvmEditLabel(WPARAM wParam, LPARAM)
-{
-    int nItem = (int)wParam;
-    if (nItem < 0) {
-        return 0;
-    }
-    if (GetStyle() & LVS_OWNERDATA) {
-        StartVirtualEditLabel(nItem, m_nSubItemClicked);
-    } else {
-        if (SendLabelEditNotify(this, LVN_BEGINLABELEDIT, nItem, m_nSubItemClicked)) {
-            SendLabelEditNotify(this, LVN_DOLABELEDIT, nItem, m_nSubItemClicked);
-        }
-    }
-    return 0;
-}
-
 void CPlayerListCtrl::OnLButtonDown(UINT nFlags, CPoint point)
 {
     CListCtrl::OnLButtonDown(nFlags, point);
@@ -1087,7 +1070,13 @@ void CPlayerListCtrl::OnTimer(UINT_PTR nIDEvent)
 
         UINT flag = LVIS_FOCUSED;
         if ((GetItemState(m_nItemClicked, flag) & flag) == flag && m_nSubItemClicked >= 0) {
-            SendMessage(LVM_EDITLABEL, m_nItemClicked, 0);
+            LV_DISPINFO dispinfo = {};
+            dispinfo.hdr.hwndFrom = m_hWnd;
+            dispinfo.hdr.idFrom = GetDlgCtrlID();
+            dispinfo.hdr.code = LVN_DOLABELEDIT;
+            dispinfo.item.iItem = m_nItemClicked;
+            dispinfo.item.iSubItem = m_nSubItemClicked;
+            GetParent()->SendMessage(WM_NOTIFY, GetDlgCtrlID(), (LPARAM)&dispinfo);
         }
     } else if (nIDEvent == 43) {
         // CListCtrl does really strange things on this timer.

--- a/src/mpc-hc/PlayerListCtrl.cpp
+++ b/src/mpc-hc/PlayerListCtrl.cpp
@@ -828,6 +828,7 @@ BEGIN_MESSAGE_MAP(CPlayerListCtrl, CMPCThemePlayerListCtrl)
     ON_WM_HSCROLL()
     ON_WM_MOUSEWHEEL()
     ON_WM_LBUTTONDOWN()
+    ON_WM_RBUTTONDOWN()
     ON_WM_TIMER()
     ON_WM_LBUTTONDBLCLK()
     ON_NOTIFY_REFLECT(LVN_MARQUEEBEGIN, OnLvnMarqueeBegin)
@@ -1143,4 +1144,14 @@ int CPlayerListCtrl::InsertColumn(_In_ int nCol, _In_z_ LPCWSTR lpszColumnHeadin
     }
 
     return nCol;
+}
+
+void CPlayerListCtrl::OnRButtonDown(UINT nFlags, CPoint point)
+{
+    if (m_nTimerID) {
+        KillTimer(m_nTimerID);
+        m_nTimerID = 0;
+    }
+    m_nItemClicked = -1;
+    __super::OnRButtonDown(nFlags, point);
 }

--- a/src/mpc-hc/PlayerListCtrl.cpp
+++ b/src/mpc-hc/PlayerListCtrl.cpp
@@ -466,86 +466,6 @@ void CInPlaceListBox::OnNcDestroy()
 }
 
 
-// CMPCThemeInPlaceEdit
-
-CMPCThemeInPlaceEdit::CMPCThemeInPlaceEdit(int iItem, int iSubItem, CString sInitText, CMPCThemeInPlaceEdit** ppSelf)
-    : m_iItem(iItem)
-    , m_iSubItem(iSubItem)
-    , m_sInitText(sInitText)
-    , m_ppSelf(ppSelf)
-    , m_bESC(FALSE)
-{
-    if (m_ppSelf) *m_ppSelf = this;
-}
-
-CMPCThemeInPlaceEdit::~CMPCThemeInPlaceEdit()
-{
-}
-
-BEGIN_MESSAGE_MAP(CMPCThemeInPlaceEdit, CMPCThemeInlineEdit)
-    ON_WM_KILLFOCUS()
-    ON_WM_NCDESTROY()
-    ON_WM_CHAR()
-    ON_WM_CREATE()
-END_MESSAGE_MAP()
-
-BOOL CMPCThemeInPlaceEdit::PreTranslateMessage(MSG* pMsg)
-{
-    if (pMsg->message == WM_KEYDOWN) {
-        if (pMsg->wParam == VK_RETURN
-                || pMsg->wParam == VK_DELETE
-                || pMsg->wParam == VK_ESCAPE
-                || GetKeyState(VK_CONTROL)) {
-            ::TranslateMessage(pMsg);
-            ::DispatchMessage(pMsg);
-            return TRUE;
-        }
-    }
-    return CEdit::PreTranslateMessage(pMsg);
-}
-
-void CMPCThemeInPlaceEdit::OnKillFocus(CWnd* pNewWnd)
-{
-    CEdit::OnKillFocus(pNewWnd);
-
-    CString str;
-    GetWindowText(str);
-
-    CPlayerListCtrl::SendLabelEditNotify(GetParent(), LVN_ENDLABELEDIT, m_iItem, m_iSubItem,
-                                         m_bESC ? nullptr : (LPCTSTR)str);
-
-    DestroyWindow();
-}
-
-void CMPCThemeInPlaceEdit::OnNcDestroy()
-{
-    if (m_ppSelf) *m_ppSelf = nullptr;
-    CEdit::OnNcDestroy();
-    delete this;
-}
-
-void CMPCThemeInPlaceEdit::OnChar(UINT nChar, UINT nRepCnt, UINT nFlags)
-{
-    if (nChar == VK_ESCAPE || nChar == VK_RETURN) {
-        if (nChar == VK_ESCAPE) {
-            m_bESC = TRUE;
-        }
-        GetParent()->SetFocus();
-        return;
-    }
-    CEdit::OnChar(nChar, nRepCnt, nFlags);
-}
-
-int CMPCThemeInPlaceEdit::OnCreate(LPCREATESTRUCT lpCreateStruct)
-{
-    if (CEdit::OnCreate(lpCreateStruct) == -1) {
-        return -1;
-    }
-    SetFont(GetParent()->GetFont());
-    SetWindowText(m_sInitText);
-    return 0;
-}
-
 // CPlayerListCtrl
 
 IMPLEMENT_DYNAMIC(CPlayerListCtrl, CMPCThemePlayerListCtrl)
@@ -556,7 +476,6 @@ CPlayerListCtrl::CPlayerListCtrl(bool bDoubleClickAction)
     , m_nTimerID(0)
     , m_fInPlaceDirty(false)
     , inPlaceControl(false)
-    , m_pVirtualEdit(nullptr)
 {
 }
 
@@ -793,7 +712,7 @@ void CPlayerListCtrl::OnEnChangeWinHotkey1()
     m_fInPlaceDirty = true;
 }
 
-CEdit* CPlayerListCtrl::ShowInPlaceEdit(int nItem, int nCol)
+CInPlaceEdit* CPlayerListCtrl::ShowInPlaceEdit(int nItem, int nCol)
 {
     CRect rect;
     if (!PrepareInPlaceControl(nItem, nCol, rect)) {
@@ -809,61 +728,12 @@ CEdit* CPlayerListCtrl::ShowInPlaceEdit(int nItem, int nCol)
                : (lvcol.fmt & LVCFMT_JUSTIFYMASK) == LVCFMT_RIGHT ? ES_RIGHT
                : ES_CENTER;
 
-    CEdit* pEdit = DEBUG_NEW CInPlaceEdit(nItem, nCol, GetItemText(nItem, nCol));
+    CInPlaceEdit* pEdit = DEBUG_NEW CInPlaceEdit(nItem, nCol, GetItemText(nItem, nCol));
     pEdit->Create(dwStyle, rect, this, IDC_EDIT1);
 
     m_fInPlaceDirty = false;
 
     return pEdit;
-}
-
-void CPlayerListCtrl::AdjustVirtualEditPos(int xOffset, int maxWidth)
-{
-    if (!m_pVirtualEdit) return;
-    CRect r;
-    m_pVirtualEdit->GetWindowRect(r);
-    ScreenToClient(r);
-    r.left += xOffset;
-    if (maxWidth > 0 && r.left + maxWidth < r.right) {
-        r.right = r.left + maxWidth;
-    }
-    m_pVirtualEdit->MoveWindow(r);
-    m_pVirtualEdit->setOverridePos(xOffset, maxWidth > 0 ? maxWidth : -1);
-}
-
-void CPlayerListCtrl::StartVirtualEditLabel(int nItem, int nSubItem)
-{
-    // Cancel any lingering edit (should already be gone via SetFocus at top of OnLButtonDown)
-    if (m_pVirtualEdit) {
-        SetFocus();
-    }
-
-    CString text = GetItemText(nItem, nSubItem); // triggers LVN_GETDISPINFO for virtual lists
-
-    CRect rect;
-    GetItemRect(nItem, &rect, LVIR_LABEL);
-
-    m_fInPlaceDirty = false;
-
-    // Create hidden — parent adjusts rect/font in response to LVN_BEGINLABELEDIT
-    m_pVirtualEdit = DEBUG_NEW CMPCThemeInPlaceEdit(nItem, nSubItem, text, &m_pVirtualEdit);
-    m_pVirtualEdit->Create(WS_CHILD | WS_BORDER | ES_AUTOHSCROLL, rect, this, IDC_EDIT1);
-
-    // Notify parent; edit is already created so parent can call GetVirtualEditCtrl()
-    if (!SendLabelEditNotify(this, LVN_BEGINLABELEDIT, nItem, nSubItem, text)) {
-        // Parent denied editing
-        if (m_pVirtualEdit) {
-            m_pVirtualEdit->DestroyWindow(); // → OnNcDestroy → m_pVirtualEdit = nullptr
-        }
-        return;
-    }
-
-    // Parent allowed; show and focus
-    if (m_pVirtualEdit) {
-        m_pVirtualEdit->ShowWindow(SW_SHOW);
-        m_pVirtualEdit->SetFocus();
-        m_pVirtualEdit->SetSel(0, -1);
-    }
 }
 
 CEdit* CPlayerListCtrl::ShowInPlaceFloatEdit(int nItem, int nCol)
@@ -954,7 +824,6 @@ CListBox* CPlayerListCtrl::ShowInPlaceListBox(int nItem, int nCol, CAtlList<CStr
 }
 
 BEGIN_MESSAGE_MAP(CPlayerListCtrl, CMPCThemePlayerListCtrl)
-    ON_WM_SIZE()
     ON_WM_VSCROLL()
     ON_WM_HSCROLL()
     ON_WM_MOUSEWHEEL()
@@ -982,14 +851,6 @@ END_MESSAGE_MAP()
 
 // CPlayerListCtrl message handlers
 
-void CPlayerListCtrl::OnSize(UINT nType, int cx, int cy)
-{
-    if (m_pVirtualEdit) {
-        SetFocus();
-    }
-    __super::OnSize(nType, cx, cy);
-}
-
 void CPlayerListCtrl::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 {
     if (GetFocus() != this) {
@@ -1008,9 +869,6 @@ void CPlayerListCtrl::OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar)
 
 BOOL CPlayerListCtrl::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
 {
-    if (m_pVirtualEdit && ::IsWindow(m_pVirtualEdit->GetSafeHwnd())) {
-        return TRUE;
-    }
     if (GetFocus() != this) {
         SetFocus();
     }
@@ -1061,6 +919,7 @@ void CPlayerListCtrl::OnLButtonDown(UINT nFlags, CPoint point)
         SetItemState(m_nItemClicked, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
     }
 }
+
 
 void CPlayerListCtrl::OnTimer(UINT_PTR nIDEvent)
 {

--- a/src/mpc-hc/PlayerListCtrl.h
+++ b/src/mpc-hc/PlayerListCtrl.h
@@ -24,7 +24,6 @@
 #include "WinHotkeyCtrl.h"
 #include "CMPCThemeComboBox.h"
 #include "CMPCThemePlayerListCtrl.h"
-#include "CMPCThemeInlineEdit.h"
 
 #define LVN_DOLABELEDIT (LVN_FIRST+1)
 
@@ -141,35 +140,6 @@ public:
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
 };
 
-// CMPCThemeInPlaceEdit — themed inline edit for virtual (LVS_OWNERDATA) list controls.
-// CPlayerListCtrl creates and owns instances. The edit notifies the list ctrl via a
-// back-reference pointer and self-destructs in OnNcDestroy (same as CInPlaceEdit).
-
-class CMPCThemeInPlaceEdit : public CMPCThemeInlineEdit
-{
-protected:
-    int m_iItem;
-    int m_iSubItem;
-    CString m_sInitText;
-    CMPCThemeInPlaceEdit** m_ppSelf; // nulled on destruction so owner's pointer clears
-    BOOL m_bESC;
-
-public:
-    CMPCThemeInPlaceEdit(int iItem, int iSubItem, CString sInitText, CMPCThemeInPlaceEdit** ppSelf);
-    virtual ~CMPCThemeInPlaceEdit();
-
-protected:
-    virtual BOOL PreTranslateMessage(MSG* pMsg);
-
-    DECLARE_MESSAGE_MAP()
-
-public:
-    afx_msg void OnKillFocus(CWnd* pNewWnd);
-    afx_msg void OnNcDestroy();
-    afx_msg void OnChar(UINT nChar, UINT nRepCnt, UINT nFlags);
-    afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
-};
-
 // CPlayerListCtrl
 
 class CPlayerListCtrl : public CMPCThemePlayerListCtrl
@@ -183,33 +153,21 @@ private:
     CRect inPlaceControlRect;
     UINT_PTR m_nTimerID;
 
-    CMPCThemeInPlaceEdit* m_pVirtualEdit; // active virtual-list inline edit, or nullptr
-
-    bool PrepareInPlaceControl(int nRow, int nCol, CRect& rect);
-    void StartVirtualEditLabel(int nItem, int nSubItem);
-
 public:
     CPlayerListCtrl(bool bDoubleClickAction = false);
     virtual ~CPlayerListCtrl();
+
+    bool PrepareInPlaceControl(int nRow, int nCol, CRect& rect);
 
     int HitTestEx(const CPoint& point, int* col) const;
     CImageList* CreateDragImageEx(LPPOINT lpPoint);
 
     int GetBottomIndex() const;
 
-    // Returns the active virtual-list inline edit, or nullptr if none is open.
-    // Valid during and after LVN_BEGINLABELEDIT; caller may adjust rect/font.
-    CMPCThemeInPlaceEdit* GetVirtualEditCtrl() const { return m_pVirtualEdit; }
-
-    // Positions the active virtual-list inline edit. xOffset shifts the left edge
-    // (e.g. to clear a sequence number drawn before the label); maxWidth caps the
-    // right edge. Call from LVN_BEGINLABELEDIT before returning *pResult = 1.
-    void AdjustVirtualEditPos(int xOffset, int maxWidth = -1);
-
     static LRESULT SendLabelEditNotify(CWnd* pList, UINT code, int nItem, int nSubItem, LPCTSTR pszText = nullptr);
 
     CWinHotkeyCtrl* ShowInPlaceWinHotkey(int nItem, int nCol);
-    CEdit* ShowInPlaceEdit(int nItem, int nCol);
+    CInPlaceEdit* ShowInPlaceEdit(int nItem, int nCol);
     CEdit* ShowInPlaceFloatEdit(int nItem, int nCol);
     CComboBox* ShowInPlaceComboBox(int nItem, int nCol, CAtlList<CString>& lstItems, int nSel, bool bShowDropDown = false);
     CListBox* ShowInPlaceListBox(int nItem, int nCol, CAtlList<CString>& lstItems, int nSel);
@@ -224,7 +182,6 @@ protected:
     DECLARE_MESSAGE_MAP()
 
 public:
-    afx_msg void OnSize(UINT nType, int cx, int cy);
     afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
     afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
     afx_msg void OnLButtonDown(UINT nFlags, CPoint point);

--- a/src/mpc-hc/PlayerListCtrl.h
+++ b/src/mpc-hc/PlayerListCtrl.h
@@ -247,5 +247,4 @@ public:
     afx_msg void OnXButtonDblClk(UINT nFlags, UINT nButton, CPoint point);
     afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
     afx_msg BOOL OnLvnEndlabeledit(NMHDR* pNMHDR, LRESULT* pResult);
-    afx_msg LRESULT OnLvmEditLabel(WPARAM wParam, LPARAM lParam);
 };

--- a/src/mpc-hc/PlayerListCtrl.h
+++ b/src/mpc-hc/PlayerListCtrl.h
@@ -185,6 +185,7 @@ public:
     afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
     afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
     afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
+    afx_msg void OnRButtonDown(UINT nFlags, CPoint point);
     afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
     afx_msg void OnTimer(UINT_PTR nIDEvent);
     afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1310,19 +1310,6 @@ void CPlayerPlaylistBar::EnsureVisible(POSITION pos)
     m_list.Invalidate();
 }
 
-void CPlayerPlaylistBar::EnsureCurrentVisible()
-{
-    if (!m_pl.IsEmpty()) {
-        POSITION pos = m_pl.GetPos();
-        int i = FindItem(pos);
-        if (i < 0) {
-            return;
-        }
-        m_list.EnsureVisible(i, TRUE);
-        m_list.Invalidate();
-    }
-}
-
 int CPlayerPlaylistBar::FindItem(const POSITION pos) const
 {
     auto it = m_posToIndex.find(pos);

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1893,18 +1893,13 @@ void CPlayerPlaylistBar::ResizeListColumn()
 
         m_list.SetRedraw(FALSE);
         m_list.SetColumnWidth(COL_NAME, 0);
-        m_list.SetRedraw(TRUE);
-
         m_list.MoveWindow(listR, FALSE);
-
         m_list.GetClientRect(r);
-
-        m_list.SetRedraw(FALSE);
-        m_list.SetColumnWidth(COL_NAME, r.Width() - m_nTimeColWidth);
+        m_list.SetColumnWidth(COL_NAME, std::max(0, r.Width() - m_nTimeColWidth));
         m_list.SetRedraw(TRUE);
 
         Invalidate();
-        m_list.RedrawWindow(nullptr, nullptr, RDW_FRAME | RDW_INVALIDATE);
+        m_listFrame.RedrawWindow(nullptr, nullptr, RDW_FRAME | RDW_INVALIDATE | RDW_NOCHILDREN);
     }
 }
 

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -129,6 +129,7 @@ BOOL CPlayerPlaylistBar::Create(CWnd* pParentWnd, UINT defDockBarID)
         WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_TABSTOP
         | LVS_OWNERDRAWFIXED
         | LVS_OWNERDATA
+        | LVS_EDITLABELS
         | LVS_NOCOLUMNHEADER
         | LVS_REPORT | LVS_SINGLESEL | LVS_AUTOARRANGE | LVS_NOSORTHEADER, // TODO: remove LVS_SINGLESEL and implement multiple item repositioning (dragging is ready)
         CRect(0, 0, 100, 100), &m_listFrame, IDC_PLAYLIST);
@@ -1882,11 +1883,6 @@ void CPlayerPlaylistBar::EventCallback(MpcEvent ev)
 void CPlayerPlaylistBar::ResizeListColumn()
 {
     if (::IsWindow(m_list.m_hWnd)) {
-        // Commit any active inline edit before resizing
-        if (m_list.GetVirtualEditCtrl()) {
-            m_list.SetFocus();
-        }
-
         CRect r;
         GetClientRect(r);
         r.DeflateRect(2, 2);
@@ -2769,10 +2765,22 @@ void CPlayerPlaylistBar::OnLvnGetDispInfoList(NMHDR* pNMHDR, LRESULT* pResult)
 void CPlayerPlaylistBar::OnLvnBeginlabeleditList(NMHDR* pNMHDR, LRESULT* pResult)
 {
     NMLVDISPINFO* pDispInfo = reinterpret_cast<NMLVDISPINFO*>(pNMHDR);
-    POSITION pos = FindPos(pDispInfo->item.iItem);
-    int maxW = pos ? m_pl.GetAt(pos).inlineEditMaxWidth : -1;
-    m_list.AdjustVirtualEditPos(inlineEditXpos, maxW);
-    *pResult = 1; // allow editing
+    if (pDispInfo->item.iSubItem != COL_NAME) {
+        *pResult = 1; // cancel
+        return;
+    }
+    HWND hEdit = (HWND)m_list.SendMessage(LVM_GETEDITCONTROL);
+    if (::IsWindow(m_edit.m_hWnd)) {
+        m_edit.UnsubclassWindow();
+    }
+    if (hEdit) {
+        m_edit.SubclassWindow(hEdit);
+        m_list.m_fInPlaceDirty = false;
+        POSITION pos = FindPos(pDispInfo->item.iItem);
+        int maxW = pos ? m_pl.GetAt(pos).inlineEditMaxWidth : -1;
+        m_edit.setOverridePos(inlineEditXpos, maxW);
+    }
+    *pResult = 0; // allow
 }
 
 void CPlayerPlaylistBar::OnLvnEndlabeleditList(NMHDR* pNMHDR, LRESULT* pResult)

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -169,7 +169,6 @@ public:
     void SetFirstSelected();
     void SetFirst();
     void SetLast();
-    void EnsureCurrentVisible();
     void SetCurValid(bool fValid);
     void SetCurLabel(CString label);
     void SetCurTime(REFERENCE_TIME rt);

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -31,6 +31,7 @@
 #include "../Subtitles/TextFile.h"
 #include "YoutubeDL.h"
 #include "AppSettings.h"
+#include "CMPCThemeInlineEdit.h"
 
 
 class OpenMediaData;
@@ -64,6 +65,7 @@ private:
 
     CMainFrame* m_pMainFrame;
     int inlineEditXpos;
+    CMPCThemeInlineEdit m_edit;
 
     CFont m_font;
     void ScaleFont();


### PR DESCRIPTION
I believe this fixes all issues with inline edits as well as some others with the virtual list.

Main points are:
1. Reverted almost all of the code changing how inline edits work.
2. Playlist and subresync both should work how they did prior to the virtual list being introduced. 
3. Original PR incorrectly stated "Rewrite inline label editing with manual CEdit (TriggerInlineEdit) since virtual lists don't support LVM_EDITLABEL" -- I checked the documentation, and this is not stated anywhere. I also confirmed through testing that virtual lists do support it. Because LVS_OWNERDATA disables certain features, I did not check this claim carefully, but all of the subsequent changes to handle the virtual edits were unnecessarily done based on this bad assumption. 
4. Fix all issues from https://github.com/clsid2/mpc-hc/issues/3885