### PR TITLE
support vs 2026

### DIFF
--- a/src/platform.props
+++ b/src/platform.props
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Configuration">
     <WindowsTargetPlatformVersion Condition="'$(MPCHC_WINSDK_VER)' == ''">8.1</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(MPCHC_WINSDK_VER)' != ''">$(MPCHC_WINSDK_VER)</WindowsTargetPlatformVersion>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '18.0'">v145</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>


### PR DESCRIPTION
Also needs:

```
diff --git a/IntelQuickSyncDecoder.vcxproj b/IntelQuickSyncDecoder.vcxproj
index 8396e9d..00d139c 100644
--- a/IntelQuickSyncDecoder.vcxproj
+++ b/IntelQuickSyncDecoder.vcxproj
@@ -44,6 +44,11 @@
     <SpectreMitigation>false</SpectreMitigation>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '18.0'">^M
+    <PlatformToolset>v145</PlatformToolset>^M
+    <SpectreMitigation>false</SpectreMitigation>^M
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>^M
+  </PropertyGroup>^M
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>

```