### PR TITLE
Build VS2026 (18.0) with the v143 toolset instead of v145

### DIFF
--- a/src/platform.props
+++ b/src/platform.props
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Configuration">
     <WindowsTargetPlatformVersion Condition="'$(MPCHC_WINSDK_VER)' == ''">8.1</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(MPCHC_WINSDK_VER)' != ''">$(MPCHC_WINSDK_VER)</WindowsTargetPlatformVersion>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '18.0'">v145</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '18.0'">v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>


### PR DESCRIPTION
VS2026 (VisualStudioVersion 18.0) currently maps to the v145 platform toolset. This switches it to v143 so the build uses the same toolset as VS2022 and matches the prebuilt third-party dependencies, avoiding a mixed-toolset build and the need for the v145 toolset to be installed.
