### PR TITLE
minimize theme overrides for light theme

### DIFF
--- a/src/mpc-hc/CMPCThemeButton.cpp
+++ b/src/mpc-hc/CMPCThemeButton.cpp
@@ -24,7 +24,7 @@ END_MESSAGE_MAP()
 LRESULT CMPCThemeButton::setShieldIcon(WPARAM wParam, LPARAM lParam)
 {
     drawShield = (BOOL)lParam;
-    return 1; //pass it along
+    return Default(); //pass it along so the native button draws the shield when we don't paint it ourselves
 }
 
 void CMPCThemeButton::drawButtonBase(CDC* pDC, CRect rect, CString strText, bool selected, bool highLighted, bool focused, bool disabled, bool thin, bool shield, HWND accelWindow)

--- a/src/mpc-hc/CMPCThemeButton.cpp
+++ b/src/mpc-hc/CMPCThemeButton.cpp
@@ -149,7 +149,7 @@ void CMPCThemeButton::OnNMCustomdraw(NMHDR* pNMHDR, LRESULT* pResult)
 {
     LPNMCUSTOMDRAW pNMCD = reinterpret_cast<LPNMCUSTOMDRAW>(pNMHDR);
     *pResult = CDRF_DODEFAULT;
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         if (pNMCD->dwDrawStage == CDDS_PREERASE) {
             drawButton(pNMCD->hdc, pNMCD->rc, pNMCD->uItemState);
             *pResult = CDRF_SKIPDEFAULT;

--- a/src/mpc-hc/CMPCThemeDialog.cpp
+++ b/src/mpc-hc/CMPCThemeDialog.cpp
@@ -35,7 +35,7 @@ BOOL CMPCThemeDialog::OnInitDialog()
 
 HBRUSH CMPCThemeDialog::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return getCtlColor(pDC, pWnd, nCtlColor);
     } else {
         HBRUSH hbr = CDialog::OnCtlColor(pDC, pWnd, nCtlColor);

--- a/src/mpc-hc/CMPCThemeEdit.cpp
+++ b/src/mpc-hc/CMPCThemeEdit.cpp
@@ -311,7 +311,7 @@ LRESULT CMPCThemeEdit::ResizeSupport(WPARAM wParam, LPARAM lParam) {
 
 void CMPCThemeEdit::PreSubclassWindow()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CRect r;
         GetClientRect(r);
         r.DeflateRect(2, 2); //some default padding for those spaceless fonts

--- a/src/mpc-hc/CMPCThemeMaskedEdit.cpp
+++ b/src/mpc-hc/CMPCThemeMaskedEdit.cpp
@@ -20,7 +20,7 @@ END_MESSAGE_MAP()
 
 void CMPCThemeMaskedEdit::PreSubclassWindow()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         ModifyStyleEx(WS_EX_CLIENTEDGE, WS_EX_STATICEDGE, SWP_FRAMECHANGED);
         CRect r;
         GetClientRect(r);
@@ -33,7 +33,7 @@ void CMPCThemeMaskedEdit::PreSubclassWindow()
 
 void CMPCThemeMaskedEdit::OnNcPaint()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CWindowDC dc(this);
 
         CRect rect;

--- a/src/mpc-hc/CMPCThemeModelessResizableDialog.cpp
+++ b/src/mpc-hc/CMPCThemeModelessResizableDialog.cpp
@@ -30,7 +30,7 @@ END_MESSAGE_MAP()
 
 HBRUSH CMPCThemeModelessResizableDialog::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return getCtlColor(pDC, pWnd, nCtlColor);
     } else {
         HBRUSH hbr = __super::OnCtlColor(pDC, pWnd, nCtlColor);

--- a/src/mpc-hc/CMPCThemeMsgBox.cpp
+++ b/src/mpc-hc/CMPCThemeMsgBox.cpp
@@ -36,7 +36,7 @@ END_MESSAGE_MAP()
 
 HBRUSH CMPCThemeMsgBox::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return getCtlColor(pDC, pWnd, nCtlColor);
     } else {
         HBRUSH hbr = CDialog::OnCtlColor(pDC, pWnd, nCtlColor);
@@ -47,7 +47,7 @@ HBRUSH CMPCThemeMsgBox::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 
 BOOL CMPCThemeMsgBox::OnEraseBkgnd(CDC* pDC)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CRect rect, messageArea, buttonArea;
         GetClientRect(&rect);
         messageArea = rect;

--- a/src/mpc-hc/CMPCThemePPageBase.cpp
+++ b/src/mpc-hc/CMPCThemePPageBase.cpp
@@ -25,7 +25,7 @@ BOOL CMPCThemePPageBase::OnInitDialog()
 
 void CMPCThemePPageBase::SetMPCThemeButtonIcon(UINT nIDButton, IconDef iconDef, ImageGrayer::mpcColorStyle colorStyle)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         if (!m_buttonIcons.count(iconDef)) {
             CImage img, imgEnabled, imgDisabled;
             if (iconDef.svgTargetWidth) {

--- a/src/mpc-hc/CMPCThemeProgressCtrl.cpp
+++ b/src/mpc-hc/CMPCThemeProgressCtrl.cpp
@@ -21,7 +21,7 @@ END_MESSAGE_MAP()
 LRESULT CMPCThemeProgressCtrl::OnSetPos(WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefWindowProc(PBM_SETPOS, wParam, lParam);
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         Invalidate(FALSE);
     }
     return result;
@@ -30,7 +30,7 @@ LRESULT CMPCThemeProgressCtrl::OnSetPos(WPARAM wParam, LPARAM lParam)
 LRESULT CMPCThemeProgressCtrl::OnStepIt(WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefWindowProc(PBM_STEPIT, wParam, lParam);
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         Invalidate(FALSE);
     }
     return result;
@@ -39,7 +39,7 @@ LRESULT CMPCThemeProgressCtrl::OnStepIt(WPARAM wParam, LPARAM lParam)
 LRESULT CMPCThemeProgressCtrl::OnDpiChanged(WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefWindowProc(WM_DPICHANGED, wParam, lParam);
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
     }
     return result;
@@ -47,7 +47,7 @@ LRESULT CMPCThemeProgressCtrl::OnDpiChanged(WPARAM wParam, LPARAM lParam)
 
 void CMPCThemeProgressCtrl::OnPaint()
 {
-    if (!AppIsThemeLoaded()) {
+    if (!AppNeedsThemedControls()) {
         return __super::OnPaint();
     }
 

--- a/src/mpc-hc/CMPCThemePropPageFrame.cpp
+++ b/src/mpc-hc/CMPCThemePropPageFrame.cpp
@@ -2,6 +2,7 @@
 #include "CMPCThemePropPageFrame.h"
 #include "CMPCTheme.h"
 #include "CMPCThemeUtil.h"
+#include "mplayerc.h"
 #include "TreePropSheet/PropPageFrameDefault.h"
 #include "../DSUtil/WinAPIUtils.h"
 
@@ -86,13 +87,17 @@ void CMPCThemePropPageFrame::OnPaint()
 
 BOOL CMPCThemePropPageFrame::OnEraseBkgnd(CDC* pDC)
 {
-    bool ret = CMPCThemeUtil::MPCThemeEraseBkgnd(pDC, this, CTLCOLOR_DLG);
-    if (ret) {
+    BOOL ret;
+    if (CMPCThemeUtil::MPCThemeEraseBkgnd(pDC, this, CTLCOLOR_DLG)) {
+        ret = TRUE;
+    } else {
+        ret = __super::OnEraseBkgnd(pDC); //light erases to match its native pages
+    }
+
+    if (AppIsThemeLoaded()) { //the caption is themed in light too, so keep the matching frame border
         CRect rect;
         GetClientRect(rect);
         pDC->FrameRect(rect, &mpcThemeBorderBrush);
-        return ret;
-    } else {
-        return __super::OnEraseBkgnd(pDC);
     }
+    return ret;
 }

--- a/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
+++ b/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
@@ -52,7 +52,7 @@ END_MESSAGE_MAP()
 
 void CMPCThemeRadioOrCheck::OnPaint()
 {
-    if (AppIsThemeLoaded() && CMPCTheme::drawThemedControls) {
+    if (AppNeedsThemedControls()) {
         DWORD buttonStyle = GetWindowLongPtr(GetSafeHwnd(), GWL_STYLE);
 
         CPaintDC dc(this);
@@ -241,7 +241,7 @@ void CMPCThemeRadioOrCheck::OnLButtonDown(UINT nFlags, CPoint point)
 
 void CMPCThemeRadioOrCheck::OnEnable(BOOL bEnable)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         SetRedraw(FALSE);
         __super::OnEnable(bEnable);
         SetRedraw(TRUE);
@@ -254,6 +254,10 @@ void CMPCThemeRadioOrCheck::OnEnable(BOOL bEnable)
 
 BOOL CMPCThemeRadioOrCheck::OnEraseBkgnd(CDC* pDC)
 {
+    if (!AppNeedsThemedControls() && !isFileDialogChild) { //must match the OnPaint condition; this class is also used as a dialog member in classic mode
+        return __super::OnEraseBkgnd(pDC);
+    }
+
     CRect r;
     GetClientRect(r);
     if (isFileDialogChild) {

--- a/src/mpc-hc/CMPCThemeResizableDialog.cpp
+++ b/src/mpc-hc/CMPCThemeResizableDialog.cpp
@@ -44,7 +44,7 @@ END_MESSAGE_MAP()
 
 HBRUSH CMPCThemeResizableDialog::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return getCtlColor(pDC, pWnd, nCtlColor);
     } else {
         HBRUSH hbr = __super::OnCtlColor(pDC, pWnd, nCtlColor);

--- a/src/mpc-hc/CMPCThemeSliderCtrl.cpp
+++ b/src/mpc-hc/CMPCThemeSliderCtrl.cpp
@@ -17,7 +17,7 @@ CMPCThemeSliderCtrl::~CMPCThemeSliderCtrl()
 
 void CMPCThemeSliderCtrl::PreSubclassWindow()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CToolTipCtrl* pTip = GetToolTips();
         if (nullptr != pTip) {
             themedToolTip.SubclassWindow(pTip->m_hWnd);
@@ -41,7 +41,7 @@ void CMPCThemeSliderCtrl::OnNMCustomdraw(NMHDR* pNMHDR, LRESULT* pResult)
     LPNMCUSTOMDRAW pNMCD = reinterpret_cast<LPNMCUSTOMDRAW>(pNMHDR);
     LRESULT lr = CDRF_DODEFAULT;
 
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         switch (pNMCD->dwDrawStage) {
             case CDDS_PREPAINT:
                 lr = CDRF_NOTIFYITEMDRAW;

--- a/src/mpc-hc/CMPCThemeSpinButtonCtrl.cpp
+++ b/src/mpc-hc/CMPCThemeSpinButtonCtrl.cpp
@@ -107,7 +107,7 @@ void CMPCThemeSpinButtonCtrl::drawSpinArrow(CDC& dc, COLORREF arrowClr, CRect ar
 
 void CMPCThemeSpinButtonCtrl::OnPaint()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CWnd* buddy = GetBuddy();
         bool hasBuddy = false;
         CMPCThemeEdit* buddyEdit;
@@ -228,7 +228,7 @@ void CMPCThemeSpinButtonCtrl::OnLButtonUp(UINT nFlags, CPoint point)
 
 BOOL CMPCThemeSpinButtonCtrl::OnEraseBkgnd(CDC* pDC)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return TRUE;
     } else {
         return __super::OnEraseBkgnd(pDC);

--- a/src/mpc-hc/CMPCThemeStaticLink.cpp
+++ b/src/mpc-hc/CMPCThemeStaticLink.cpp
@@ -26,7 +26,7 @@ END_MESSAGE_MAP()
 
 void CMPCThemeStaticLink::OnPaint()
 {
-    if (AppIsThemeLoaded()) {  //only reason for custom paint is disabled statics do not honor ctlcolor and draw greyed text which looks terrible on other bgs
+    if (AppNeedsThemedControls()) {  //only reason for custom paint is disabled statics do not honor ctlcolor and draw greyed text which looks terrible on other bgs
         CPaintDC dc(this); // device context for painting
         COLORREF oldBkClr = dc.GetBkColor();
         COLORREF oldTextClr = dc.GetTextColor();
@@ -77,7 +77,7 @@ void CMPCThemeStaticLink::OnPaint()
 
 HBRUSH CMPCThemeStaticLink::CtlColor(CDC* pDC, UINT nCtlColor)   //avoid overridden cstaticlink ctlcolor
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return NULL;
     } else {
         return __super::CtlColor(pDC, nCtlColor);
@@ -87,7 +87,7 @@ HBRUSH CMPCThemeStaticLink::CtlColor(CDC* pDC, UINT nCtlColor)   //avoid overrid
 
 void CMPCThemeStaticLink::OnEnable(BOOL bEnable)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         SetRedraw(FALSE);
         __super::OnEnable(bEnable);
         SetRedraw(TRUE);

--- a/src/mpc-hc/CMPCThemeStatusBar.cpp
+++ b/src/mpc-hc/CMPCThemeStatusBar.cpp
@@ -47,7 +47,6 @@ void CMPCThemeStatusBar::SetText(LPCTSTR lpszText, int nPane, int nType)
 BOOL CMPCThemeStatusBar::SetParts(int nParts, int* pWidths)
 {
     CStatusBarCtrl& ctrl = GetStatusBarCtrl();
-    numParts = nParts;
     BOOL result = ctrl.SetParts(nParts, pWidths);
     UpdateProgressBarLayout();
     Invalidate();
@@ -102,6 +101,7 @@ void CMPCThemeStatusBar::OnNcPaint()
 
         int nHorz, nVert, nSpacing;
         GetStatusBarCtrl().GetBorders(nHorz, nVert, nSpacing);
+        int numParts = ctrl.GetParts(0, nullptr);
         for (int item = 0; item < numParts; item++) { //don't touch the status bar elements; they are painted in DrawItem
             CRect rc;
             if (GetRect(item, rc)) {
@@ -160,7 +160,8 @@ void CMPCThemeStatusBar::OnPaint()
     dc.SetBkColor(CMPCTheme::StatusBarBGColor);
     dc.SetTextColor(CMPCTheme::TextFGColor);
 
-    // Paint each part
+    // Paint each part (queried live; the pane count is owned by the control, not cached here)
+    int numParts = GetStatusBarCtrl().GetParts(0, nullptr);
     for (int item = 0; item < numParts; item++) {
         CRect rc;
         if (GetRect(item, rc)) {

--- a/src/mpc-hc/CMPCThemeStatusBar.cpp
+++ b/src/mpc-hc/CMPCThemeStatusBar.cpp
@@ -18,7 +18,7 @@ CMPCThemeStatusBar::~CMPCThemeStatusBar()
 
 void CMPCThemeStatusBar::PreSubclassWindow()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         ModifyStyleEx(WS_BORDER, WS_EX_STATICEDGE, 0);
     } else {
         __super::PreSubclassWindow();
@@ -35,7 +35,7 @@ END_MESSAGE_MAP()
 
 void CMPCThemeStatusBar::SetText(LPCTSTR lpszText, int nPane, int nType)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         texts[nPane] = lpszText;
         Invalidate();
     } else {
@@ -88,7 +88,7 @@ BOOL CMPCThemeStatusBar::GetRect(int nPane, LPRECT lpRect)
 
 void CMPCThemeStatusBar::OnNcPaint()
 {
-    if (!AppIsThemeLoaded()) {
+    if (!AppNeedsThemedControls()) {
         return __super::OnNcPaint();
     } else {
         CWindowDC dc(this);
@@ -128,7 +128,7 @@ void CMPCThemeStatusBar::OnNcPaint()
 
 BOOL CMPCThemeStatusBar::OnEraseBkgnd(CDC* pDC)
 {
-    if (!AppIsThemeLoaded()) {
+    if (!AppNeedsThemedControls()) {
         return __super::OnEraseBkgnd(pDC);
     } else {
         // Paint the entire client area background
@@ -141,7 +141,7 @@ BOOL CMPCThemeStatusBar::OnEraseBkgnd(CDC* pDC)
 
 void CMPCThemeStatusBar::OnPaint()
 {
-    if (!AppIsThemeLoaded()) {
+    if (!AppNeedsThemedControls()) {
         return __super::OnPaint();
     }
 

--- a/src/mpc-hc/CMPCThemeStatusBar.h
+++ b/src/mpc-hc/CMPCThemeStatusBar.h
@@ -15,7 +15,6 @@ public:
     DECLARE_MESSAGE_MAP()
 protected:
     std::map<int, CString> texts;
-    int numParts;
     CWnd* m_pProgressBar;
     int m_nProgressPane;
     void UpdateProgressBarLayout();

--- a/src/mpc-hc/CMPCThemeTabCtrl.cpp
+++ b/src/mpc-hc/CMPCThemeTabCtrl.cpp
@@ -27,7 +27,7 @@ END_MESSAGE_MAP()
 
 HBRUSH CMPCThemeTabCtrl::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return getCtlColor(pDC, pWnd, nCtlColor);
     } else {
         HBRUSH hbr = __super::OnCtlColor(pDC, pWnd, nCtlColor);

--- a/src/mpc-hc/CMPCThemeTabCtrl.cpp
+++ b/src/mpc-hc/CMPCThemeTabCtrl.cpp
@@ -114,7 +114,7 @@ void CMPCThemeTabCtrl::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 
 BOOL CMPCThemeTabCtrl::OnEraseBkgnd(CDC* pDC)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CRect r;
         GetClientRect(r);
         CMPCThemeUtil::drawParentDialogBGClr(this, pDC, r);
@@ -124,7 +124,7 @@ BOOL CMPCThemeTabCtrl::OnEraseBkgnd(CDC* pDC)
 
 void CMPCThemeTabCtrl::OnPaint()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CPaintDC dc(this); // device context for painting
         int oldDC = dc.SaveDC();
         CRect rClient, rContent, rectDC;

--- a/src/mpc-hc/CMPCThemeToolTipCtrl.cpp
+++ b/src/mpc-hc/CMPCThemeToolTipCtrl.cpp
@@ -71,7 +71,7 @@ void CMPCThemeToolTipCtrl::paintTT(CDC& dc, CMPCThemeToolTipCtrl* tt)
 
 void CMPCThemeToolTipCtrl::OnPaint()
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CPaintDC dc(this);
         paintTT(dc, this);
     } else {
@@ -82,7 +82,7 @@ void CMPCThemeToolTipCtrl::OnPaint()
 
 BOOL CMPCThemeToolTipCtrl::OnEraseBkgnd(CDC* pDC)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         return TRUE;
     } else {
         return __super::OnEraseBkgnd(pDC);
@@ -115,7 +115,7 @@ void CMPCThemeToolTipCtrl::RedrawIfVisible() {
 void CMPCThemeToolTipCtrl::OnWindowPosChanging(WINDOWPOS* lpwndpos)
 {
     CToolTipCtrl::OnWindowPosChanging(lpwndpos);
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         //hack to make it fit if fonts differ from parent. can be manually avoided
         //if the parent widget is set to same font (see CMPCThemePlayerListCtrl using MessageFont now)
         CString text;

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -89,7 +89,9 @@ void CMPCThemeUtil::fulfillThemeReqs(CWnd* wnd, SpecialThemeCases specialCase /*
                 } else if (0 == _tcsicmp(windowClass, WC_BUTTON) && buttonType == BS_GROUPBOX) {
                     CMPCThemeGroupBox* pObject = DEBUG_NEW CMPCThemeGroupBox();
                     makeThemed(pObject, tChild);
-                    SetWindowTheme(tChild->GetSafeHwnd(), L"", L"");
+                    if (AppNeedsThemedControls()) { //only strip the visual style when we take over the painting
+                        SetWindowTheme(tChild->GetSafeHwnd(), L"", L"");
+                    }
                 } else if (0 == _tcsicmp(windowClass, WC_STATIC) && SS_ICON == staticStyle) { //don't touch icons for now
                 } else if (0 == _tcsicmp(windowClass, WC_STATIC) && SS_BITMAP == staticStyle) { //don't touch BITMAPS for now
                 } else if (0 == _tcsicmp(windowClass, WC_STATIC) && SS_OWNERDRAW == staticStyle) { //don't touch OWNERDRAW for now

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -185,7 +185,7 @@ void CMPCThemeUtil::makeThemed(CWnd* pObject, CWnd* tChild)
 
 void CMPCThemeUtil::EnableThemedDialogTooltips(CDialog* wnd)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         if (themedDialogToolTip.m_hWnd) {
             themedDialogToolTip.DestroyWindow();
         }
@@ -205,7 +205,7 @@ void CMPCThemeUtil::EnableThemedDialogTooltips(CDialog* wnd)
 }
 
 void CMPCThemeUtil::RedrawDialogTooltipIfVisible() {
-    if (AppIsThemeLoaded() && themedDialogToolTip.m_hWnd) {
+    if (AppNeedsThemedControls() && themedDialogToolTip.m_hWnd) {
         themedDialogToolTip.RedrawIfVisible();
     } else {
         AFX_MODULE_THREAD_STATE* pModuleThreadState = AfxGetModuleThreadState();
@@ -218,7 +218,7 @@ void CMPCThemeUtil::RedrawDialogTooltipIfVisible() {
 
 void CMPCThemeUtil::PlaceThemedDialogTooltip(UINT_PTR nID)
 {
-    if (AppIsThemeLoaded() && IsWindow(themedDialogToolTip)) {
+    if (AppNeedsThemedControls() && IsWindow(themedDialogToolTip)) {
         if (::IsWindow(themedDialogToolTipParent->GetSafeHwnd())) {
             CWnd* controlWnd = themedDialogToolTipParent->GetDlgItem(nID);
             themedDialogToolTip.SetHoverPosition(controlWnd);
@@ -228,7 +228,7 @@ void CMPCThemeUtil::PlaceThemedDialogTooltip(UINT_PTR nID)
 
 void CMPCThemeUtil::RelayThemedDialogTooltip(MSG* pMsg)
 {
-    if (AppIsThemeLoaded() && IsWindow(themedDialogToolTip)) {
+    if (AppNeedsThemedControls() && IsWindow(themedDialogToolTip)) {
         themedDialogToolTip.RelayEvent(pMsg);
     }
 }

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -446,7 +446,7 @@ HBRUSH CMPCThemeUtil::getCtlColorFileDialog(HDC hDC, UINT nCtlColor)
 
 HBRUSH CMPCThemeUtil::getCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         initHelperObjects();
         LRESULT lResult;
         if (pWnd->SendChildNotifyLastMsg(&lResult)) {
@@ -467,7 +467,7 @@ HBRUSH CMPCThemeUtil::getCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 
 bool CMPCThemeUtil::MPCThemeEraseBkgnd(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CRect rect;
         pWnd->GetClientRect(rect);
         if (CTLCOLOR_DLG == nCtlColor) { //only supported "class" for now

--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1144,7 +1144,7 @@ void CMPCThemeUtil::drawParentDialogBGClr(CWnd* wnd, CDC* pDC, CRect r, bool fil
 
 void CMPCThemeUtil::fulfillThemeReqs(CProgressCtrl* ctl)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         SetWindowTheme(ctl->GetSafeHwnd(), _T(""), _T(""));
         ctl->SetBarColor(CMPCTheme::ProgressBarColor);
         ctl->SetBkColor(CMPCTheme::ProgressBarBGColor);

--- a/src/mpc-hc/PPageAccelTbl.cpp
+++ b/src/mpc-hc/PPageAccelTbl.cpp
@@ -1094,14 +1094,14 @@ void CPPageAccelTbl::GetCustomTextColors(INT_PTR nItem, int iSubItem, COLORREF& 
         || iSubItem == COL_KEY && (dup & DUP_KEY)
         || iSubItem == COL_APPCMD && (dup & DUP_APPCMD)
         || iSubItem == COL_RMCMD && (dup & DUP_RMCMD)) {
-        if (AppIsThemeLoaded()) {
+        if (AppNeedsThemedControls()) {
             clrTextBk = CMPCTheme::ListCtrlErrorColor;
             overrideSelectedBG = true;
         } else {
             clrTextBk = RGB(255, 130, 120);
         }
     } else {
-        if (AppIsThemeLoaded()) {
+        if (AppNeedsThemedControls()) {
             clrTextBk = CMPCTheme::ContentBGColor;
         } else {
             clrTextBk = GetSysColor(COLOR_WINDOW);
@@ -1115,7 +1115,7 @@ void CPPageAccelTbl::GetCustomGridColors(int nItem, COLORREF& horzGridColor, COL
 }
 
 void CPPageAccelTbl::OnCustomdrawList(NMHDR* pNMHDR, LRESULT* pResult) {
-    //this custom draw is used only in classic mode
+    //this custom draw is used in classic and light modes; dark draws via CMPCThemePlayerListCtrl
     *pResult = CDRF_DODEFAULT;
     if (!AppNeedsThemedControls()) {
         NMLVCUSTOMDRAW* pLVCD = reinterpret_cast<NMLVCUSTOMDRAW*>(pNMHDR);

--- a/src/mpc-hc/PPageAccelTbl.cpp
+++ b/src/mpc-hc/PPageAccelTbl.cpp
@@ -1383,20 +1383,14 @@ HBRUSH CPPageAccelTbl::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
     HBRUSH hbr = __super::OnCtlColor(pDC, pWnd, nCtlColor);
 
-    const CAppSettings& s = AfxGetAppSettings();
-    if (AppIsThemeLoaded()) {
-        return hbr; //should have already been handled inside themed ctlcolor
-    }
-    int status = -1;
-
     if (*pWnd == m_WinLircEdit) {
-        status = s.WinLircClient.GetStatus();
-    }
-
-    if (status == 0 || status == 2 && (m_counter & 1)) {
-        pDC->SetTextColor(0x0000ff);
-    } else if (status == 1) {
-        pDC->SetTextColor(0x008000);
+        //must be applied after the base handler, which sets the default text color for every control on the page
+        int status = AfxGetAppSettings().WinLircClient.GetStatus();
+        if (status == 0 || (status == 2 && (m_counter & 1))) {
+            pDC->SetTextColor(RGB(255, 0, 0));
+        } else if (status == 1) {
+            pDC->SetTextColor(RGB(0, 128, 0));
+        }
     }
 
     return hbr;

--- a/src/mpc-hc/PPageShaders.cpp
+++ b/src/mpc-hc/PPageShaders.cpp
@@ -177,7 +177,7 @@ CString CShaderListBox::GetTitle(const Shader& shader)
 void CShaderListBox::PreSubclassWindow()
 {
     CMPCThemeListBox::PreSubclassWindow();
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) { //only suppress the standard tooltips where CMPCThemeToolTipCtrl replaces them
         EnableToolTips(FALSE);
     } else {
         EnableToolTips(TRUE);

--- a/src/mpc-hc/PPageSheet.cpp
+++ b/src/mpc-hc/PPageSheet.cpp
@@ -92,7 +92,7 @@ CPPageSheet::CPPageSheet(LPCTSTR pszCaption, IFilterGraph* pFG, CWnd* pParentWnd
         }
     }
 
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CMPCThemeUtil::ModifyTemplates(this, RUNTIME_CLASS(CPPageShaders), IDC_LIST1, LBS_OWNERDRAWFIXED | LBS_HASSTRINGS);
         CMPCThemeUtil::ModifyTemplates(this, RUNTIME_CLASS(CPPageShaders), IDC_LIST2, LBS_OWNERDRAWFIXED | LBS_HASSTRINGS);
         CMPCThemeUtil::ModifyTemplates(this, RUNTIME_CLASS(CPPageShaders), IDC_LIST3, LBS_OWNERDRAWFIXED | LBS_HASSTRINGS);

--- a/src/mpc-hc/PPageSheet.cpp
+++ b/src/mpc-hc/PPageSheet.cpp
@@ -148,7 +148,7 @@ CMPCThemeTreeCtrl* CPPageSheet::CreatePageTreeObject()
 
 void CPPageSheet::SetTreeCtrlTheme(CTreeCtrl* ctrl)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         ((CMPCThemeTreeCtrl*)ctrl)->fulfillThemeReqs();
     } else {
         __super::SetTreeCtrlTheme(ctrl);

--- a/src/mpc-hc/PPageSheet.cpp
+++ b/src/mpc-hc/PPageSheet.cpp
@@ -244,7 +244,7 @@ TreePropSheet::CPropPageFrame* CPPageSheet::CreatePageFrame()
 
 HBRUSH CPPageSheet::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         LRESULT lResult;
         if (pWnd->SendChildNotifyLastMsg(&lResult)) {
             return (HBRUSH)lResult;

--- a/src/mpc-hc/WinHotkeyCtrl.cpp
+++ b/src/mpc-hc/WinHotkeyCtrl.cpp
@@ -144,7 +144,7 @@ void CWinHotkeyCtrl::SetWinHotkey(UINT vkCode, UINT fModifiers)
 
 void CWinHotkeyCtrl::DrawButton(CRect rectButton)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CWindowDC dc(this);
         bool disabled = 0 != (GetStyle() & (ES_READONLY | WS_DISABLED));
         bool selected = GetButtonThemeState() == PBS_PRESSED;

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -689,7 +689,7 @@ CMPlayerCApp::~CMPlayerCApp()
 int CMPlayerCApp::DoMessageBox(LPCTSTR lpszPrompt, UINT nType,
                                UINT nIDPrompt)
 {
-    if (AppIsThemeLoaded()) {
+    if (AppNeedsThemedControls()) {
         CWnd* pParentWnd = CWnd::GetActiveWindow();
         if (pParentWnd == NULL) {
             pParentWnd = GetMainWnd();


### PR DESCRIPTION
Found 24 issues with light theme due to following the theming path when it could just use classic.