### PR TITLE
Settings: HKLM machine defaults, separate MediaHistory file, DVB downgrade protection (#2347)

### DIFF
--- a/docs/settings-history-store.md
+++ b/docs/settings-history-store.md
@@ -122,8 +122,8 @@ safe since both are the same format) and erases them from the settings store. Th
   new mode, then `SaveSettings(true)` rewrites the full in-memory history into the
   new location in the correct format (no cross-mode value copy, so no corruption).
 - **Newer history format:** `SetupHistoryStore()` forks to
-  `<exe>.history.local.ini` if `history.ini` declares a `Format` newer than this
-  build understands (same protection as the settings store).
+  `<exe>.history.<thisFormat>.local.ini` if `history.ini` declares a `Format`
+  newer than this build understands (same protection as the settings store).
 
 ## Export
 
@@ -145,7 +145,7 @@ safe since both are the same format) and erases them from the settings store. Th
 
 ## Key identifiers (quick reference)
 
-- `CProfile::HistoryIniPath()` → `<exe-basename>.history.ini`; `HistoryLocalIniPath()` → `.history.local.ini`
+- `CProfile::HistoryIniPath()` → `<exe-basename>.history.ini`; `HistoryLocalIniPath()` → `.history.<ver>.local.ini`
 - `CMPlayerCApp::m_HistoryProfile` — the history store (null in registry mode)
 - `CMPlayerCApp::SetupHistoryStore()` — creates the store, forks, one-time split
 - `ProfileForSection(section)` / `IsMediaHistorySection(section)` — routing

--- a/docs/settings-history-store.md
+++ b/docs/settings-history-store.md
@@ -1,0 +1,154 @@
+# The MediaHistory ("history mode") settings store
+
+How MPC-HC stores **MediaHistory** (recently-played files, resume positions,
+per-file audio/subtitle selections, A-B repeat, etc.) separately from the rest of
+the settings. Part of the issue #2347 settings rework.
+
+Relevant code:
+- `src/mpc-hc/Profile.{h,cpp}` — the `CProfile` store engine.
+- `src/mpc-hc/mplayerc.{h,cpp}` — `CMPlayerCApp` owns the stores and routes to them.
+- `src/mpc-hc/AppSettings.cpp` — the MediaHistory reader/writer
+  (`CRecentFileListWithMoreInfo`), unchanged by this feature.
+
+See also [`settings-versioning.md`](settings-versioning.md) for the shared
+versioning/migration model these stores use.
+
+---
+
+## Why a separate store
+
+MediaHistory grows with every file ever opened (one subsection per entry, up to
+the configured limit) and is rewritten constantly during playback. Keeping it in
+the main settings file made that file large and churn-heavy. Issue #2347 asked to
+move MediaHistory into its own file.
+
+The split applies to **portable (INI) mode only**. In **registry** mode history
+stays inside the settings key (the registry handles a large, frequently-updated
+key fine, and it keeps the design minimal).
+
+## The two stores
+
+`CMPlayerCApp` owns two `CProfile` instances:
+
+| Member | Backing | Lifetime |
+|---|---|---|
+| `m_Profile` | Main settings store: `<exe-basename>.settings.ini` or `HKCU\Software\MPC-HC\Settings`. | Always present. |
+| `m_HistoryProfile` (`unique_ptr`) | MediaHistory store: a second INI-mode `CProfile` at `<exe-basename>.history.ini`. | Created **only in portable/INI mode**; **null in registry mode**. |
+
+The history store is a full `CProfile`, so `history.ini` uses the same on-disk
+format as the settings INI (UTF-8 with BOM-sniffing on read, `[section]` /
+`key=value`, `b64:`-prefixed Base64 for binary).
+
+## Section routing
+
+Every profile accessor on `CMPlayerCApp` funnels through one helper:
+
+```cpp
+CProfile& CMPlayerCApp::ProfileForSection(LPCWSTR lpszSection)
+{
+    if (m_HistoryProfile && IsMediaHistorySection(lpszSection))
+        return *m_HistoryProfile;
+    return m_Profile;
+}
+```
+
+`IsMediaHistorySection()` is true for the section named exactly `"MediaHistory"`
+and for any subsection starting with `"MediaHistory\"`. So:
+
+- **INI mode:** any read/write of a `MediaHistory[...]` section transparently hits
+  `m_HistoryProfile` (`history.ini`).
+- **Registry mode:** `m_HistoryProfile` is null, so those calls fall through to
+  `m_Profile` (the registry `Settings` key), exactly as everything else.
+
+Because the routing lives inside the generic accessors, the MediaHistory code in
+`AppSettings.cpp` needs **no changes** — it already calls `theApp.GetProfile*/
+WriteProfile*` with the `"MediaHistory"` section.
+
+```
+AppSettings.cpp (MediaHistory code)
+        │  theApp.GetProfileString("MediaHistory\\<hash>", ...)
+        ▼
+CMPlayerCApp::GetProfileString ── ProfileForSection("MediaHistory\\<hash>")
+        │                                   │
+        │ (registry mode / non-history)     │ (INI mode + history section)
+        ▼                                   ▼
+     m_Profile                        *m_HistoryProfile
+  (registry Settings / settings.ini)   (<exe>.history.ini)
+```
+
+## Version stamp
+
+Like the settings store, the history file carries its own `[Version]` section,
+versioned **independently** of the settings and of the app:
+
+```
+[Version]
+Format        = v1        ; HISTORY_FORMAT_VERSION - MediaHistory on-disk format
+LastWrittenBy = 2.7.3.44  ; MPC-HC build that last wrote it (informational)
+```
+
+Bump `HISTORY_FORMAT_VERSION` (in `Profile.h`) on an incompatible MediaHistory
+layout change. These are written straight to `m_HistoryProfile` (not through the
+routed `WriteProfile*`), because `[Version]` is not a `MediaHistory` section.
+
+## One-time split (migration)
+
+MediaHistory has always lived in the main settings store, so on the first
+portable run it is moved out once, in `SetupHistoryStore()`:
+
+```cpp
+m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
+// (fork if the history file is a newer format - see settings-versioning.md)
+if (!m_Profile.HasEntry(L"Version", L"HistorySplit")) {
+    m_Profile.MoveSectionTree(L"MediaHistory", *m_HistoryProfile);  // move + subsections
+    m_Profile.WriteString(L"Version", L"HistorySplit", L"1");        // done marker
+    m_Profile.Flush(true);
+}
+```
+
+`CProfile::MoveSectionTree(root, dst)` moves the `MediaHistory` section and every
+`MediaHistory\<hash>` subsection into the history store (verbatim raw-value copy,
+safe since both are the same format) and erases them from the settings store. The
+`[Version] HistorySplit = 1` marker in the settings store makes it run once.
+
+## Lifecycle
+
+- **Flush:** `FlushProfile()` flushes both stores (each writes only if dirty), on
+  the same cadence as before (`OnIdle`, `SaveSettings`).
+- **Reset** (`/reset` or HKLM `SettingsReset`): clears both stores, then re-stamps
+  `[Version] Format` / `LastWrittenBy` / `HistorySplit` in the settings store.
+- **Change settings location** (Options → Player → "Store settings in .ini file"):
+  `ChangeSettingsLocation()` re-points/creates or drops `m_HistoryProfile` for the
+  new mode, then `SaveSettings(true)` rewrites the full in-memory history into the
+  new location in the correct format (no cross-mode value copy, so no corruption).
+- **Newer history format:** `SetupHistoryStore()` forks to
+  `<exe>.history.local.ini` if `history.ini` declares a `Format` newer than this
+  build understands (same protection as the settings store).
+
+## Export
+
+- **INI mode:** a full export (`ExportSettings`) bundles `settings.ini` **and**
+  `history.ini` into a single `.zip` (under their real names), so a restore
+  ("extract into the program folder") can't miss either file.
+- **Registry mode:** exports one `.reg` of the whole `Settings` key, which already
+  contains MediaHistory — no zip needed.
+
+## Registry vs INI — summary
+
+| Aspect | INI (portable) | Registry (installed) |
+|---|---|---|
+| History location | `<exe>.history.ini` (separate file) | `HKCU\Software\MPC-HC\Settings` (same key) |
+| `m_HistoryProfile` | non-null | null |
+| Routing for `MediaHistory[...]` | `*m_HistoryProfile` | `m_Profile` |
+| One-time split | performed | not applicable |
+| Export | companion inside the `.zip` | already in the `.reg` |
+
+## Key identifiers (quick reference)
+
+- `CProfile::HistoryIniPath()` → `<exe-basename>.history.ini`; `HistoryLocalIniPath()` → `.history.local.ini`
+- `CMPlayerCApp::m_HistoryProfile` — the history store (null in registry mode)
+- `CMPlayerCApp::SetupHistoryStore()` — creates the store, forks, one-time split
+- `ProfileForSection(section)` / `IsMediaHistorySection(section)` — routing
+- `CProfile::MoveSectionTree(root, dst)` — the one-time move
+- `[Version] HistorySplit = 1` (settings store) — split-done marker
+- `[Version] Format` (history file) — history format version (`HISTORY_FORMAT_VERSION`)

--- a/docs/settings-history-store.md
+++ b/docs/settings-history-store.md
@@ -10,8 +10,9 @@ Relevant code:
 - `src/mpc-hc/AppSettings.cpp` — the MediaHistory reader/writer
   (`CRecentFileListWithMoreInfo`), unchanged by this feature.
 
-See also [`settings-versioning.md`](settings-versioning.md) for the shared
-versioning/migration model these stores use.
+See also [`settings-versioning.md`](settings-versioning.md) for the overall
+storage model (the store keeps its historical location; only these two things —
+MediaHistory and the downgrade-protected `v2` subsections — move).
 
 ---
 
@@ -32,12 +33,12 @@ key fine, and it keeps the design minimal).
 
 | Member | Backing | Lifetime |
 |---|---|---|
-| `m_Profile` | Main settings store: `<exe-basename>.settings.ini` or `HKCU\Software\MPC-HC\Settings`. | Always present. |
+| `m_Profile` | Main settings store: `<exe-basename>.ini` or `HKCU\Software\MPC-HC\MPC-HC`. | Always present. |
 | `m_HistoryProfile` (`unique_ptr`) | MediaHistory store: a second INI-mode `CProfile` at `<exe-basename>.history.ini`. | Created **only in portable/INI mode**; **null in registry mode**. |
 
 The history store is a full `CProfile`, so `history.ini` uses the same on-disk
 format as the settings INI (UTF-8 with BOM-sniffing on read, `[section]` /
-`key=value`, `b64:`-prefixed Base64 for binary).
+`key=value`, A-P-encoded binary values).
 
 ## Section routing
 
@@ -58,7 +59,7 @@ and for any subsection starting with `"MediaHistory\"`. So:
 - **INI mode:** any read/write of a `MediaHistory[...]` section transparently hits
   `m_HistoryProfile` (`history.ini`).
 - **Registry mode:** `m_HistoryProfile` is null, so those calls fall through to
-  `m_Profile` (the registry `Settings` key), exactly as everything else.
+  `m_Profile` (the registry `MPC-HC` key), exactly as everything else.
 
 Because the routing lives inside the generic accessors, the MediaHistory code in
 `AppSettings.cpp` needs **no changes** — it already calls `theApp.GetProfile*/
@@ -73,23 +74,8 @@ CMPlayerCApp::GetProfileString ── ProfileForSection("MediaHistory\\<hash>")
         │ (registry mode / non-history)     │ (INI mode + history section)
         ▼                                   ▼
      m_Profile                        *m_HistoryProfile
-  (registry Settings / settings.ini)   (<exe>.history.ini)
+  (registry MPC-HC key / <exe>.ini)    (<exe>.history.ini)
 ```
-
-## Version stamp
-
-Like the settings store, the history file carries its own `[Version]` section,
-versioned **independently** of the settings and of the app:
-
-```
-[Version]
-Format        = v1        ; HISTORY_FORMAT_VERSION - MediaHistory on-disk format
-LastWrittenBy = 2.7.3.44  ; MPC-HC build that last wrote it (informational)
-```
-
-Bump `HISTORY_FORMAT_VERSION` (in `Profile.h`) on an incompatible MediaHistory
-layout change. These are written straight to `m_HistoryProfile` (not through the
-routed `WriteProfile*`), because `[Version]` is not a `MediaHistory` section.
 
 ## One-time split (migration)
 
@@ -98,7 +84,6 @@ portable run it is moved out once, in `SetupHistoryStore()`:
 
 ```cpp
 m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
-// (fork if the history file is a newer format - see settings-versioning.md)
 if (!m_Profile.HasEntry(L"Version", L"HistorySplit")) {
     m_Profile.MoveSectionTree(L"MediaHistory", *m_HistoryProfile);  // move + subsections
     m_Profile.WriteString(L"Version", L"HistorySplit", L"1");        // done marker
@@ -111,33 +96,35 @@ if (!m_Profile.HasEntry(L"Version", L"HistorySplit")) {
 safe since both are the same format) and erases them from the settings store. The
 `[Version] HistorySplit = 1` marker in the settings store makes it run once.
 
+An older build that later runs in the same folder simply doesn't know about
+`history.ini`; it regenerates its own `MediaHistory` inside `<exe>.ini` as it
+always did. That's non-critical (history, not configuration) and can't corrupt
+anything — the two histories just diverge.
+
 ## Lifecycle
 
 - **Flush:** `FlushProfile()` flushes both stores (each writes only if dirty), on
   the same cadence as before (`OnIdle`, `SaveSettings`).
 - **Reset** (`/reset` or HKLM `SettingsReset`): clears both stores, then re-stamps
-  `[Version] Format` / `LastWrittenBy` / `HistorySplit` in the settings store.
+  `[Version] HistorySplit = 1` in the settings store.
 - **Change settings location** (Options → Player → "Store settings in .ini file"):
   `ChangeSettingsLocation()` re-points/creates or drops `m_HistoryProfile` for the
   new mode, then `SaveSettings(true)` rewrites the full in-memory history into the
-  new location in the correct format (no cross-mode value copy, so no corruption).
-- **Newer history format:** `SetupHistoryStore()` forks to
-  `<exe>.history.<thisFormat>.local.ini` if `history.ini` declares a `Format`
-  newer than this build understands (same protection as the settings store).
+  new location (no cross-mode value copy, so no corruption).
 
 ## Export
 
-- **INI mode:** a full export (`ExportSettings`) bundles `settings.ini` **and**
+- **INI mode:** a full export (`ExportSettings`) bundles `<exe>.ini` **and**
   `history.ini` into a single `.zip` (under their real names), so a restore
   ("extract into the program folder") can't miss either file.
-- **Registry mode:** exports one `.reg` of the whole `Settings` key, which already
+- **Registry mode:** exports one `.reg` of the whole `MPC-HC` key, which already
   contains MediaHistory — no zip needed.
 
 ## Registry vs INI — summary
 
 | Aspect | INI (portable) | Registry (installed) |
 |---|---|---|
-| History location | `<exe>.history.ini` (separate file) | `HKCU\Software\MPC-HC\Settings` (same key) |
+| History location | `<exe>.history.ini` (separate file) | `HKCU\Software\MPC-HC\MPC-HC` (same key) |
 | `m_HistoryProfile` | non-null | null |
 | Routing for `MediaHistory[...]` | `*m_HistoryProfile` | `m_Profile` |
 | One-time split | performed | not applicable |
@@ -145,10 +132,9 @@ safe since both are the same format) and erases them from the settings store. Th
 
 ## Key identifiers (quick reference)
 
-- `CProfile::HistoryIniPath()` → `<exe-basename>.history.ini`; `HistoryLocalIniPath()` → `.history.<ver>.local.ini`
+- `CProfile::HistoryIniPath()` → `<exe-basename>.history.ini`
 - `CMPlayerCApp::m_HistoryProfile` — the history store (null in registry mode)
-- `CMPlayerCApp::SetupHistoryStore()` — creates the store, forks, one-time split
+- `CMPlayerCApp::SetupHistoryStore()` — creates the store and runs the one-time split
 - `ProfileForSection(section)` / `IsMediaHistorySection(section)` — routing
 - `CProfile::MoveSectionTree(root, dst)` — the one-time move
 - `[Version] HistorySplit = 1` (settings store) — split-done marker
-- `[Version] Format` (history file) — history format version (`HISTORY_FORMAT_VERSION`)

--- a/docs/settings-history-store.md
+++ b/docs/settings-history-store.md
@@ -77,6 +77,23 @@ CMPlayerCApp::GetProfileString ── ProfileForSection("MediaHistory\\<hash>")
   (registry MPC-HC key / <exe>.ini)    (<exe>.history.ini)
 ```
 
+## Location option and fallback (`HistoryInAppData`)
+
+By default the history INI sits next to the executable. Two things relocate it
+to `%APPDATA%\MPC-HC\<exe-basename>.history.ini` instead:
+
+- the **`HistoryInAppData`** advanced option (Options → Advanced) — e.g. a
+  shared/portable install where each user should keep private history;
+- automatically, when the history file **cannot be created** in the player
+  folder (read-only install running off a settings INI).
+
+The option lives in the main settings store, which is read before the history
+store is set up, so `ResolveHistoryIniPath()` (mplayerc.cpp) can honor it during
+startup; it also carries an existing history file over when the location
+changes, so toggling the option doesn't lose history. The **saved playlist**
+(`default.mpcpl`) follows the history file's folder (`GetPlaylistSavePath()`),
+so both relocate together.
+
 ## One-time split (migration)
 
 MediaHistory has always lived in the main settings store, so on the first

--- a/docs/settings-versioning.md
+++ b/docs/settings-versioning.md
@@ -97,8 +97,11 @@ entirely, so they never touch this one). When a build finds `Format` **newer**
 than it understands, it must not clobber it:
 
 - `CProfile::ForkToLocalIni()` detaches from the shared store **without deleting
-  it** and switches this instance to a private `<exe-basename>.settings.local.ini`
-  (history: `.history.local.ini`).
+  it** and switches this instance to a private, **version-qualified** local file
+  `<exe-basename>.settings.<thisFormat>.local.ini` (history:
+  `.history.<thisFormat>.local.ini`). Putting this build's own format version in
+  the fork name keeps two different older builds from colliding on one file and
+  makes each fork self-identifying.
 - If that local file already exists (this build forked before) it is loaded and
   reused silently. If it's new, it is **seeded from the current store** (registry
   values converted to INI form) so the older build starts from the newer data it
@@ -146,7 +149,7 @@ invocations neither pop a modal nor apply machine policy.
 
 - `SETTINGS_FORMAT_VERSION` / `HISTORY_FORMAT_VERSION` / `LEGACY_EQUIVALENT_VERSION` (`Profile.h`) — bump the first to introduce a new format
 - Stores: `HKCU\Software\MPC-HC\Settings` / `<exe>.settings.ini`; legacy `…\MPC-HC` / `<exe>.ini`
-- Fork files: `<exe>.settings.local.ini`, `<exe>.history.local.ini`
+- Fork files (version-qualified): `<exe>.settings.<ver>.local.ini`, `<exe>.history.<ver>.local.ini`
 - Fields: `[Version] Format`, `[Version] LastWrittenBy`, `[Version] HistorySplit`
 - `CMPlayerCApp::SetupSettingsStore()` / `SetupHistoryStore()` / `StampSettingsStoreInitialized()` / `ApplySettingsPolicies()`
 - `CProfile::MigrateFromLegacy()` — one-time pre-versioned import (non-destructive)

--- a/docs/settings-versioning.md
+++ b/docs/settings-versioning.md
@@ -50,10 +50,6 @@ LastWrittenBy = 2.7.3.44 ; MPC-HC build that last wrote the store (informational
 - `CompareVersionStrings` compares these tokens numerically (`v2 < v11`), so any
   monotonic `v1 → v2 → …` sequence orders correctly. Always keep the `v` prefix.
 
-This replaces the earlier scheme that put the version in the store name
-(`Settings-v1` / `<exe>.settings-v1.ini`) plus a separate index file — that was
-removed as redundant and confusing.
-
 ---
 
 ## Startup — `SetupSettingsStore()`

--- a/docs/settings-versioning.md
+++ b/docs/settings-versioning.md
@@ -1,159 +1,155 @@
-# Versioned settings
+# Settings storage & downgrade protection
 
-How MPC-HC's settings are stored, versioned, migrated, and protected against
-older builds. Introduced for issue #2347.
+How MPC-HC's settings are stored and how a few format-fragile values are
+protected against being clobbered by an older build. Reworked for issue #2347.
 
 Relevant code:
 - `src/mpc-hc/Profile.{h,cpp}` — the `CProfile` store engine (INI + registry
-  backends, legacy import, fork-to-local, binary encoding).
-- `src/mpc-hc/mplayerc.cpp` — `CMPlayerCApp::SetupSettingsStore()` and helpers
-  (the version/migration logic), plus the `GetProfile*`/`WriteProfile*` overrides.
+  backends, binary encoding).
+- `src/mpc-hc/mplayerc.cpp` — `CMPlayerCApp::SetupSettingsStore()` / helpers and
+  the `GetProfile*`/`WriteProfile*` overrides that delegate to `CProfile`.
 
 Related: [`settings-history-store.md`](settings-history-store.md) (the separate
 MediaHistory store) and the HKLM machine-defaults import (`ApplyHKLMDefaults`).
 
 ---
 
-## The store
+## The store stays where it always was
 
-Settings live in a single store whose **name has no version in it**:
+External tools read MPC-HC's settings directly (for example madVR reads some
+player values), so this rework **keeps the on-disk location and byte format
+unchanged**:
 
-| | Legacy (pre-#2347) | Current |
-|---|---|---|
-| Registry | `HKCU\Software\MPC-HC\MPC-HC` | `HKCU\Software\MPC-HC\Settings` |
-| Portable INI | `<exe-basename>.ini` | `<exe-basename>.settings.ini` |
+| | Location |
+|---|---|
+| Registry (installed) | `HKCU\Software\MPC-HC\MPC-HC` |
+| Portable INI | `<exe-basename>.ini` next to the executable |
 
-The legacy store is **never modified** — it's only read once, to import
-pre-#2347 settings (below), so an old MPC-HC build keeps working unchanged.
+`CProfile` replaces the old hand-rolled profile code in `CMPlayerCApp`, but it is
+a drop-in: it reads/writes the same sections and keys, and binary values use the
+legacy **A-P encoding** (two chars per byte, low nibble first, `'A'`+nibble) so
+the bytes are identical to what MFC's `WriteProfileBinary` produced. An older
+build, and any external reader, keeps reading the store unchanged.
 
-`CProfile` picks the location at construction: if a settings INI (new or legacy)
-sits next to the executable it runs **portable/INI**, otherwise **registry**. In
-registry mode the key is opened/created **lazily** on first access (never at
-static-init time — the store object is a member of the global `theApp`).
+`CProfile` picks the location at construction: if `<exe-basename>.ini` sits next
+to the executable it runs **portable/INI**, otherwise **registry**. In registry
+mode the key is opened/created **lazily** on first access — never at static-init
+time, because the store object is a member of the global `theApp`.
 
-## The format version is a field, not the filename
+The one relocation is **MediaHistory**, which moves to a separate file in
+portable mode — see [`settings-history-store.md`](settings-history-store.md).
 
-The on-disk *format* version is recorded **inside** the store, in a `[Version]`
-section:
+## Scalar migration is unchanged
 
-```
-[Version]
-Format       = v1      ; on-disk format version (SETTINGS_FORMAT_VERSION)
-LastWrittenBy = 2.7.3.44 ; MPC-HC build that last wrote the store (informational)
-```
+There is **no whole-store format version and no store-level migration
+framework** in this design. Ordinary settings evolve the way they always have:
 
-- `Format` is the constant `SETTINGS_FORMAT_VERSION` in `Profile.h` (currently
-  `"v1"`). It is bumped **only** on an incompatible layout change — not per
-  release. Within a format version, all app versions interoperate; changes are
-  additive (a new key an old build ignores) or, if a value's format must change,
-  it goes under a **new key**.
-- `CompareVersionStrings` compares these tokens numerically (`v2 < v11`), so any
-  monotonic `v1 → v2 → …` sequence orders correctly. Always keep the `v` prefix.
+- New settings are additive — an old build simply ignores a key it doesn't know.
+- Scalar migrations that must transform an existing value are handled by the
+  pre-existing `CAppSettings::MigrateSettings()`, keyed on `[Settings]
+  SettingsVersion` (`IDS_R_VERSION`) versus `APPSETTINGS_VERSION`. That mechanism
+  predates #2347 and is untouched here.
+
+An empirical sweep of ~45 archived official releases confirmed that scalar
+settings only ever change **additively** — no in-place type or encoding change of
+an existing key has ever shipped — so no store-wide versioning is needed to keep
+old and new builds interoperating on scalars.
 
 ---
 
-## Startup — `SetupSettingsStore()`
+## Downgrade protection — the `v2` namespace
 
-Runs early in `InitInstance`, after the store location is detected and before
-`LoadSettings()`. It reads the store's `[Version] Format` and acts on it:
+The sweep found exactly **one** value that needs physical separation: the saved
+DVB channels. Their serialization is pipe-delimited with a leading
+format-version token, and it has changed shape repeatedly (tokens 0…6 so far);
+an older build **throws** on a newer token, drops the channel, and — because
+channels are rewritten on **every** `SaveSettings` — overwrites the newer list
+just by running. Only a key an old build never touches can prevent that.
 
-```cpp
-CStringW fmt;
-bool haveStore = m_Profile.ReadString(L"Version", L"Format", fmt) && !fmt.IsEmpty();
+The new build stores channels under a **top-level `v2` namespace**:
 
-if (!haveStore) {
-    // (1) first run: import pre-versioned legacy settings, then migrate up
-    if (m_Profile.MigrateFromLegacy())
-        ApplySettingsMigrations(m_Profile, LEGACY_EQUIVALENT_VERSION, myS);
-} else if (CompareVersionStrings(fmt, myS) < 0) {
-    // (2) older format: upgrade this store in place
-    ApplySettingsMigrations(m_Profile, fmt, myS);
-} else if (CompareVersionStrings(fmt, myS) > 0) {
-    // (3) newer format: fork to a private local file (see below)
-    const CStringW local = CProfile::LocalIniPath();
-    bool existed = PathUtils::Exists(local);
-    m_Profile.ForkToLocalIni(local, !existed);   // seed from current if new
-    m_bWarnNewerFormat = !existed;               // warn once, later
-}
-// history store (portable mode) + stamp Format/LastWrittenBy
+```
+IDS_R_DVB_V2 = "v2\DVBConfiguration"   (SettingsDefines.h)
 ```
 
-Cases:
+`v2` sits at the top level (the versioned section lives *under* it) rather than
+as a subkey of the data section. Besides reading naturally — one versioned
+namespace that future format-fragile values can also live in — this keeps the
+legacy section a plain leaf key: old builds clear `DVBConfiguration` on every
+save with MFC's non-recursive `RegDeleteKey`, which would fail if a `v2` subkey
+were nested inside it (leaving stale channel entries a downgrade would read back
+as phantom channels).
 
-1. **First run (no store):** `MigrateFromLegacy()` copies the pre-#2347 settings
-   into the new store (registry: recursive key copy with native value types; INI:
-   verbatim parse+merge). Legacy is the `v1` layout, so the migration chain runs
-   from `LEGACY_EQUIVALENT_VERSION`. Non-destructive.
-2. **Older format:** the migration chain transforms the store in place up to our
-   version, then the `Format` stamp is updated.
-3. **Newer format (downgrade protection):** see below.
+Rules:
 
-## Downgrade protection — fork to a local file
+- **Write:** the new build writes channels **only** under `v2\DVBConfiguration`,
+  clearing that section first (so a shrunken channel list leaves no stale
+  trailing entries). The format-stable BDA scalars stay in the shared
+  `DVBConfiguration` section and are overwritten in place. The legacy channel
+  entries in `DVBConfiguration` are **left frozen** — deliberately not cleared.
+- **Read + one-time migrate:** the new build reads `v2` once the `[Version]
+  DVBChannelsV2 = 1` marker is present (set on the first save); before that it
+  reads the legacy entries so they migrate forward. Gating on a marker rather
+  than "does `v2` have a channel" means clearing all channels in a new build
+  can't resurrect the frozen legacy list on the next load.
+- **Old builds** only ever read/write the legacy entries, never `v2`, so they
+  can't see or corrupt the new-format data. A downgrade keeps operating on its
+  own frozen legacy copy.
 
-Because the store name is now version-independent, an **older build opens the
-same file a newer build wrote**. That is safe *only because every #2347-era build
-checks `[Version] Format`* (the pre-#2347 legacy builds use a different store
-entirely, so they never touch this one). When a build finds `Format` **newer**
-than it understands, it must not clobber it:
+The accepted tradeoff: after upgrading and re-saving, a subsequent downgrade sees
+its **pre-upgrade** channels (the frozen legacy snapshot), not any rescan done by
+the newer build. Nothing is lost or corrupted in either direction.
 
-- `CProfile::ForkToLocalIni()` detaches from the shared store **without deleting
-  it** and switches this instance to a private, **version-qualified** local file
-  `<exe-basename>.settings.<thisFormat>.local.ini` (history:
-  `.history.<thisFormat>.local.ini`). Putting this build's own format version in
-  the fork name keeps two different older builds from colliding on one file and
-  makes each fork self-identifying.
-- If that local file already exists (this build forked before) it is loaded and
-  reused silently. If it's new, it is **seeded from the current store** (registry
-  values converted to INI form) so the older build starts from the newer data it
-  can read, and the user is told **once** (`IDS_SETTINGS_NEWER_VERSION`, shown by
-  `ApplySettingsPolicies` on the next committed normal launch).
+### Why the toolbar layout does *not* get this treatment
 
-The newer build is never modified; each older build keeps its own local file.
+`Toolbars\PlayerToolBar → ButtonSequence` looked like a candidate (its shape
+changed once, in 2.5.5.30), but it already carries **in-band versioning** — the
+companion `ButtonLayoutRevision` key — and current builds read every shipped
+revision correctly. Two further properties make physical separation unnecessary,
+and in fact harmful:
 
-## Migration framework
+- Old builds rewrite the layout **only when the user customizes the toolbar**
+  (`SaveToolbarState` fires from the customization handlers only) — there is no
+  passive overwrite-on-every-save like the DVB channels.
+- Today's builds all write the identical revision-1 format, so a split key would
+  protect nothing while making a downgrade show a stale frozen layout it could
+  have read perfectly.
 
-Format upgrades are an ordered table in `mplayerc.cpp`:
+If the layout format changes again, it stays self-contained: bump
+`ButtonLayoutRevision` and handle the older revisions in the reader, exactly as
+the revision-0 → revision-1 transition already does. The revision key *is* the
+upgrade process — no new keys or namespace needed.
 
-```cpp
-struct SettingsMigrationStep { const wchar_t* from; const wchar_t* to; SettingsMigrationFn apply; };
-static const std::vector<SettingsMigrationStep> s_settingsMigrations = {
-    // { L"v1", L"v2", &Migrate_Settings_v1_to_v2 },   // added when v2 ships
-};
-```
+## Unrelated hardening — validated binary reads
 
-Each step transforms a store **in place** from `from` to `to`.
-`ApplySettingsMigrations(profile, from, to)` walks the chain;
-`CountSettingsMigrations` returns the step count or `-1` if no path exists. The
-table is **empty today** (only `v1`), so no step runs. To introduce `v2`: bump
-`SETTINGS_FORMAT_VERSION` and add `{ L"v1", L"v2", fn }`; existing `v1` stores
-then upgrade in place, and `v1` builds fork away from `v2` stores.
+`CAppSettings` reads a few audio-renderer `double`s straight from a binary blob.
+Those reads now guard on `dSize == sizeof(double)` before dereferencing, so a
+truncated or foreign value can't be misread. This is defensive only; it is not
+tied to any format version.
 
-## Interaction with reset
+---
 
-`/reset` and an HKLM `SettingsReset` clear the store and immediately re-stamp
-`[Version] Format`, `LastWrittenBy`, and `HistorySplit`, so the next launch does
-not treat the cleared store as a fresh install and re-import legacy settings.
+## Interaction with reset and HKLM defaults
 
-## Command-line / policy timing
-
-`SetupSettingsStore()` runs for every launch (it must, before `LoadSettings`),
-but the **user-visible policies** — the newer-format notice and the HKLM
-machine-defaults import — are deferred to `ApplySettingsPolicies()`, called only
-once a **normal interactive launch** is committed (after `/help`, `/close`,
-`/regvid`, `/admin`, and single-instance forwarding have returned). So utility
-invocations neither pop a modal nor apply machine policy.
+- `/reset` and an HKLM `SettingsReset` clear the store and re-stamp
+  `[Version] HistorySplit = 1`, so the next launch doesn't treat the cleared
+  store as a fresh install and re-run the MediaHistory split.
+- The **HKLM machine-defaults import** (`ApplyHKLMDefaults`, issue #2347) is
+  deferred to `ApplySettingsPolicies()`, called only once a **normal interactive
+  launch** is committed (after `/help`, `/close`, `/regvid`, `/admin`, and
+  single-instance forwarding have returned) so utility invocations don't apply
+  machine policy. See the source for the `SettingsReset` / `SettingsTimestamp`
+  gating.
 
 ---
 
 ## Key identifiers (quick reference)
 
-- `SETTINGS_FORMAT_VERSION` / `HISTORY_FORMAT_VERSION` / `LEGACY_EQUIVALENT_VERSION` (`Profile.h`) — bump the first to introduce a new format
-- Stores: `HKCU\Software\MPC-HC\Settings` / `<exe>.settings.ini`; legacy `…\MPC-HC` / `<exe>.ini`
-- Fork files (version-qualified): `<exe>.settings.<ver>.local.ini`, `<exe>.history.<ver>.local.ini`
-- Fields: `[Version] Format`, `[Version] LastWrittenBy`, `[Version] HistorySplit`
-- `CMPlayerCApp::SetupSettingsStore()` / `SetupHistoryStore()` / `StampSettingsStoreInitialized()` / `ApplySettingsPolicies()`
-- `CProfile::MigrateFromLegacy()` — one-time pre-versioned import (non-destructive)
-- `CProfile::ForkToLocalIni(iniPath, seedFromCurrent)` — downgrade fork
-- `s_settingsMigrations` + `CountSettingsMigrations` / `ApplySettingsMigrations`
-- `CompareVersionStrings()` — numeric `vN` compare
-- `IDS_SETTINGS_NEWER_VERSION` — the "newer settings, using a separate file" notice
+- Store: `HKCU\Software\MPC-HC\MPC-HC` / `<exe>.ini` (unchanged location, A-P binary)
+- `CProfile` — the store engine; `AfxGetProfile()` reaches the app's instance
+- `IDS_R_DVB_V2` (`SettingsDefines.h`) — downgrade-protected DVB channels under the top-level `v2` namespace
+- `[Version] DVBChannelsV2 = 1` — DVB-channels-migrated-to-v2 marker
+- `[Version] HistorySplit = 1` — MediaHistory split-done marker
+- `CAppSettings::MigrateSettings()` + `[Settings] SettingsVersion` (`IDS_R_VERSION`) — pre-existing scalar migration (unchanged)
+- `CMPlayerCApp::SetupSettingsStore()` / `SetupHistoryStore()` / `ApplySettingsPolicies()`
+- `ApplyHKLMDefaults()` / `ImportHKLMTree()` — HKLM machine-defaults import (#2347)

--- a/docs/settings-versioning.md
+++ b/docs/settings-versioning.md
@@ -57,7 +57,7 @@ old and new builds interoperating on scalars.
 
 ---
 
-## Downgrade protection — the `v2` namespace
+## Downgrade protection — `DVBConfiguration2`
 
 The sweep found exactly **one** value that needs physical separation: the saved
 DVB channels. Their serialization is pipe-delimited with a leading
@@ -66,39 +66,38 @@ an older build **throws** on a newer token, drops the channel, and — because
 channels are rewritten on **every** `SaveSettings` — overwrites the newer list
 just by running. Only a key an old build never touches can prevent that.
 
-The new build stores channels under a **top-level `v2` namespace**:
+The new build stores the whole DVB configuration (BDA scalars + channels) in a
+**replacement section** old builds don't know about, following the same pattern
+`Commands2` and `FileFormats2` used when their formats changed:
 
 ```
-IDS_R_DVB_V2 = "v2\DVBConfiguration"   (SettingsDefines.h)
+IDS_R_DVB2 = "DVBConfiguration2"   (SettingsDefines.h)
 ```
 
-`v2` sits at the top level (the versioned section lives *under* it) rather than
-as a subkey of the data section. Besides reading naturally — one versioned
-namespace that future format-fragile values can also live in — this keeps the
-legacy section a plain leaf key: old builds clear `DVBConfiguration` on every
-save with MFC's non-recursive `RegDeleteKey`, which would fail if a `v2` subkey
-were nested inside it (leaving stale channel entries a downgrade would read back
-as phantom channels).
+A *sibling* section (not a subkey of the legacy one) keeps `DVBConfiguration` a
+plain leaf key: old builds clear it on every save with MFC's non-recursive
+`RegDeleteKey`, which would fail if a subkey were nested inside it (leaving
+stale channel entries a downgrade would read back as phantom channels).
 
 Rules:
 
-- **Write:** the new build writes channels **only** under `v2\DVBConfiguration`,
-  clearing that section first (so a shrunken channel list leaves no stale
-  trailing entries). The format-stable BDA scalars stay in the shared
-  `DVBConfiguration` section and are overwritten in place. The legacy channel
-  entries in `DVBConfiguration` are **left frozen** — deliberately not cleared.
-- **Read + one-time migrate:** the new build reads `v2` once the `[Version]
-  DVBChannelsV2 = 1` marker is present (set on the first save); before that it
-  reads the legacy entries so they migrate forward. Gating on a marker rather
-  than "does `v2` have a channel" means clearing all channels in a new build
-  can't resurrect the frozen legacy list on the next load.
-- **Old builds** only ever read/write the legacy entries, never `v2`, so they
-  can't see or corrupt the new-format data. A downgrade keeps operating on its
-  own frozen legacy copy.
+- **Write:** the new build writes **only** to `DVBConfiguration2`, clearing it
+  first (so a shrunken channel list leaves no stale trailing entries). The
+  legacy `DVBConfiguration` section is **left frozen** — deliberately not
+  written or cleared.
+- **Read + one-time migrate:** the new build probes `BDASymbolRate` in
+  `DVBConfiguration2` with a default of `-1` (never a legitimate stored value).
+  `-1` means the section hasn't been written yet — first run after an upgrade —
+  so everything is read once from the legacy section and the next save migrates
+  it. Once the section exists, the legacy entries are never read again, so
+  clearing all channels in a new build can't resurrect the frozen legacy list.
+- **Old builds** only ever read/write the legacy section, never
+  `DVBConfiguration2`, so they can't see or corrupt the new-format data. A
+  downgrade keeps operating on its own frozen legacy copy.
 
 The accepted tradeoff: after upgrading and re-saving, a subsequent downgrade sees
-its **pre-upgrade** channels (the frozen legacy snapshot), not any rescan done by
-the newer build. Nothing is lost or corrupted in either direction.
+its **pre-upgrade** DVB settings (the frozen legacy snapshot), not any changes
+made by the newer build. Nothing is lost or corrupted in either direction.
 
 ### Why the toolbar layout does *not* get this treatment
 
@@ -147,8 +146,7 @@ tied to any format version.
 
 - Store: `HKCU\Software\MPC-HC\MPC-HC` / `<exe>.ini` (unchanged location, A-P binary)
 - `CProfile` — the store engine; `AfxGetProfile()` reaches the app's instance
-- `IDS_R_DVB_V2` (`SettingsDefines.h`) — downgrade-protected DVB channels under the top-level `v2` namespace
-- `[Version] DVBChannelsV2 = 1` — DVB-channels-migrated-to-v2 marker
+- `IDS_R_DVB2` = `DVBConfiguration2` (`SettingsDefines.h`) — downgrade-protected replacement section for the DVB settings (`BDASymbolRate` probe with default `-1` detects first run after upgrade)
 - `[Version] HistorySplit = 1` — MediaHistory split-done marker
 - `CAppSettings::MigrateSettings()` + `[Settings] SettingsVersion` (`IDS_R_VERSION`) — pre-existing scalar migration (unchanged)
 - `CMPlayerCApp::SetupSettingsStore()` / `SetupHistoryStore()` / `ApplySettingsPolicies()`

--- a/docs/settings-versioning.md
+++ b/docs/settings-versioning.md
@@ -1,0 +1,160 @@
+# Versioned settings
+
+How MPC-HC's settings are stored, versioned, migrated, and protected against
+older builds. Introduced for issue #2347.
+
+Relevant code:
+- `src/mpc-hc/Profile.{h,cpp}` — the `CProfile` store engine (INI + registry
+  backends, legacy import, fork-to-local, binary encoding).
+- `src/mpc-hc/mplayerc.cpp` — `CMPlayerCApp::SetupSettingsStore()` and helpers
+  (the version/migration logic), plus the `GetProfile*`/`WriteProfile*` overrides.
+
+Related: [`settings-history-store.md`](settings-history-store.md) (the separate
+MediaHistory store) and the HKLM machine-defaults import (`ApplyHKLMDefaults`).
+
+---
+
+## The store
+
+Settings live in a single store whose **name has no version in it**:
+
+| | Legacy (pre-#2347) | Current |
+|---|---|---|
+| Registry | `HKCU\Software\MPC-HC\MPC-HC` | `HKCU\Software\MPC-HC\Settings` |
+| Portable INI | `<exe-basename>.ini` | `<exe-basename>.settings.ini` |
+
+The legacy store is **never modified** — it's only read once, to import
+pre-#2347 settings (below), so an old MPC-HC build keeps working unchanged.
+
+`CProfile` picks the location at construction: if a settings INI (new or legacy)
+sits next to the executable it runs **portable/INI**, otherwise **registry**. In
+registry mode the key is opened/created **lazily** on first access (never at
+static-init time — the store object is a member of the global `theApp`).
+
+## The format version is a field, not the filename
+
+The on-disk *format* version is recorded **inside** the store, in a `[Version]`
+section:
+
+```
+[Version]
+Format       = v1      ; on-disk format version (SETTINGS_FORMAT_VERSION)
+LastWrittenBy = 2.7.3.44 ; MPC-HC build that last wrote the store (informational)
+```
+
+- `Format` is the constant `SETTINGS_FORMAT_VERSION` in `Profile.h` (currently
+  `"v1"`). It is bumped **only** on an incompatible layout change — not per
+  release. Within a format version, all app versions interoperate; changes are
+  additive (a new key an old build ignores) or, if a value's format must change,
+  it goes under a **new key**.
+- `CompareVersionStrings` compares these tokens numerically (`v2 < v11`), so any
+  monotonic `v1 → v2 → …` sequence orders correctly. Always keep the `v` prefix.
+
+This replaces the earlier scheme that put the version in the store name
+(`Settings-v1` / `<exe>.settings-v1.ini`) plus a separate index file — that was
+removed as redundant and confusing.
+
+---
+
+## Startup — `SetupSettingsStore()`
+
+Runs early in `InitInstance`, after the store location is detected and before
+`LoadSettings()`. It reads the store's `[Version] Format` and acts on it:
+
+```cpp
+CStringW fmt;
+bool haveStore = m_Profile.ReadString(L"Version", L"Format", fmt) && !fmt.IsEmpty();
+
+if (!haveStore) {
+    // (1) first run: import pre-versioned legacy settings, then migrate up
+    if (m_Profile.MigrateFromLegacy())
+        ApplySettingsMigrations(m_Profile, LEGACY_EQUIVALENT_VERSION, myS);
+} else if (CompareVersionStrings(fmt, myS) < 0) {
+    // (2) older format: upgrade this store in place
+    ApplySettingsMigrations(m_Profile, fmt, myS);
+} else if (CompareVersionStrings(fmt, myS) > 0) {
+    // (3) newer format: fork to a private local file (see below)
+    const CStringW local = CProfile::LocalIniPath();
+    bool existed = PathUtils::Exists(local);
+    m_Profile.ForkToLocalIni(local, !existed);   // seed from current if new
+    m_bWarnNewerFormat = !existed;               // warn once, later
+}
+// history store (portable mode) + stamp Format/LastWrittenBy
+```
+
+Cases:
+
+1. **First run (no store):** `MigrateFromLegacy()` copies the pre-#2347 settings
+   into the new store (registry: recursive key copy with native value types; INI:
+   verbatim parse+merge). Legacy is the `v1` layout, so the migration chain runs
+   from `LEGACY_EQUIVALENT_VERSION`. Non-destructive.
+2. **Older format:** the migration chain transforms the store in place up to our
+   version, then the `Format` stamp is updated.
+3. **Newer format (downgrade protection):** see below.
+
+## Downgrade protection — fork to a local file
+
+Because the store name is now version-independent, an **older build opens the
+same file a newer build wrote**. That is safe *only because every #2347-era build
+checks `[Version] Format`* (the pre-#2347 legacy builds use a different store
+entirely, so they never touch this one). When a build finds `Format` **newer**
+than it understands, it must not clobber it:
+
+- `CProfile::ForkToLocalIni()` detaches from the shared store **without deleting
+  it** and switches this instance to a private `<exe-basename>.settings.local.ini`
+  (history: `.history.local.ini`).
+- If that local file already exists (this build forked before) it is loaded and
+  reused silently. If it's new, it is **seeded from the current store** (registry
+  values converted to INI form) so the older build starts from the newer data it
+  can read, and the user is told **once** (`IDS_SETTINGS_NEWER_VERSION`, shown by
+  `ApplySettingsPolicies` on the next committed normal launch).
+
+The newer build is never modified; each older build keeps its own local file.
+
+## Migration framework
+
+Format upgrades are an ordered table in `mplayerc.cpp`:
+
+```cpp
+struct SettingsMigrationStep { const wchar_t* from; const wchar_t* to; SettingsMigrationFn apply; };
+static const std::vector<SettingsMigrationStep> s_settingsMigrations = {
+    // { L"v1", L"v2", &Migrate_Settings_v1_to_v2 },   // added when v2 ships
+};
+```
+
+Each step transforms a store **in place** from `from` to `to`.
+`ApplySettingsMigrations(profile, from, to)` walks the chain;
+`CountSettingsMigrations` returns the step count or `-1` if no path exists. The
+table is **empty today** (only `v1`), so no step runs. To introduce `v2`: bump
+`SETTINGS_FORMAT_VERSION` and add `{ L"v1", L"v2", fn }`; existing `v1` stores
+then upgrade in place, and `v1` builds fork away from `v2` stores.
+
+## Interaction with reset
+
+`/reset` and an HKLM `SettingsReset` clear the store and immediately re-stamp
+`[Version] Format`, `LastWrittenBy`, and `HistorySplit`, so the next launch does
+not treat the cleared store as a fresh install and re-import legacy settings.
+
+## Command-line / policy timing
+
+`SetupSettingsStore()` runs for every launch (it must, before `LoadSettings`),
+but the **user-visible policies** — the newer-format notice and the HKLM
+machine-defaults import — are deferred to `ApplySettingsPolicies()`, called only
+once a **normal interactive launch** is committed (after `/help`, `/close`,
+`/regvid`, `/admin`, and single-instance forwarding have returned). So utility
+invocations neither pop a modal nor apply machine policy.
+
+---
+
+## Key identifiers (quick reference)
+
+- `SETTINGS_FORMAT_VERSION` / `HISTORY_FORMAT_VERSION` / `LEGACY_EQUIVALENT_VERSION` (`Profile.h`) — bump the first to introduce a new format
+- Stores: `HKCU\Software\MPC-HC\Settings` / `<exe>.settings.ini`; legacy `…\MPC-HC` / `<exe>.ini`
+- Fork files: `<exe>.settings.local.ini`, `<exe>.history.local.ini`
+- Fields: `[Version] Format`, `[Version] LastWrittenBy`, `[Version] HistorySplit`
+- `CMPlayerCApp::SetupSettingsStore()` / `SetupHistoryStore()` / `StampSettingsStoreInitialized()` / `ApplySettingsPolicies()`
+- `CProfile::MigrateFromLegacy()` — one-time pre-versioned import (non-destructive)
+- `CProfile::ForkToLocalIni(iniPath, seedFromCurrent)` — downgrade fork
+- `s_settingsMigrations` + `CountSettingsMigrations` / `ApplySettingsMigrations`
+- `CompareVersionStrings()` — numeric `vN` compare
+- `IDS_SETTINGS_NEWER_VERSION` — the "newer settings, using a separate file" notice

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -1162,9 +1162,10 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileString(IDS_R_CAPTURE, IDS_RS_AUDIO_DISP_NAME, strAnalogAudio);
     pApp->WriteProfileInt(IDS_R_CAPTURE, IDS_RS_COUNTRY, iAnalogCountry);
 
-    // Save digital capture settings (BDA)
-    pApp->WriteProfileString(IDS_R_DVB, nullptr, nullptr); // Ensure the section is cleared before saving the new settings
-
+    // Save digital capture settings (BDA). The BDA scalars are format-stable, so
+    // they stay in the shared (unversioned) section and are overwritten in place.
+    // We intentionally do NOT clear IDS_R_DVB: the legacy channel entries ("0"..)
+    // are left frozen there as a last-known-good snapshot for an older build.
     //pApp->WriteProfileString(IDS_R_DVB, IDS_RS_BDA_NETWORKPROVIDER, strBDANetworkProvider);
     pApp->WriteProfileString(IDS_R_DVB, IDS_RS_BDA_TUNER, strBDATuner);
     pApp->WriteProfileString(IDS_R_DVB, IDS_RS_BDA_RECEIVER, strBDAReceiver);
@@ -1180,11 +1181,19 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_DVB_REBUILD_FG, nDVBRebuildFilterGraph);
     pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_DVB_STOP_FG, nDVBStopFilterGraph);
 
+    // Saved channels use a format-versioned serialization an older build rejects,
+    // so they are stored only under the top-level v2 namespace. Clear that
+    // section first so a shrunken channel list leaves no stale trailing entries.
+    pApp->WriteProfileString(IDS_R_DVB_V2, nullptr, nullptr);
     for (size_t i = 0; i < m_DVBChannels.size(); i++) {
         CString numChannel;
         numChannel.Format(_T("%Iu"), i);
-        pApp->WriteProfileString(IDS_R_DVB, numChannel, m_DVBChannels[i].ToString());
+        pApp->WriteProfileString(IDS_R_DVB_V2, numChannel, m_DVBChannels[i].ToString());
     }
+    // Mark that channels now live under the v2 namespace. Once set, we never read
+    // the frozen legacy channels again, so clearing all channels here can't
+    // resurrect them on the next load.
+    pApp->WriteProfileString(_T("Version"), _T("DVBChannelsV2"), _T("1"));
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_DVDPOS, fRememberDVDPos);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_FILEPOS, fRememberFilePos);
@@ -2217,10 +2226,17 @@ void CAppSettings::LoadSettings()
     nDVBRebuildFilterGraph = (DVB_RebuildFilterGraph) pApp->GetProfileInt(IDS_R_DVB, IDS_RS_DVB_REBUILD_FG, DVB_STOP_FG_ALWAYS);
     nDVBStopFilterGraph = (DVB_StopFilterGraph) pApp->GetProfileInt(IDS_R_DVB, IDS_RS_DVB_STOP_FG, DVB_STOP_FG_ALWAYS);
 
+    // Read channels from the v2 namespace once migration has run
+    // (the marker is written on the first save). Before that, read the legacy
+    // entries written by an older build so they migrate forward. Gating on the
+    // marker rather than "does v2 have a channel" means clearing all channels in
+    // a new build doesn't resurrect the frozen legacy list on the next load.
+    LPCTSTR dvbChannelsSection =
+        AfxGetMyApp()->HasProfileEntry(_T("Version"), _T("DVBChannelsV2")) ? IDS_R_DVB_V2 : IDS_R_DVB;
     for (int iChannel = 0; ; iChannel++) {
         CString strTemp;
         strTemp.Format(_T("%d"), iChannel);
-        CString strChannel = pApp->GetProfileString(IDS_R_DVB, strTemp);
+        CString strChannel = pApp->GetProfileString(dvbChannelsSection, strTemp);
         if (strChannel.IsEmpty()) {
             break;
         }
@@ -2522,17 +2538,25 @@ void CAppSettings::UpdateRenderersData(bool fSave)
 
         double* dPtr;
         UINT dSize;
+        // Guard the size before dereferencing: a truncated/foreign blob must not
+        // be read as a double (the writer stores exactly sizeof(double) bytes).
         if (pApp->GetProfileBinary(IDS_R_SETTINGS, _T("CycleDelta"), (LPBYTE*)&dPtr, &dSize)) {
-            ars.fCycleDelta = *dPtr;
+            if (dSize == sizeof(double)) {
+                ars.fCycleDelta = *dPtr;
+            }
             delete [] dPtr;
         }
 
         if (pApp->GetProfileBinary(IDS_R_SETTINGS, _T("TargetSyncOffset"), (LPBYTE*)&dPtr, &dSize)) {
-            ars.fTargetSyncOffset = *dPtr;
+            if (dSize == sizeof(double)) {
+                ars.fTargetSyncOffset = *dPtr;
+            }
             delete [] dPtr;
         }
         if (pApp->GetProfileBinary(IDS_R_SETTINGS, _T("ControlLimit"), (LPBYTE*)&dPtr, &dSize)) {
-            ars.fControlLimit = *dPtr;
+            if (dSize == sizeof(double)) {
+                ars.fControlLimit = *dPtr;
+            }
             delete [] dPtr;
         }
 

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -1163,38 +1163,31 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileString(IDS_R_CAPTURE, IDS_RS_AUDIO_DISP_NAME, strAnalogAudio);
     pApp->WriteProfileInt(IDS_R_CAPTURE, IDS_RS_COUNTRY, iAnalogCountry);
 
-    // Save digital capture settings (BDA). The BDA scalars are format-stable, so
-    // they stay in the shared (unversioned) section and are overwritten in place.
-    // We intentionally do NOT clear IDS_R_DVB: the legacy channel entries ("0"..)
-    // are left frozen there as a last-known-good snapshot for an older build.
-    //pApp->WriteProfileString(IDS_R_DVB, IDS_RS_BDA_NETWORKPROVIDER, strBDANetworkProvider);
-    pApp->WriteProfileString(IDS_R_DVB, IDS_RS_BDA_TUNER, strBDATuner);
-    pApp->WriteProfileString(IDS_R_DVB, IDS_RS_BDA_RECEIVER, strBDAReceiver);
-    //pApp->WriteProfileString(IDS_R_DVB, IDS_RS_BDA_STANDARD, strBDAStandard);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_BDA_SCAN_FREQ_START, iBDAScanFreqStart);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_BDA_SCAN_FREQ_END, iBDAScanFreqEnd);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_BDA_BANDWIDTH, iBDABandwidth);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_BDA_SYMBOLRATE, iBDASymbolRate);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_BDA_USE_OFFSET, fBDAUseOffset);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_BDA_OFFSET, iBDAOffset);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_BDA_IGNORE_ENCRYPTED_CHANNELS, fBDAIgnoreEncryptedChannels);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_DVB_LAST_CHANNEL, nDVBLastChannel);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_DVB_REBUILD_FG, nDVBRebuildFilterGraph);
-    pApp->WriteProfileInt(IDS_R_DVB, IDS_RS_DVB_STOP_FG, nDVBStopFilterGraph);
+    // Save digital capture settings (BDA) to the replacement section (see
+    // IDS_R_DVB2 in SettingsDefines.h). The legacy section is deliberately left
+    // frozen as a last-known-good snapshot for older builds. Clear the section
+    // first so a shrunken channel list leaves no stale trailing entries.
+    pApp->WriteProfileString(IDS_R_DVB2, nullptr, nullptr);
+    //pApp->WriteProfileString(IDS_R_DVB2, IDS_RS_BDA_NETWORKPROVIDER, strBDANetworkProvider);
+    pApp->WriteProfileString(IDS_R_DVB2, IDS_RS_BDA_TUNER, strBDATuner);
+    pApp->WriteProfileString(IDS_R_DVB2, IDS_RS_BDA_RECEIVER, strBDAReceiver);
+    //pApp->WriteProfileString(IDS_R_DVB2, IDS_RS_BDA_STANDARD, strBDAStandard);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_BDA_SCAN_FREQ_START, iBDAScanFreqStart);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_BDA_SCAN_FREQ_END, iBDAScanFreqEnd);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_BDA_BANDWIDTH, iBDABandwidth);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_BDA_SYMBOLRATE, iBDASymbolRate);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_BDA_USE_OFFSET, fBDAUseOffset);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_BDA_OFFSET, iBDAOffset);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_BDA_IGNORE_ENCRYPTED_CHANNELS, fBDAIgnoreEncryptedChannels);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_DVB_LAST_CHANNEL, nDVBLastChannel);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_DVB_REBUILD_FG, nDVBRebuildFilterGraph);
+    pApp->WriteProfileInt(IDS_R_DVB2, IDS_RS_DVB_STOP_FG, nDVBStopFilterGraph);
 
-    // Saved channels use a format-versioned serialization an older build rejects,
-    // so they are stored only under the top-level v2 namespace. Clear that
-    // section first so a shrunken channel list leaves no stale trailing entries.
-    pApp->WriteProfileString(IDS_R_DVB_V2, nullptr, nullptr);
     for (size_t i = 0; i < m_DVBChannels.size(); i++) {
         CString numChannel;
         numChannel.Format(_T("%Iu"), i);
-        pApp->WriteProfileString(IDS_R_DVB_V2, numChannel, m_DVBChannels[i].ToString());
+        pApp->WriteProfileString(IDS_R_DVB2, numChannel, m_DVBChannels[i].ToString());
     }
-    // Mark that channels now live under the v2 namespace. Once set, we never read
-    // the frozen legacy channels again, so clearing all channels here can't
-    // resurrect them on the next load.
-    pApp->WriteProfileString(_T("Version"), _T("DVBChannelsV2"), _T("1"));
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_DVDPOS, fRememberDVDPos);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_FILEPOS, fRememberFilePos);
@@ -1409,6 +1402,7 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_CONFIRM_FILE_DELETE, bConfirmFileDelete);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_SHOW_VOLUME_PERCENTAGE, bShowVolumePercentage);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_HISTORY_IN_APPDATA, bHistoryInAppData);
+    pApp->SetHistoryInAppData(bHistoryInAppData); // keep the app's cached copy in sync
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, L"LastGPUCheck", LastGPUCheck);
     pApp->WriteProfileString(IDS_R_SETTINGS, L"GPUID1", gpuid1);
@@ -1890,6 +1884,7 @@ void CAppSettings::LoadSettings()
     bConfirmFileDelete = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_CONFIRM_FILE_DELETE, TRUE);
     bShowVolumePercentage = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_SHOW_VOLUME_PERCENTAGE, TRUE);
     bHistoryInAppData = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_HISTORY_IN_APPDATA, FALSE);
+    AfxGetMyApp()->SetHistoryInAppData(bHistoryInAppData);
 
     fClosedCaptions = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_CLOSEDCAPTIONS, FALSE);
     {
@@ -2214,32 +2209,33 @@ void CAppSettings::LoadSettings()
     strAnalogAudio        = pApp->GetProfileString(IDS_R_CAPTURE, IDS_RS_AUDIO_DISP_NAME, _T("dummy"));
     iAnalogCountry        = pApp->GetProfileInt(IDS_R_CAPTURE, IDS_RS_COUNTRY, 1);
 
-    //strBDANetworkProvider = pApp->GetProfileString(IDS_R_DVB, IDS_RS_BDA_NETWORKPROVIDER);
-    strBDATuner           = pApp->GetProfileString(IDS_R_DVB, IDS_RS_BDA_TUNER);
-    strBDAReceiver        = pApp->GetProfileString(IDS_R_DVB, IDS_RS_BDA_RECEIVER);
-    //sBDAStandard        = pApp->GetProfileString(IDS_R_DVB, IDS_RS_BDA_STANDARD);
-    iBDAScanFreqStart     = pApp->GetProfileInt(IDS_R_DVB, IDS_RS_BDA_SCAN_FREQ_START, 474000);
-    iBDAScanFreqEnd       = pApp->GetProfileInt(IDS_R_DVB, IDS_RS_BDA_SCAN_FREQ_END, 858000);
-    iBDABandwidth         = pApp->GetProfileInt(IDS_R_DVB, IDS_RS_BDA_BANDWIDTH, 8);
-    iBDASymbolRate        = pApp->GetProfileInt(IDS_R_DVB, IDS_RS_BDA_SYMBOLRATE, 0);
-    fBDAUseOffset         = !!pApp->GetProfileInt(IDS_R_DVB, IDS_RS_BDA_USE_OFFSET, FALSE);
-    iBDAOffset            = pApp->GetProfileInt(IDS_R_DVB, IDS_RS_BDA_OFFSET, 166);
-    fBDAIgnoreEncryptedChannels = !!pApp->GetProfileInt(IDS_R_DVB, IDS_RS_BDA_IGNORE_ENCRYPTED_CHANNELS, FALSE);
-    nDVBLastChannel       = pApp->GetProfileInt(IDS_R_DVB, IDS_RS_DVB_LAST_CHANNEL, INT_ERROR);
-    nDVBRebuildFilterGraph = (DVB_RebuildFilterGraph) pApp->GetProfileInt(IDS_R_DVB, IDS_RS_DVB_REBUILD_FG, DVB_STOP_FG_ALWAYS);
-    nDVBStopFilterGraph = (DVB_StopFilterGraph) pApp->GetProfileInt(IDS_R_DVB, IDS_RS_DVB_STOP_FG, DVB_STOP_FG_ALWAYS);
+    // DVB settings live in the replacement section (see IDS_R_DVB2). Probe
+    // BDASymbolRate there with a default of -1 (never a legitimate stored
+    // value): -1 means the section has not been written yet — first run after
+    // an upgrade — so read everything once from the legacy section; the next
+    // save migrates it. After that the frozen legacy entries are never read
+    // again, so clearing all channels can't resurrect them on the next load.
+    LPCTSTR dvbSection =
+        pApp->GetProfileInt(IDS_R_DVB2, IDS_RS_BDA_SYMBOLRATE, -1) != -1 ? IDS_R_DVB2 : IDS_R_DVB;
+    //strBDANetworkProvider = pApp->GetProfileString(dvbSection, IDS_RS_BDA_NETWORKPROVIDER);
+    strBDATuner           = pApp->GetProfileString(dvbSection, IDS_RS_BDA_TUNER);
+    strBDAReceiver        = pApp->GetProfileString(dvbSection, IDS_RS_BDA_RECEIVER);
+    //sBDAStandard        = pApp->GetProfileString(dvbSection, IDS_RS_BDA_STANDARD);
+    iBDAScanFreqStart     = pApp->GetProfileInt(dvbSection, IDS_RS_BDA_SCAN_FREQ_START, 474000);
+    iBDAScanFreqEnd       = pApp->GetProfileInt(dvbSection, IDS_RS_BDA_SCAN_FREQ_END, 858000);
+    iBDABandwidth         = pApp->GetProfileInt(dvbSection, IDS_RS_BDA_BANDWIDTH, 8);
+    iBDASymbolRate        = pApp->GetProfileInt(dvbSection, IDS_RS_BDA_SYMBOLRATE, 0);
+    fBDAUseOffset         = !!pApp->GetProfileInt(dvbSection, IDS_RS_BDA_USE_OFFSET, FALSE);
+    iBDAOffset            = pApp->GetProfileInt(dvbSection, IDS_RS_BDA_OFFSET, 166);
+    fBDAIgnoreEncryptedChannels = !!pApp->GetProfileInt(dvbSection, IDS_RS_BDA_IGNORE_ENCRYPTED_CHANNELS, FALSE);
+    nDVBLastChannel       = pApp->GetProfileInt(dvbSection, IDS_RS_DVB_LAST_CHANNEL, INT_ERROR);
+    nDVBRebuildFilterGraph = (DVB_RebuildFilterGraph) pApp->GetProfileInt(dvbSection, IDS_RS_DVB_REBUILD_FG, DVB_STOP_FG_ALWAYS);
+    nDVBStopFilterGraph = (DVB_StopFilterGraph) pApp->GetProfileInt(dvbSection, IDS_RS_DVB_STOP_FG, DVB_STOP_FG_ALWAYS);
 
-    // Read channels from the v2 namespace once migration has run
-    // (the marker is written on the first save). Before that, read the legacy
-    // entries written by an older build so they migrate forward. Gating on the
-    // marker rather than "does v2 have a channel" means clearing all channels in
-    // a new build doesn't resurrect the frozen legacy list on the next load.
-    LPCTSTR dvbChannelsSection =
-        AfxGetMyApp()->HasProfileEntry(_T("Version"), _T("DVBChannelsV2")) ? IDS_R_DVB_V2 : IDS_R_DVB;
     for (int iChannel = 0; ; iChannel++) {
         CString strTemp;
         strTemp.Format(_T("%d"), iChannel);
-        CString strChannel = pApp->GetProfileString(dvbChannelsSection, strTemp);
+        CString strChannel = pApp->GetProfileString(dvbSection, strTemp);
         if (strChannel.IsEmpty()) {
             break;
         }

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -298,6 +298,7 @@ CAppSettings::CAppSettings()
     , bPauseWhileDraggingSeekbar(true)
     , bConfirmFileDelete(true)
     , bShowVolumePercentage(true)
+    , bHistoryInAppData(false)
     , LastGPUCheck(0)
     , gpuid1(L"")
     , gpuid2(L"")
@@ -1407,6 +1408,7 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_PAUSE_WHILE_DRAGGING_SEEKBAR, bPauseWhileDraggingSeekbar);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_CONFIRM_FILE_DELETE, bConfirmFileDelete);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_SHOW_VOLUME_PERCENTAGE, bShowVolumePercentage);
+    pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_HISTORY_IN_APPDATA, bHistoryInAppData);
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, L"LastGPUCheck", LastGPUCheck);
     pApp->WriteProfileString(IDS_R_SETTINGS, L"GPUID1", gpuid1);
@@ -1887,6 +1889,7 @@ void CAppSettings::LoadSettings()
     bPauseWhileDraggingSeekbar = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_PAUSE_WHILE_DRAGGING_SEEKBAR, TRUE);
     bConfirmFileDelete = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_CONFIRM_FILE_DELETE, TRUE);
     bShowVolumePercentage = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_SHOW_VOLUME_PERCENTAGE, TRUE);
+    bHistoryInAppData = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_HISTORY_IN_APPDATA, FALSE);
 
     fClosedCaptions = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_CLOSEDCAPTIONS, FALSE);
     {

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -1029,6 +1029,9 @@ public:
     bool bCaptureDeinterlace;
     bool bConfirmFileDelete;
     bool bShowVolumePercentage;
+    // Portable mode: keep the MediaHistory INI and the saved playlist in
+    // %APPDATA%\MPC-HC instead of the player folder (issue #2347 follow-up).
+    bool bHistoryInAppData;
 
     int LastGPUCheck;
     CString gpuid1;

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -193,6 +193,7 @@ void CPPageAdvanced::InitSettings()
         { StrRes(IDS_STARTUP_PRESET_REMEMBER), StrRes(IDS_AG_VIEW_MINIMAL), StrRes(IDS_AG_VIEW_COMPACT), StrRes(IDS_AG_VIEW_NORMAL), StrRes(IDS_AG_VIEW_CUSTOM) },
         StrRes(IDS_PPAGEADVANCED_STARTUP_PRESET));
     addBoolItem(TIME_ON_SEEKBAR_LEFT, IDS_RS_TIME_ON_SEEKBAR_LEFT, false, s.bTimeOnSeekBarLeft, StrRes(IDS_PPAGEADVANCED_TIME_ON_SEEKBAR_LEFT));
+    addBoolItem(HISTORY_IN_APPDATA, IDS_RS_HISTORY_IN_APPDATA, false, s.bHistoryInAppData, L"Store the history file and the saved playlist in %APPDATA%\\MPC-HC instead of the player folder, when settings are stored in an INI file. This also happens automatically when the player folder is not writable. Requires restart.");
 }
 
 BOOL CPPageAdvanced::OnApply()

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -236,6 +236,7 @@ private:
         SHOW_VOLUME_PERCENTAGE,
         STARTUP_PRESET,
         TIME_ON_SEEKBAR_LEFT,
+        HISTORY_IN_APPDATA,
     };
 
     enum {

--- a/src/mpc-hc/PPageMisc.cpp
+++ b/src/mpc-hc/PPageMisc.cpp
@@ -241,7 +241,9 @@ void CPPageMisc::OnExportSettings()
         }
     }
 
-    CString ext = AfxGetMyApp()->IsIniValid() ? _T("ini") : _T("reg");
+    // In INI mode the settings live in two files (settings + MediaHistory), so
+    // they are exported together as a .zip; in registry mode a single .reg.
+    CString ext = AfxGetMyApp()->IsIniValid() ? _T("zip") : _T("reg");
     CFileDialog fileSaveDialog(FALSE, ext, _T("mpc-hc-settings.") + ext);
 
     if (fileSaveDialog.DoModal() == IDOK) {

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1741,7 +1741,7 @@ void CPlayerPlaylistBar::LoadPlaylist(LPCTSTR filename)
 
     m_list.SetRedraw(FALSE);
 
-    if (AfxGetMyApp()->GetAppSavePath(base)) {
+    if (AfxGetMyApp()->GetPlaylistSavePath(base)) {
         CPath p;
         p.Combine(base, _T("default.mpcpl"));
 
@@ -1774,7 +1774,7 @@ void CPlayerPlaylistBar::SavePlaylist(bool can_delay /* = false*/)
 {
     CString base;
 
-    if (AfxGetMyApp()->GetAppSavePath(base)) {
+    if (AfxGetMyApp()->GetPlaylistSavePath(base)) {
         CPath p;
         p.Combine(base, _T("default.mpcpl"));
 

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -30,11 +30,18 @@
 // its old location (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini) untouched so
 // older builds stay downgrade-safe. FIXME: confirm final names with the team.
 // ---------------------------------------------------------------------------
-static const wchar_t* const PROFILE_REG_KEY = L"Software\\MPC-HC\\MPC-HC-settings";
-static const wchar_t* const LEGACY_REG_KEY  = L"Software\\MPC-HC\\MPC-HC"; // pre-versioning MFC key
-static const wchar_t* const NEW_INI_SUFFIX  = L".settings.ini"; // <exe-basename>.settings.ini
-static const wchar_t* const OLD_INI_SUFFIX  = L".ini";          // legacy portable ini
-static const wchar_t* const HISTORY_INI_SUFFIX = L".history.ini"; // separate MediaHistory store
+static const wchar_t* const COMPANY_REG_KEY  = L"Software\\MPC-HC";        // parent of all stores
+static const wchar_t* const LEGACY_REG_KEY   = L"Software\\MPC-HC\\MPC-HC"; // pre-versioning MFC key
+static const wchar_t* const OLD_INI_SUFFIX   = L".ini";                     // legacy portable ini
+static const wchar_t* const INDEX_INI_SUFFIX = L".settings.ini";           // version-independent index/manifest
+
+// Format-versioned store names are built from SETTINGS_FORMAT_VERSION /
+// HISTORY_FORMAT_VERSION so older builds only ever touch their own version's
+// store (Settings-<ver> / History-<ver>).
+static CStringW SettingsRegKey()
+{
+    return CStringW(COMPANY_REG_KEY) + L"\\Settings-" + SETTINGS_FORMAT_VERSION;
+}
 
 // Prefix marking a NEW-format Base64 binary value in an INI. Legacy binary
 // values are A-P encoded (only chars 'A'..'P'), so this lowercase-led prefix
@@ -54,7 +61,7 @@ static CStringW GetExeBasePath()
 
 static CStringW GetNewIniPath()
 {
-    return GetExeBasePath() + NEW_INI_SUFFIX;
+    return GetExeBasePath() + L".settings-" + SETTINGS_FORMAT_VERSION + L".ini";
 }
 
 static CStringW GetLegacyIniPath()
@@ -195,15 +202,14 @@ static bool ReadIniFileIntoMap(const CStringW& iniPath, ProfileMap& map)
 
 CProfile::CProfile()
 {
-    // Prefer a portable INI: the new-format file, or an existing legacy .ini
-    // next to the executable (so upgrading a portable install stays portable).
-    CStringW newIni = GetNewIniPath();
-    if (::PathFileExistsW(newIni)) {
-        m_IniPath = newIni;
-        return;
-    }
-    if (::PathFileExistsW(GetLegacyIniPath())) {
-        m_IniPath = newIni; // portable: write the new-format file alongside the legacy one
+    // Portable if any INI marker exists next to the executable: this version's
+    // settings file, the legacy .ini, or the version-independent index file.
+    // (The index persists portability across format-version bumps.)
+    const CStringW newIni = GetNewIniPath();
+    if (::PathFileExistsW(newIni) ||
+        ::PathFileExistsW(GetLegacyIniPath()) ||
+        ::PathFileExistsW(GetExeBasePath() + INDEX_INI_SUFFIX)) {
+        m_IniPath = newIni; // write this version's file (alongside any legacy one)
         return;
     }
 
@@ -226,79 +232,12 @@ CProfile::~CProfile()
 
 CStringW CProfile::HistoryIniPath()
 {
-    return GetExeBasePath() + HISTORY_INI_SUFFIX;
+    return GetExeBasePath() + L".history-" + HISTORY_FORMAT_VERSION + L".ini";
 }
 
-CStringW CProfile::VersionedIniPath(const CStringW& version)
+CStringW CProfile::SettingsIndexIniPath()
 {
-    if (version.IsEmpty()) {
-        return GetNewIniPath();
-    }
-    return GetExeBasePath() + L"." + version + NEW_INI_SUFFIX;
-}
-
-// Enumerate an open registry key recursively into a ProfileMap, converting each
-// value to the INI textual form CProfile would use (so a registry store can seed
-// an INI fork). `section` is the path built from subkeys ("" at the root).
-static void EnumerateRegistryTree(HKEY hKey, const CStringW& section, ProfileMap& out)
-{
-    if (!section.IsEmpty()) {
-        WCHAR name[512];
-        for (DWORD i = 0;; i++) {
-            DWORD nameLen = _countof(name), type = 0, dataLen = 0;
-            LONG r = RegEnumValueW(hKey, i, name, &nameLen, nullptr, &type, nullptr, &dataLen);
-            if (r == ERROR_NO_MORE_ITEMS) {
-                break;
-            }
-            if (r != ERROR_SUCCESS || dataLen == 0) {
-                continue;
-            }
-            std::vector<BYTE> data(dataLen);
-            DWORD cb = dataLen;
-            if (RegQueryValueExW(hKey, name, nullptr, &type, data.data(), &cb) != ERROR_SUCCESS) {
-                continue;
-            }
-            CStringW val;
-            switch (type) {
-                case REG_DWORD:
-                    if (cb < sizeof(DWORD)) continue;
-                    val.Format(L"%d", static_cast<int>(*reinterpret_cast<DWORD*>(data.data())));
-                    break;
-                case REG_QWORD:
-                    if (cb < sizeof(ULONGLONG)) continue;
-                    val.Format(L"%I64d", *reinterpret_cast<ULONGLONG*>(data.data()));
-                    break;
-                case REG_SZ:
-                case REG_EXPAND_SZ:
-                    val = reinterpret_cast<LPCWSTR>(data.data());
-                    break;
-                case REG_BINARY:
-                    val = CStringW(BINARY_B64_PREFIX) + BinaryToBase64(data.data(), cb);
-                    break;
-                default:
-                    continue;
-            }
-            out[section][name] = val;
-        }
-    }
-
-    WCHAR sub[256];
-    for (DWORD i = 0;; i++) {
-        DWORD subLen = _countof(sub);
-        LONG r = RegEnumKeyExW(hKey, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
-        if (r == ERROR_NO_MORE_ITEMS) {
-            break;
-        }
-        if (r != ERROR_SUCCESS) {
-            continue;
-        }
-        HKEY hSub;
-        if (RegOpenKeyExW(hKey, sub, 0, KEY_READ, &hSub) == ERROR_SUCCESS) {
-            CStringW child = section.IsEmpty() ? CStringW(sub) : (section + L"\\" + sub);
-            EnumerateRegistryTree(hSub, child, out);
-            RegCloseKey(hSub);
-        }
-    }
+    return GetExeBasePath() + INDEX_INI_SUFFIX;
 }
 
 LONG CProfile::OpenRegistryKey()
@@ -307,7 +246,7 @@ LONG CProfile::OpenRegistryKey()
 
     if (!m_hAppRegKey) {
         DWORD dwDisposition = 0;
-        lResult = RegCreateKeyExW(HKEY_CURRENT_USER, PROFILE_REG_KEY, 0, nullptr, 0,
+        lResult = RegCreateKeyExW(HKEY_CURRENT_USER, SettingsRegKey(), 0, nullptr, 0,
                                   KEY_READ | KEY_WRITE, nullptr, &m_hAppRegKey, &dwDisposition);
         ASSERT(lResult == ERROR_SUCCESS);
     }
@@ -1205,50 +1144,7 @@ bool CProfile::HasEntry(const wchar_t* section, const wchar_t* entry)
 
 CStringW CProfile::GetRegistryKeyPath() const
 {
-    return m_hAppRegKey ? CStringW(PROFILE_REG_KEY) : CStringW();
-}
-
-bool CProfile::ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent)
-{
-    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
-
-    // Capture the current store's contents first (if seeding a new fork).
-    ProfileMap seed;
-    if (seedFromCurrent) {
-        if (m_hAppRegKey) {
-            EnumerateRegistryTree(m_hAppRegKey, CStringW(), seed); // registry -> INI form
-        } else {
-            InitIni();
-            seed = m_ProfileMap; // already INI form (verbatim, incl. b64: values)
-        }
-    }
-
-    if (m_hAppRegKey) {
-        RegCloseKey(m_hAppRegKey); // detach only; the shared registry store is left intact
-        m_hAppRegKey = nullptr;
-    }
-
-    m_IniPath = iniPath;
-    m_ProfileMap.clear();
-    m_bIniFirstInit = false; // force InitIni() to (re)read the local file if present
-    m_bIniNeedFlush = false;
-    InitIni();
-
-    if (seedFromCurrent && !seed.empty()) {
-        // Fill in from the seed without overwriting anything already in an
-        // existing fork file.
-        for (const auto& sec : seed) {
-            for (const auto& kv : sec.second) {
-                auto& dst = m_ProfileMap[sec.first];
-                if (dst.find(kv.first) == dst.end()) {
-                    dst[kv.first] = kv.second;
-                    m_bIniNeedFlush = true;
-                }
-            }
-        }
-    }
-
-    return true;
+    return m_hAppRegKey ? SettingsRegKey() : CStringW();
 }
 
 SettingsLocation CProfile::GetSettingsLocation() const

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -1050,6 +1050,51 @@ void CProfile::Clear()
     m_bIniNeedFlush = false;
 }
 
+// Recursively copy a registry key's values and subkeys from src to dst,
+// preserving native value types. Unlike RegCopyTree it does NOT copy security
+// descriptors, so it works with a dst handle opened only for KEY_READ|KEY_WRITE
+// (RegCopyTree needs WRITE_DAC to clone the DACL and fails with ACCESS_DENIED).
+static void CopyRegistryTree(HKEY src, HKEY dst)
+{
+    // Values at this level.
+    for (DWORD i = 0;; i++) {
+        WCHAR name[512];
+        DWORD nameLen = _countof(name), type = 0, dataLen = 0;
+        LONG r = RegEnumValueW(src, i, name, &nameLen, nullptr, &type, nullptr, &dataLen);
+        if (r == ERROR_NO_MORE_ITEMS) {
+            break;
+        }
+        if (r != ERROR_SUCCESS) {
+            continue; // e.g. name too long; skip
+        }
+        std::vector<BYTE> data(dataLen ? dataLen : 1);
+        DWORD cb = dataLen;
+        if (RegQueryValueExW(src, name, nullptr, &type, data.data(), &cb) == ERROR_SUCCESS) {
+            RegSetValueExW(dst, name, 0, type, data.data(), cb);
+        }
+    }
+    // Subkeys.
+    for (DWORD i = 0;; i++) {
+        WCHAR sub[256];
+        DWORD subLen = _countof(sub);
+        LONG r = RegEnumKeyExW(src, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
+        if (r == ERROR_NO_MORE_ITEMS) {
+            break;
+        }
+        if (r != ERROR_SUCCESS) {
+            continue;
+        }
+        HKEY hSrcSub, hDstSub;
+        if (RegOpenKeyExW(src, sub, 0, KEY_READ, &hSrcSub) == ERROR_SUCCESS) {
+            if (RegCreateKeyExW(dst, sub, 0, nullptr, 0, KEY_READ | KEY_WRITE, nullptr, &hDstSub, nullptr) == ERROR_SUCCESS) {
+                CopyRegistryTree(hSrcSub, hDstSub);
+                RegCloseKey(hDstSub);
+            }
+            RegCloseKey(hSrcSub);
+        }
+    }
+}
+
 bool CProfile::MigrateFromLegacy()
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
@@ -1061,9 +1106,9 @@ bool CProfile::MigrateFromLegacy()
         if (ERROR_SUCCESS != RegOpenKeyExW(HKEY_CURRENT_USER, LEGACY_REG_KEY, 0, KEY_READ, &hLegacy)) {
             return false;
         }
-        LONG res = RegCopyTreeW(hLegacy, nullptr, m_hAppRegKey);
+        CopyRegistryTree(hLegacy, m_hAppRegKey);
         RegCloseKey(hLegacy);
-        return res == ERROR_SUCCESS;
+        return true;
     }
 
     // INI: parse the legacy <exe>.ini verbatim into the (new) map, then flush

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -22,13 +22,13 @@
 #include "Profile.h"
 #include "FileHandle.h" // GetModulePath
 #include "Utils.h"      // StrToInt32/UInt32/Int64/Double, StrHexToUInt32
-#include "text.h"       // StartsWith
+#include "text.h"       // StartsWithNoCase
 #include "base64/base64.h"
 
 // ---------------------------------------------------------------------------
-// NEW-format store names. These live ALONGSIDE the legacy store, which keeps
-// its old location (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini) untouched so
-// older builds stay downgrade-safe. FIXME: confirm final names with the team.
+// Versioned store names. These live ALONGSIDE the legacy store, which keeps its
+// old location (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini) untouched so older
+// builds stay downgrade-safe.
 // ---------------------------------------------------------------------------
 static const wchar_t* const COMPANY_REG_KEY  = L"Software\\MPC-HC";        // parent of all stores
 static const wchar_t* const LEGACY_REG_KEY   = L"Software\\MPC-HC\\MPC-HC"; // pre-versioning MFC key
@@ -911,16 +911,20 @@ void CProfile::EnumSectionNames(const wchar_t* section, std::vector<CStringW>& s
         CStringW prefix(section);
         prefix += L'\\';
 
+        // The map is ordered case-insensitively (IgnoreCaseLess), so prefix
+        // matches are contiguous only when compared case-insensitively.
         auto it = m_ProfileMap.cbegin();
-        while (it != m_ProfileMap.cend() && !StartsWith(it->first, prefix)) {
+        while (it != m_ProfileMap.cend() && !StartsWithNoCase(it->first, prefix)) {
             ++it;
         }
 
-        while (it != m_ProfileMap.cend() && StartsWith(it->first, prefix)) {
-            if (it->first.GetLength() > prefix.GetLength()) {
-                sectionnames.emplace_back(it->first.Mid(prefix.GetLength()));
+        for (; it != m_ProfileMap.cend() && StartsWithNoCase(it->first, prefix); ++it) {
+            CStringW child = it->first.Mid(prefix.GetLength());
+            // Immediate children only, matching the registry branch and the
+            // original GetSectionSubKeys semantics (skip deeper "a\b").
+            if (!child.IsEmpty() && child.Find(L'\\') == -1) {
+                sectionnames.emplace_back(child);
             }
-            ++it;
         }
     }
 }
@@ -972,20 +976,18 @@ bool CProfile::DeleteSection(const wchar_t* section)
         const CStringW mainsection(section);
         const CStringW prefix(mainsection + L'\\');
 
-        auto start = m_ProfileMap.cbegin();
-        while (start != m_ProfileMap.cend() && start->first != mainsection && !StartsWith(start->first, prefix)) {
-            ++start;
-        }
-
-        if (start != m_ProfileMap.cend()) {
-            auto end = std::next(start);
-            while (end != m_ProfileMap.cend() && StartsWith(end->first, prefix)) {
-                ++end;
+        // Erase the section and every subsection. Iterate-and-erase rather than a
+        // contiguous range: a sibling like "Foo0" can sort between "Foo" and
+        // "Foo\bar" under case-insensitive ordering, so the matches are not
+        // guaranteed contiguous.
+        for (auto it = m_ProfileMap.begin(); it != m_ProfileMap.end();) {
+            if (it->first.CompareNoCase(mainsection) == 0 || StartsWithNoCase(it->first, prefix)) {
+                it = m_ProfileMap.erase(it);
+                m_bIniNeedFlush = true;
+                ret = true;
+            } else {
+                ++it;
             }
-
-            m_ProfileMap.erase(start, end);
-            m_bIniNeedFlush = true;
-            ret = true;
         }
     }
 
@@ -1063,30 +1065,48 @@ void CProfile::Clear()
 // preserving native value types. Unlike RegCopyTree it does NOT copy security
 // descriptors, so it works with a dst handle opened only for KEY_READ|KEY_WRITE
 // (RegCopyTree needs WRITE_DAC to clone the DACL and fails with ACCESS_DENIED).
+// Buffer sizes (in WCHARs, incl. NUL) for enumerating a key's value and subkey
+// names, from RegQueryInfoKey. Registry value names can be up to 16383 chars and
+// key names up to 255, so fixed buffers would silently drop long names.
+static void RegNameBufferSizes(HKEY key, DWORD& valueNameChars, DWORD& subKeyNameChars)
+{
+    DWORD maxValueName = 0, maxSubKeyName = 0;
+    if (RegQueryInfoKeyW(key, nullptr, nullptr, nullptr, nullptr, &maxSubKeyName,
+                         nullptr, nullptr, &maxValueName, nullptr, nullptr, nullptr) != ERROR_SUCCESS) {
+        maxValueName = 16383;
+        maxSubKeyName = 255;
+    }
+    valueNameChars = maxValueName + 1;
+    subKeyNameChars = maxSubKeyName + 1;
+}
+
 static void CopyRegistryTree(HKEY src, HKEY dst)
 {
+    DWORD valueNameChars, subKeyNameChars;
+    RegNameBufferSizes(src, valueNameChars, subKeyNameChars);
+    std::vector<WCHAR> name(valueNameChars);
+    std::vector<WCHAR> sub(subKeyNameChars);
+
     // Values at this level.
     for (DWORD i = 0;; i++) {
-        WCHAR name[512];
-        DWORD nameLen = _countof(name), type = 0, dataLen = 0;
-        LONG r = RegEnumValueW(src, i, name, &nameLen, nullptr, &type, nullptr, &dataLen);
+        DWORD nameLen = static_cast<DWORD>(name.size()), type = 0, dataLen = 0;
+        LONG r = RegEnumValueW(src, i, name.data(), &nameLen, nullptr, &type, nullptr, &dataLen);
         if (r == ERROR_NO_MORE_ITEMS) {
             break;
         }
         if (r != ERROR_SUCCESS) {
-            continue; // e.g. name too long; skip
+            continue;
         }
         std::vector<BYTE> data(dataLen ? dataLen : 1);
         DWORD cb = dataLen;
-        if (RegQueryValueExW(src, name, nullptr, &type, data.data(), &cb) == ERROR_SUCCESS) {
-            RegSetValueExW(dst, name, 0, type, data.data(), cb);
+        if (RegQueryValueExW(src, name.data(), nullptr, &type, data.data(), &cb) == ERROR_SUCCESS) {
+            RegSetValueExW(dst, name.data(), 0, type, data.data(), cb);
         }
     }
     // Subkeys.
     for (DWORD i = 0;; i++) {
-        WCHAR sub[256];
-        DWORD subLen = _countof(sub);
-        LONG r = RegEnumKeyExW(src, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
+        DWORD subLen = static_cast<DWORD>(sub.size());
+        LONG r = RegEnumKeyExW(src, i, sub.data(), &subLen, nullptr, nullptr, nullptr, nullptr);
         if (r == ERROR_NO_MORE_ITEMS) {
             break;
         }
@@ -1094,8 +1114,8 @@ static void CopyRegistryTree(HKEY src, HKEY dst)
             continue;
         }
         HKEY hSrcSub, hDstSub;
-        if (RegOpenKeyExW(src, sub, 0, KEY_READ, &hSrcSub) == ERROR_SUCCESS) {
-            if (RegCreateKeyExW(dst, sub, 0, nullptr, 0, KEY_READ | KEY_WRITE, nullptr, &hDstSub, nullptr) == ERROR_SUCCESS) {
+        if (RegOpenKeyExW(src, sub.data(), 0, KEY_READ, &hSrcSub) == ERROR_SUCCESS) {
+            if (RegCreateKeyExW(dst, sub.data(), 0, nullptr, 0, KEY_READ | KEY_WRITE, nullptr, &hDstSub, nullptr) == ERROR_SUCCESS) {
                 CopyRegistryTree(hSrcSub, hDstSub);
                 RegCloseKey(hDstSub);
             }
@@ -1170,6 +1190,55 @@ bool CProfile::SeedFromVersion(const CStringW& fromVersion)
     m_bIniNeedFlush = true;
     Flush(true);
     return true;
+}
+
+void CProfile::EnumSettingsStoreVersions(std::vector<CStringW>& versions)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+    versions.clear();
+
+    if (m_hAppRegKey) {
+        CRegKey parent;
+        if (parent.Open(HKEY_CURRENT_USER, COMPANY_REG_KEY, KEY_READ) == ERROR_SUCCESS) {
+            const CStringW pfx(L"Settings-");
+            WCHAR sub[256];
+            for (DWORD i = 0;; i++) {
+                DWORD subLen = _countof(sub); // key names are <= 255 chars
+                LONG r = RegEnumKeyExW(parent.m_hKey, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
+                if (r == ERROR_NO_MORE_ITEMS) {
+                    break;
+                }
+                if (r != ERROR_SUCCESS) {
+                    continue;
+                }
+                CStringW name(sub);
+                if (name.GetLength() > pfx.GetLength() && name.Left(pfx.GetLength()) == pfx) {
+                    versions.emplace_back(name.Mid(pfx.GetLength()));
+                }
+            }
+            parent.Close();
+        }
+    } else {
+        // <exe>.settings-<ver>.ini (the dash distinguishes it from the
+        // version-independent <exe>.settings.ini index file).
+        const CStringW pattern = GetExeBasePath() + L".settings-*.ini";
+        WIN32_FIND_DATAW fd;
+        HANDLE h = FindFirstFileW(pattern, &fd);
+        if (h != INVALID_HANDLE_VALUE) {
+            do {
+                CStringW fn(fd.cFileName);
+                int a = fn.Find(L".settings-");
+                if (a >= 0) {
+                    CStringW rest = fn.Mid(a + 10); // after ".settings-"
+                    int b = rest.ReverseFind(L'.'); // strip ".ini"
+                    if (b > 0) {
+                        versions.emplace_back(rest.Left(b));
+                    }
+                }
+            } while (FindNextFileW(h, &fd));
+            FindClose(h);
+        }
+    }
 }
 
 void CProfile::MoveSectionTree(const wchar_t* root, CProfile& dst)

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -26,25 +26,19 @@
 #include "base64/base64.h"
 
 // ---------------------------------------------------------------------------
-// Versioned store names. These live ALONGSIDE the legacy store, which keeps its
-// old location (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini) untouched so older
-// builds stay downgrade-safe.
+// Store location. MPC-HC keeps its historical settings location so external
+// tools (e.g. madVR) and older builds keep reading it: the HKCU registry key
+// below, or <exe-basename>.ini next to the executable in portable mode. Only
+// MediaHistory is relocated, into <exe-basename>.history.ini (portable mode).
 // ---------------------------------------------------------------------------
-// The on-disk format version is NOT in the store name; each store records it in
-// a [Version] Format field. The new stores live ALONGSIDE the pre-versioning
-// legacy store (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini), which is untouched.
-static const wchar_t* const LEGACY_REG_KEY     = L"Software\\MPC-HC\\MPC-HC";   // pre-versioning MFC key
-static const wchar_t* const SETTINGS_REG_KEY   = L"Software\\MPC-HC\\Settings"; // format in [Version]Format
-static const wchar_t* const OLD_INI_SUFFIX     = L".ini";                       // legacy portable ini
-static const wchar_t* const NEW_INI_SUFFIX     = L".settings.ini";             // <exe-basename>.settings.ini
-static const wchar_t* const HISTORY_INI_SUFFIX = L".history.ini";              // <exe-basename>.history.ini
-// Downgrade-fork files carry THIS build's format version in the name, so two
-// different older builds forking from the same newer store don't collide and
-// each file is self-identifying: <exe>.settings.<ver>.local.ini / .history.<ver>.local.ini
+static const wchar_t* const REG_KEY            = L"Software\\MPC-HC\\MPC-HC"; // HKCU settings key
+static const wchar_t* const INI_SUFFIX         = L".ini";                     // <exe-basename>.ini (portable)
+static const wchar_t* const HISTORY_INI_SUFFIX = L".history.ini";            // <exe-basename>.history.ini
 
-// Prefix marking a NEW-format Base64 binary value in an INI. Legacy binary
-// values are A-P encoded (only chars 'A'..'P'), so this lowercase-led prefix
-// can never collide with a legacy value -> ReadBinary disambiguates by it.
+// Binary INI values are written in the legacy A-P encoding (two chars 'A'..'P'
+// per byte) so the file stays byte-compatible with what stock MPC-HC builds
+// read and write. A "b64:"-prefixed Base64 form is still accepted on read for
+// forward-compatibility, but never written.
 static const wchar_t* const BINARY_B64_PREFIX = L"b64:";
 
 static CStringW GetExeBasePath()
@@ -58,29 +52,13 @@ static CStringW GetExeBasePath()
     return path;
 }
 
-static CStringW GetNewIniPath()
+static CStringW GetIniFilePath()
 {
-    return GetExeBasePath() + NEW_INI_SUFFIX;
-}
-static CStringW GetLocalIniPath()
-{
-    return GetExeBasePath() + L".settings." + SETTINGS_FORMAT_VERSION + L".local.ini";
-}
-
-static CStringW GetLegacyIniPath()
-{
-    return GetExeBasePath() + OLD_INI_SUFFIX;
+    return GetExeBasePath() + INI_SUFFIX;
 }
 
 // Base64 helpers bridging BYTE[] <-> CStringW using the ASCII Base64 codec
 // in include/base64/base64.h.
-static CStringW BinaryToBase64(const BYTE* pdata, unsigned nbytes)
-{
-    std::string bytes(reinterpret_cast<const char*>(pdata), nbytes);
-    std::string b64 = Base64::encode(bytes);
-    return CStringW(CStringA(b64.c_str(), static_cast<int>(b64.size())));
-}
-
 static unsigned Base64ToBinary(const CStringW& str, BYTE** ppdata)
 {
     *ppdata = nullptr;
@@ -125,6 +103,23 @@ static unsigned APToBinary(const CStringW& valueStr, BYTE** ppdata)
         (*ppdata)[i] = BYTE((valueStr[i * 2] - L'A') | ((valueStr[i * 2 + 1] - L'A') << 4));
     }
     return nbytes;
+}
+
+// Encode bytes in the legacy A-P form (inverse of APToBinary): two chars
+// 'A'..'P' per byte, low nibble first. Matches stock MPC-HC's INI binary format
+// exactly, so old builds read our binary values unchanged.
+static CStringW BinaryToAP(const BYTE* pdata, unsigned nbytes)
+{
+    CStringW out;
+    if (nbytes) {
+        wchar_t* buf = out.GetBuffer(static_cast<int>(nbytes) * 2);
+        for (unsigned i = 0; i < nbytes; i++) {
+            buf[i * 2]     = wchar_t(L'A' + (pdata[i] & 0x0F));
+            buf[i * 2 + 1] = wchar_t(L'A' + ((pdata[i] >> 4) & 0x0F));
+        }
+        out.ReleaseBuffer(static_cast<int>(nbytes) * 2);
+    }
+    return out;
 }
 
 // Open and parse an INI file (BOM-sniffing UNICODE, falling back to ANSI) into
@@ -205,10 +200,10 @@ static bool ReadIniFileIntoMap(const CStringW& iniPath, ProfileMap& map)
 
 CProfile::CProfile()
 {
-    // Portable if a settings INI (new or legacy) exists next to the executable.
-    const CStringW newIni = GetNewIniPath();
-    if (::PathFileExistsW(newIni) || ::PathFileExistsW(GetLegacyIniPath())) {
-        m_IniPath = newIni; // write the new-format file (alongside any legacy one)
+    // Portable if <exe-basename>.ini exists next to the executable.
+    const CStringW iniPath = GetIniFilePath();
+    if (::PathFileExistsW(iniPath)) {
+        m_IniPath = iniPath;
         return;
     }
 
@@ -236,19 +231,9 @@ CStringW CProfile::HistoryIniPath()
     return GetExeBasePath() + HISTORY_INI_SUFFIX;
 }
 
-CStringW CProfile::HistoryLocalIniPath()
-{
-    return GetExeBasePath() + L".history." + HISTORY_FORMAT_VERSION + L".local.ini";
-}
-
 CStringW CProfile::DefaultIniPath()
 {
-    return GetNewIniPath();
-}
-
-CStringW CProfile::LocalIniPath()
-{
-    return GetLocalIniPath();
+    return GetIniFilePath();
 }
 
 LONG CProfile::OpenRegistryKey()
@@ -257,7 +242,7 @@ LONG CProfile::OpenRegistryKey()
 
     if (!m_hAppRegKey) {
         DWORD dwDisposition = 0;
-        lResult = RegCreateKeyExW(HKEY_CURRENT_USER, SETTINGS_REG_KEY, 0, nullptr, 0,
+        lResult = RegCreateKeyExW(HKEY_CURRENT_USER, REG_KEY, 0, nullptr, 0,
                                   KEY_READ | KEY_WRITE, nullptr, &m_hAppRegKey, &dwDisposition);
         ASSERT(lResult == ERROR_SUCCESS);
     }
@@ -328,7 +313,7 @@ bool CProfile::StoreSettingsTo(const SettingsLocation newLocation)
         m_bRegistryMode = false;
     }
 
-    const CStringW newIniPath = GetNewIniPath();
+    const CStringW newIniPath = GetIniFilePath();
     CFile file;
     if (file.Open(newIniPath, CFile::modeWrite | CFile::modeCreate | CFile::modeNoTruncate)) {
         file.Close();
@@ -844,9 +829,10 @@ bool CProfile::WriteBinary(const wchar_t* section, const wchar_t* entry, const B
             regkey.Close();
         }
     } else {
-        CStringW base64 = BinaryToBase64(pdata, nbytes);
-        if (!base64.IsEmpty()) {
-            CStringW value = BINARY_B64_PREFIX + base64;
+        // Write in the legacy A-P form so the INI stays byte-compatible with
+        // stock MPC-HC builds (which read/write binary values this way).
+        CStringW value = BinaryToAP(pdata, nbytes);
+        if (!value.IsEmpty()) {
             InitIni();
             CStringW& old = m_ProfileMap[section][entry];
             if (old != value) {
@@ -1089,224 +1075,6 @@ void CProfile::Clear()
     m_bIniNeedFlush = false;
 }
 
-// Recursively copy a registry key's values and subkeys from src to dst,
-// preserving native value types. Unlike RegCopyTree it does NOT copy security
-// descriptors, so it works with a dst handle opened only for KEY_READ|KEY_WRITE
-// (RegCopyTree needs WRITE_DAC to clone the DACL and fails with ACCESS_DENIED).
-// Buffer sizes (in WCHARs, incl. NUL) for enumerating a key's value and subkey
-// names, from RegQueryInfoKey. Registry value names can be up to 16383 chars and
-// key names up to 255, so fixed buffers would silently drop long names.
-static void RegNameBufferSizes(HKEY key, DWORD& valueNameChars, DWORD& subKeyNameChars)
-{
-    DWORD maxValueName = 0, maxSubKeyName = 0;
-    if (RegQueryInfoKeyW(key, nullptr, nullptr, nullptr, nullptr, &maxSubKeyName,
-                         nullptr, nullptr, &maxValueName, nullptr, nullptr, nullptr) != ERROR_SUCCESS) {
-        maxValueName = 16383;
-        maxSubKeyName = 255;
-    }
-    valueNameChars = maxValueName + 1;
-    subKeyNameChars = maxSubKeyName + 1;
-}
-
-static void CopyRegistryTree(HKEY src, HKEY dst)
-{
-    DWORD valueNameChars, subKeyNameChars;
-    RegNameBufferSizes(src, valueNameChars, subKeyNameChars);
-    std::vector<WCHAR> name(valueNameChars);
-    std::vector<WCHAR> sub(subKeyNameChars);
-
-    // Values at this level.
-    for (DWORD i = 0;; i++) {
-        DWORD nameLen = static_cast<DWORD>(name.size()), type = 0, dataLen = 0;
-        LONG r = RegEnumValueW(src, i, name.data(), &nameLen, nullptr, &type, nullptr, &dataLen);
-        if (r == ERROR_NO_MORE_ITEMS) {
-            break;
-        }
-        if (r != ERROR_SUCCESS) {
-            continue;
-        }
-        std::vector<BYTE> data(dataLen ? dataLen : 1);
-        DWORD cb = dataLen;
-        if (RegQueryValueExW(src, name.data(), nullptr, &type, data.data(), &cb) == ERROR_SUCCESS) {
-            RegSetValueExW(dst, name.data(), 0, type, data.data(), cb);
-        }
-    }
-    // Subkeys.
-    for (DWORD i = 0;; i++) {
-        DWORD subLen = static_cast<DWORD>(sub.size());
-        LONG r = RegEnumKeyExW(src, i, sub.data(), &subLen, nullptr, nullptr, nullptr, nullptr);
-        if (r == ERROR_NO_MORE_ITEMS) {
-            break;
-        }
-        if (r != ERROR_SUCCESS) {
-            continue;
-        }
-        HKEY hSrcSub, hDstSub;
-        if (RegOpenKeyExW(src, sub.data(), 0, KEY_READ, &hSrcSub) == ERROR_SUCCESS) {
-            if (RegCreateKeyExW(dst, sub.data(), 0, nullptr, 0, KEY_READ | KEY_WRITE, nullptr, &hDstSub, nullptr) == ERROR_SUCCESS) {
-                CopyRegistryTree(hSrcSub, hDstSub);
-                RegCloseKey(hDstSub);
-            }
-            RegCloseKey(hSrcSub);
-        }
-    }
-}
-
-// Enumerate a registry key recursively into a ProfileMap, converting each value
-// to the INI textual form CProfile uses (so a registry store can seed an INI
-// fork). `section` is the path built from subkeys ("" at the root).
-static void EnumerateRegistryTreeToMap(HKEY hKey, const CStringW& section, ProfileMap& out)
-{
-    DWORD valueNameChars, subKeyNameChars;
-    RegNameBufferSizes(hKey, valueNameChars, subKeyNameChars);
-    std::vector<WCHAR> name(valueNameChars);
-    std::vector<WCHAR> sub(subKeyNameChars);
-
-    if (!section.IsEmpty()) {
-        for (DWORD i = 0;; i++) {
-            DWORD nameLen = static_cast<DWORD>(name.size()), type = 0, dataLen = 0;
-            LONG r = RegEnumValueW(hKey, i, name.data(), &nameLen, nullptr, &type, nullptr, &dataLen);
-            if (r == ERROR_NO_MORE_ITEMS) {
-                break;
-            }
-            if (r != ERROR_SUCCESS || dataLen == 0) {
-                continue;
-            }
-            std::vector<BYTE> data(dataLen);
-            DWORD cb = dataLen;
-            if (RegQueryValueExW(hKey, name.data(), nullptr, &type, data.data(), &cb) != ERROR_SUCCESS) {
-                continue;
-            }
-            CStringW val;
-            switch (type) {
-                case REG_DWORD:
-                    if (cb < sizeof(DWORD)) continue;
-                    val.Format(L"%d", static_cast<int>(*reinterpret_cast<DWORD*>(data.data())));
-                    break;
-                case REG_QWORD:
-                    if (cb < sizeof(ULONGLONG)) continue;
-                    val.Format(L"%I64d", *reinterpret_cast<ULONGLONG*>(data.data()));
-                    break;
-                case REG_SZ:
-                case REG_EXPAND_SZ:
-                    val = CStringW(reinterpret_cast<LPCWSTR>(data.data()), static_cast<int>(cb / sizeof(WCHAR)));
-                    { int nul = val.Find(L'\0'); if (nul >= 0) val.Truncate(nul); }
-                    break;
-                case REG_BINARY:
-                    val = CStringW(BINARY_B64_PREFIX) + BinaryToBase64(data.data(), cb);
-                    break;
-                default:
-                    continue;
-            }
-            out[section][name.data()] = val;
-        }
-    }
-
-    for (DWORD i = 0;; i++) {
-        DWORD subLen = static_cast<DWORD>(sub.size());
-        LONG r = RegEnumKeyExW(hKey, i, sub.data(), &subLen, nullptr, nullptr, nullptr, nullptr);
-        if (r == ERROR_NO_MORE_ITEMS) {
-            break;
-        }
-        if (r != ERROR_SUCCESS) {
-            continue;
-        }
-        HKEY hSub;
-        if (RegOpenKeyExW(hKey, sub.data(), 0, KEY_READ, &hSub) == ERROR_SUCCESS) {
-            CStringW child = section.IsEmpty() ? CStringW(sub.data()) : (section + L"\\" + sub.data());
-            EnumerateRegistryTreeToMap(hSub, child, out);
-            RegCloseKey(hSub);
-        }
-    }
-}
-
-bool CProfile::MigrateFromLegacy()
-{
-    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
-
-    if (m_bRegistryMode) {
-        // Registry: recursively copy the legacy MFC key into the new key,
-        // preserving native value types (REG_DWORD/REG_SZ/REG_BINARY/...).
-        HKEY hLegacy = nullptr;
-        if (ERROR_SUCCESS != RegOpenKeyExW(HKEY_CURRENT_USER, LEGACY_REG_KEY, 0, KEY_READ, &hLegacy)) {
-            return false;
-        }
-        OpenRegistryKey();
-        CopyRegistryTree(hLegacy, m_hAppRegKey);
-        RegCloseKey(hLegacy);
-        return true;
-    }
-
-    // INI: parse the legacy <exe>.ini verbatim into the (new) map, then flush
-    // it to the new file. Old A-P binary values are read back later via the
-    // un-prefixed path in ReadBinary().
-    const CStringW legacyIni = GetLegacyIniPath();
-    if (legacyIni.CompareNoCase(m_IniPath) == 0) {
-        return false; // defensive: never import a file onto itself
-    }
-    ProfileMap legacyMap;
-    if (!ReadIniFileIntoMap(legacyIni, legacyMap)) {
-        return false;
-    }
-
-    InitIni(); // ensure the (new, likely empty) map is loaded before merging
-    for (const auto& sec : legacyMap) {
-        for (const auto& kv : sec.second) {
-            m_ProfileMap[sec.first][kv.first] = kv.second;
-        }
-    }
-    m_bIniNeedFlush = true;
-    Flush(true);
-    return true;
-}
-
-bool CProfile::ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent)
-{
-    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
-
-    // Capture the current store's contents first (if seeding a fresh fork).
-    ProfileMap seed;
-    if (seedFromCurrent) {
-        if (m_bRegistryMode) {
-            OpenRegistryKey();
-            if (m_hAppRegKey) {
-                EnumerateRegistryTreeToMap(m_hAppRegKey, CStringW(), seed);
-            }
-        } else {
-            InitIni();
-            seed = m_ProfileMap;
-        }
-    }
-
-    // Detach from the shared store WITHOUT deleting it (the newer store survives).
-    if (m_hAppRegKey) {
-        RegCloseKey(m_hAppRegKey);
-        m_hAppRegKey = nullptr;
-    }
-    m_bRegistryMode = false;
-    m_IniPath = iniPath;
-    m_ProfileMap.clear();
-    m_bIniFirstInit = false; // force InitIni() to (re)read the local file if present
-    m_bIniNeedFlush = false;
-    InitIni();
-
-    // Fill in from the seed without overwriting anything already in an existing
-    // local fork file.
-    if (seedFromCurrent && !seed.empty()) {
-        for (const auto& sec : seed) {
-            for (const auto& kv : sec.second) {
-                auto& dst = m_ProfileMap[sec.first];
-                if (dst.find(kv.first) == dst.end()) {
-                    dst[kv.first] = kv.second;
-                    m_bIniNeedFlush = true;
-                }
-            }
-        }
-    }
-
-    return true;
-}
-
 void CProfile::MoveSectionTree(const wchar_t* root, CProfile& dst)
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
@@ -1363,7 +1131,7 @@ bool CProfile::HasEntry(const wchar_t* section, const wchar_t* entry)
 
 CStringW CProfile::GetRegistryKeyPath() const
 {
-    return m_bRegistryMode ? CStringW(SETTINGS_REG_KEY) : CStringW();
+    return m_bRegistryMode ? CStringW(REG_KEY) : CStringW();
 }
 
 SettingsLocation CProfile::GetSettingsLocation() const

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -1,0 +1,1093 @@
+/*
+ * (C) 2024 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "Profile.h"
+#include "FileHandle.h" // GetModulePath
+#include "Utils.h"      // StrToInt32/UInt32/Int64/Double, StrHexToUInt32
+#include "text.h"       // StartsWith
+#include "base64/base64.h"
+
+// ---------------------------------------------------------------------------
+// NEW-format store names. These live ALONGSIDE the legacy store, which keeps
+// its old location (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini) untouched so
+// older builds stay downgrade-safe. FIXME: confirm final names with the team.
+// ---------------------------------------------------------------------------
+static const wchar_t* const PROFILE_REG_KEY = L"Software\\MPC-HC\\MPC-HC-settings";
+static const wchar_t* const LEGACY_REG_KEY  = L"Software\\MPC-HC\\MPC-HC"; // pre-versioning MFC key
+static const wchar_t* const NEW_INI_SUFFIX  = L".settings.ini"; // <exe-basename>.settings.ini
+static const wchar_t* const OLD_INI_SUFFIX  = L".ini";          // legacy portable ini
+
+// Prefix marking a NEW-format Base64 binary value in an INI. Legacy binary
+// values are A-P encoded (only chars 'A'..'P'), so this lowercase-led prefix
+// can never collide with a legacy value -> ReadBinary disambiguates by it.
+static const wchar_t* const BINARY_B64_PREFIX = L"b64:";
+
+static CStringW GetExeBasePath()
+{
+    // Full path of the executable with the extension stripped.
+    CStringW path = GetModulePath(nullptr);
+    int dot = path.ReverseFind(L'.');
+    if (dot >= 0) {
+        path = path.Left(dot);
+    }
+    return path;
+}
+
+static CStringW GetNewIniPath()
+{
+    return GetExeBasePath() + NEW_INI_SUFFIX;
+}
+
+static CStringW GetLegacyIniPath()
+{
+    return GetExeBasePath() + OLD_INI_SUFFIX;
+}
+
+// Base64 helpers bridging BYTE[] <-> CStringW using the ASCII Base64 codec
+// in include/base64/base64.h.
+static CStringW BinaryToBase64(const BYTE* pdata, unsigned nbytes)
+{
+    std::string bytes(reinterpret_cast<const char*>(pdata), nbytes);
+    std::string b64 = Base64::encode(bytes);
+    return CStringW(CStringA(b64.c_str(), static_cast<int>(b64.size())));
+}
+
+static unsigned Base64ToBinary(const CStringW& str, BYTE** ppdata)
+{
+    *ppdata = nullptr;
+    if (str.IsEmpty()) {
+        return 0;
+    }
+    CStringA ascii(str); // Base64 is pure ASCII
+    std::string decoded = Base64::decode(std::string(ascii.GetString(), ascii.GetLength()));
+    unsigned nbytes = static_cast<unsigned>(decoded.size());
+    if (nbytes == 0) {
+        return 0;
+    }
+    *ppdata = new (std::nothrow) BYTE[nbytes];
+    if (!*ppdata) {
+        return 0;
+    }
+    memcpy(*ppdata, decoded.data(), nbytes);
+    return nbytes;
+}
+
+// Legacy A-P binary decoding (each byte = 2 chars 'A'..'P', low nibble first),
+// as written by the old CMPlayerCApp::WriteProfileBinary. Used only to read
+// values imported verbatim from a legacy INI; deletable at the legacy sunset.
+static unsigned APToBinary(const CStringW& valueStr, BYTE** ppdata)
+{
+    *ppdata = nullptr;
+    const int length = valueStr.GetLength();
+    if (length == 0 || (length % 2) != 0) {
+        return 0;
+    }
+    for (int i = 0; i < length; i++) {
+        if (valueStr[i] < L'A' || valueStr[i] > L'P') {
+            return 0;
+        }
+    }
+    unsigned nbytes = length / 2;
+    *ppdata = new (std::nothrow) BYTE[nbytes];
+    if (!*ppdata) {
+        return 0;
+    }
+    for (unsigned i = 0; i < nbytes; i++) {
+        (*ppdata)[i] = BYTE((valueStr[i * 2] - L'A') | ((valueStr[i * 2 + 1] - L'A') << 4));
+    }
+    return nbytes;
+}
+
+// Open and parse an INI file (BOM-sniffing UNICODE, falling back to ANSI) into
+// a ProfileMap. Clears the map first. Returns false if the file can't be read.
+static bool ReadIniFileIntoMap(const CStringW& iniPath, ProfileMap& map)
+{
+    map.clear();
+
+    if (!::PathFileExistsW(iniPath)) {
+        return false;
+    }
+
+    FILE* fp;
+    int fpStatus;
+    do { // Open the ini in UNICODE mode, retry if it is already being used by another process
+        fp = _wfsopen(iniPath, L"r, ccs=UNICODE", _SH_SECURE);
+        if (fp || (GetLastError() != ERROR_SHARING_VIOLATION)) {
+            break;
+        }
+        Sleep(100);
+    } while (true);
+    if (!fp) {
+        ASSERT(FALSE);
+        return false;
+    }
+    if (_ftell_nolock(fp) == 0L) {
+        // No BOM was consumed, assume the ini is ANSI encoded
+        fpStatus = fclose(fp);
+        ASSERT(fpStatus == 0);
+        do { // Reopen the ini in ANSI mode, retry if it is already being used by another process
+            fp = _wfsopen(iniPath, L"r", _SH_SECURE);
+            if (fp || (GetLastError() != ERROR_SHARING_VIOLATION)) {
+                break;
+            }
+            Sleep(100);
+        } while (true);
+        if (!fp) {
+            ASSERT(FALSE);
+            return false;
+        }
+    }
+
+    CStdioFile file(fp);
+
+    CStringW line, section, var, val;
+    while (file.ReadString(line)) {
+        // Parse the ini file, this parser:
+        //  - doesn't trim whitespaces
+        //  - doesn't remove quotation marks
+        //  - omits keys with empty names
+        //  - omits unnamed sections
+        int pos = 0;
+        if (line[0] == L'[') {
+            pos = line.Find(L']');
+            if (pos == -1) {
+                continue;
+            }
+            section = line.Mid(1, pos - 1);
+        } else if (line[0] != L';') {
+            pos = line.Find(L'=');
+            if (pos == -1) {
+                continue;
+            }
+            var = line.Mid(0, pos);
+            val = line.Mid(pos + 1);
+            if (!section.IsEmpty() && !var.IsEmpty()) {
+                map[section][var] = val;
+            }
+        }
+    }
+    fpStatus = fclose(fp);
+    ASSERT(fpStatus == 0);
+
+    return true;
+}
+
+// CProfile
+
+CProfile::CProfile()
+{
+    // Prefer a portable INI: the new-format file, or an existing legacy .ini
+    // next to the executable (so upgrading a portable install stays portable).
+    CStringW newIni = GetNewIniPath();
+    if (::PathFileExistsW(newIni)) {
+        m_IniPath = newIni;
+        return;
+    }
+    if (::PathFileExistsW(GetLegacyIniPath())) {
+        m_IniPath = newIni; // portable: write the new-format file alongside the legacy one
+        return;
+    }
+
+    OpenRegistryKey();
+}
+
+CProfile::~CProfile()
+{
+    if (m_hAppRegKey) {
+        RegCloseKey(m_hAppRegKey);
+        m_hAppRegKey = nullptr;
+    }
+}
+
+LONG CProfile::OpenRegistryKey()
+{
+    LONG lResult = ERROR_SUCCESS;
+
+    if (!m_hAppRegKey) {
+        DWORD dwDisposition = 0;
+        lResult = RegCreateKeyExW(HKEY_CURRENT_USER, PROFILE_REG_KEY, 0, nullptr, 0,
+                                  KEY_READ | KEY_WRITE, nullptr, &m_hAppRegKey, &dwDisposition);
+        ASSERT(lResult == ERROR_SUCCESS);
+    }
+
+    return lResult;
+}
+
+void CProfile::InitIni()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (m_hAppRegKey) {
+        return;
+    }
+
+    // Don't reread the ini if the cache needs to be flushed or it was accessed recently
+    const ULONGLONG tick = GetTickCount64();
+    if (m_bIniFirstInit && (m_bIniNeedFlush || tick - m_IniLastAccessTick < 100u)) {
+        m_IniLastAccessTick = tick;
+        return;
+    }
+
+    m_bIniFirstInit = true;
+    m_IniLastAccessTick = tick;
+
+    ASSERT(!m_bIniNeedFlush);
+    ReadIniFileIntoMap(m_IniPath, m_ProfileMap);
+
+    m_IniLastAccessTick = GetTickCount64(); // reading the file can take a long time
+}
+
+bool CProfile::StoreSettingsTo(const SettingsLocation newLocation)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (newLocation == SETS_REGISTRY) {
+        if (m_hAppRegKey) {
+            return true; // already in the registry
+        }
+
+        InitIni();
+        if (::PathFileExistsW(m_IniPath) && _wremove(m_IniPath) != 0) {
+            return false; // ini can not be deleted; transfer canceled
+        }
+
+        OpenRegistryKey();
+        if (m_hAppRegKey) {
+            m_IniPath.Empty();
+            return true;
+        }
+
+        return false;
+    }
+
+    // SETS_PROGRAMDIR
+    if (!m_IniPath.IsEmpty() && !m_hAppRegKey) {
+        return true; // already stored in the program folder
+    }
+
+    if (m_hAppRegKey) {
+        RegDeleteTreeW(m_hAppRegKey, nullptr);
+        RegCloseKey(m_hAppRegKey);
+        m_hAppRegKey = nullptr;
+    }
+
+    const CStringW newIniPath = GetNewIniPath();
+    CFile file;
+    if (file.Open(newIniPath, CFile::modeWrite | CFile::modeCreate | CFile::modeNoTruncate)) {
+        file.Close();
+        m_IniPath = newIniPath;
+        Flush(true);
+        return true;
+    }
+
+    return false;
+}
+
+bool CProfile::ReadBool(const wchar_t* section, const wchar_t* entry, bool& value)
+{
+    int v = value;
+    bool ret = ReadInt(section, entry, v);
+    if (ret) {
+        // very strict check
+        if (v == 0) {
+            value = false;
+        } else if (v == 1) {
+            value = true;
+        } else {
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadInt(const wchar_t* section, const wchar_t* entry, int& value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            if (ERROR_SUCCESS == regkey.QueryDWORDValue(entry, *(DWORD*)&value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            auto it2 = it1->second.find(entry);
+            if (it2 != it1->second.end()) {
+                ret = StrToInt32(it2->second, value);
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadInt(const wchar_t* section, const wchar_t* entry, int& value, const int lo, const int hi)
+{
+    int v = value;
+    bool ret = ReadInt(section, entry, v);
+    if (ret) {
+        if (v >= lo && v <= hi) {
+            value = v;
+        } else {
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadUInt(const wchar_t* section, const wchar_t* entry, unsigned& value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            if (ERROR_SUCCESS == regkey.QueryDWORDValue(entry, *(DWORD*)&value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            auto it2 = it1->second.find(entry);
+            if (it2 != it1->second.end()) {
+                ret = StrToUInt32(it2->second, value);
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadUInt(const wchar_t* section, const wchar_t* entry, unsigned& value, const unsigned lo, const unsigned hi)
+{
+    unsigned v = value;
+    bool ret = ReadUInt(section, entry, v);
+    if (ret) {
+        if (v >= lo && v <= hi) {
+            value = v;
+        } else {
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadInt64(const wchar_t* section, const wchar_t* entry, __int64& value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            if (ERROR_SUCCESS == regkey.QueryQWORDValue(entry, *(ULONGLONG*)&value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            auto it2 = it1->second.find(entry);
+            if (it2 != it1->second.end()) {
+                ret = StrToInt64(it2->second, value);
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadInt64(const wchar_t* section, const wchar_t* entry, __int64& value, const __int64 lo, const __int64 hi)
+{
+    __int64 v = value;
+    bool ret = ReadInt64(section, entry, v);
+    if (ret) {
+        if (v >= lo && v <= hi) {
+            value = v;
+        } else {
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadDouble(const wchar_t* section, const wchar_t* entry, double& value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            ULONG nChars = 0;
+            if (ERROR_SUCCESS == regkey.QueryStringValue(entry, nullptr, &nChars) && nChars > 0) {
+                CStringW str;
+                if (ERROR_SUCCESS == regkey.QueryStringValue(entry, str.GetBufferSetLength(nChars - 1), &nChars)) {
+                    ret = StrToDouble(str, value);
+                }
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            auto it2 = it1->second.find(entry);
+            if (it2 != it1->second.end()) {
+                ret = StrToDouble(it2->second, value);
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadDouble(const wchar_t* section, const wchar_t* entry, double& value, const double lo, const double hi)
+{
+    double v = value;
+    bool ret = ReadDouble(section, entry, v);
+    if (ret) {
+        if (v >= lo && v <= hi) {
+            value = v;
+        } else {
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadHex32(const wchar_t* section, const wchar_t* entry, unsigned& value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            if (ERROR_SUCCESS == regkey.QueryDWORDValue(entry, *(DWORD*)&value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            auto it2 = it1->second.find(entry);
+            if (it2 != it1->second.end()) {
+                ret = StrHexToUInt32(it2->second, value);
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadString(const wchar_t* section, const wchar_t* entry, CStringW& value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            ULONG nChars = 0;
+            if (ERROR_SUCCESS == regkey.QueryStringValue(entry, nullptr, &nChars) && nChars > 0) {
+                if (ERROR_SUCCESS == regkey.QueryStringValue(entry, value.GetBufferSetLength(nChars - 1), &nChars)) {
+                    ret = true;
+                }
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            auto it2 = it1->second.find(entry);
+            if (it2 != it1->second.end()) {
+                value = it2->second;
+                ret = true;
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::ReadBinary(const wchar_t* section, const wchar_t* entry, BYTE** ppdata, unsigned& nbytes)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            if (ERROR_SUCCESS == regkey.QueryBinaryValue(entry, nullptr, (ULONG*)&nbytes)) {
+                *ppdata = new (std::nothrow) BYTE[nbytes];
+                if (*ppdata && ERROR_SUCCESS == regkey.QueryBinaryValue(entry, *ppdata, (ULONG*)&nbytes)) {
+                    ret = true;
+                }
+            }
+            regkey.Close();
+        }
+    } else {
+        CStringW valueStr;
+
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            auto it2 = it1->second.find(entry);
+            if (it2 != it1->second.end()) {
+                valueStr = it2->second;
+            }
+        }
+
+        const int prefixLen = static_cast<int>(wcslen(BINARY_B64_PREFIX));
+        if (wcsncmp(valueStr, BINARY_B64_PREFIX, prefixLen) == 0) {
+            nbytes = Base64ToBinary(valueStr.Mid(prefixLen), ppdata);
+        } else {
+            // legacy value imported verbatim from an old INI (A-P encoded)
+            nbytes = APToBinary(valueStr, ppdata);
+        }
+        ret = (nbytes != 0);
+    }
+
+    return ret;
+}
+
+bool CProfile::WriteBool(const wchar_t* section, const wchar_t* entry, const bool value)
+{
+    return WriteInt(section, entry, value ? 1 : 0); // strictly write "true" as 1
+}
+
+bool CProfile::WriteInt(const wchar_t* section, const wchar_t* entry, const int value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
+            if (ERROR_SUCCESS == regkey.SetDWORDValue(entry, (DWORD)value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        CStringW valueStr;
+        valueStr.Format(L"%d", value);
+        CStringW& old = m_ProfileMap[section][entry];
+        if (old != valueStr) {
+            old = valueStr;
+            m_bIniNeedFlush = true;
+        }
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool CProfile::WriteUInt(const wchar_t* section, const wchar_t* entry, const unsigned value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
+            if (ERROR_SUCCESS == regkey.SetDWORDValue(entry, (DWORD)value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        CStringW valueStr;
+        valueStr.Format(L"%u", value);
+        CStringW& old = m_ProfileMap[section][entry];
+        if (old != valueStr) {
+            old = valueStr;
+            m_bIniNeedFlush = true;
+        }
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool CProfile::WriteInt64(const wchar_t* section, const wchar_t* entry, const __int64 value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
+            if (ERROR_SUCCESS == regkey.SetQWORDValue(entry, (ULONGLONG)value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        CStringW valueStr;
+        valueStr.Format(L"%I64d", value);
+
+        InitIni();
+        CStringW& old = m_ProfileMap[section][entry];
+        if (old != valueStr) {
+            old = valueStr;
+            m_bIniNeedFlush = true;
+        }
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool CProfile::WriteDouble(const wchar_t* section, const wchar_t* entry, const double value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    CStringW valueStr;
+    valueStr.Format(L"%.4f", value);
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
+            if (ERROR_SUCCESS == regkey.SetStringValue(entry, valueStr)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        CStringW& old = m_ProfileMap[section][entry];
+        if (old != valueStr) {
+            old = valueStr;
+            m_bIniNeedFlush = true;
+        }
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool CProfile::WriteHex32(const wchar_t* section, const wchar_t* entry, const unsigned value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
+            if (ERROR_SUCCESS == regkey.SetDWORDValue(entry, (DWORD)value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        CStringW valueStr;
+        valueStr.Format(L"0x%06X", value);
+        CStringW& old = m_ProfileMap[section][entry];
+        if (old != valueStr) {
+            old = valueStr;
+            m_bIniNeedFlush = true;
+        }
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool CProfile::WriteString(const wchar_t* section, const wchar_t* entry, const CStringW& value)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
+            if (ERROR_SUCCESS == regkey.SetStringValue(entry, value)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        CStringW& old = m_ProfileMap[section][entry];
+        if (old != value) {
+            old = value;
+            m_bIniNeedFlush = true;
+        }
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool CProfile::WriteBinary(const wchar_t* section, const wchar_t* entry, const BYTE* pdata, const unsigned nbytes)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
+            if (ERROR_SUCCESS == regkey.SetBinaryValue(entry, pdata, nbytes)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        CStringW base64 = BinaryToBase64(pdata, nbytes);
+        if (!base64.IsEmpty()) {
+            CStringW value = BINARY_B64_PREFIX + base64;
+            InitIni();
+            CStringW& old = m_ProfileMap[section][entry];
+            if (old != value) {
+                old = value;
+                m_bIniNeedFlush = true;
+            }
+            ret = true;
+        }
+    }
+
+    return ret;
+}
+
+void CProfile::EnumValueNames(const wchar_t* section, std::vector<CStringW>& valuenames)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    valuenames.clear();
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            DWORD cValues     = 0;
+            DWORD cchMaxValue = 0;
+
+            DWORD retCode = RegQueryInfoKeyW(regkey.m_hKey, nullptr, nullptr, nullptr, nullptr,
+                                             nullptr, nullptr, &cValues, &cchMaxValue, nullptr, nullptr, nullptr);
+
+            if (ERROR_SUCCESS == retCode && cValues && cchMaxValue) {
+                std::vector<WCHAR> achValue(cchMaxValue + 1, L'\0');
+
+                for (DWORD i = 0; i < cValues; i++) {
+                    DWORD cchValue = cchMaxValue + 1;
+                    achValue[0] = L'\0';
+                    if (ERROR_SUCCESS == RegEnumValueW(regkey.m_hKey, i, achValue.data(), &cchValue, nullptr, nullptr, nullptr, nullptr)) {
+                        valuenames.emplace_back(achValue.data(), cchValue);
+                    }
+                }
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            for (const auto& entry : it1->second) {
+                valuenames.emplace_back(entry.first);
+            }
+        }
+    }
+}
+
+void CProfile::EnumSectionNames(const wchar_t* section, std::vector<CStringW>& sectionnames)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    sectionnames.clear();
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            DWORD cSubKeys    = 0;
+            DWORD cbMaxSubKey = 0;
+
+            DWORD retCode = RegQueryInfoKeyW(regkey.m_hKey, nullptr, nullptr, nullptr, &cSubKeys,
+                                             &cbMaxSubKey, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+
+            if (ERROR_SUCCESS == retCode && cSubKeys && cbMaxSubKey) {
+                std::vector<WCHAR> achKey(cbMaxSubKey + 1, L'\0');
+
+                for (DWORD i = 0; i < cSubKeys; i++) {
+                    DWORD cbName = cbMaxSubKey + 1;
+                    achKey[0] = L'\0';
+                    if (ERROR_SUCCESS == RegEnumKeyExW(regkey.m_hKey, i, achKey.data(), &cbName, nullptr, nullptr, nullptr, nullptr)) {
+                        sectionnames.emplace_back(achKey.data(), cbName);
+                    }
+                }
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        CStringW prefix(section);
+        prefix += L'\\';
+
+        auto it = m_ProfileMap.cbegin();
+        while (it != m_ProfileMap.cend() && !StartsWith(it->first, prefix)) {
+            ++it;
+        }
+
+        while (it != m_ProfileMap.cend() && StartsWith(it->first, prefix)) {
+            if (it->first.GetLength() > prefix.GetLength()) {
+                sectionnames.emplace_back(it->first.Mid(prefix.GetLength()));
+            }
+            ++it;
+        }
+    }
+}
+
+bool CProfile::DeleteValue(const wchar_t* section, const wchar_t* entry)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_WRITE)) {
+            if (ERROR_SUCCESS == regkey.DeleteValue(entry)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it = m_ProfileMap.find(section);
+        if (it != m_ProfileMap.end()) {
+            if (it->second.erase(entry)) {
+                m_bIniNeedFlush = true;
+                ret = true;
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool CProfile::DeleteSection(const wchar_t* section)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, L"", KEY_WRITE)) {
+            if (ERROR_SUCCESS == regkey.RecurseDeleteKey(section)) {
+                ret = true;
+            }
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        const CStringW mainsection(section);
+        const CStringW prefix(mainsection + L'\\');
+
+        auto start = m_ProfileMap.cbegin();
+        while (start != m_ProfileMap.cend() && start->first != mainsection && !StartsWith(start->first, prefix)) {
+            ++start;
+        }
+
+        if (start != m_ProfileMap.cend()) {
+            auto end = std::next(start);
+            while (end != m_ProfileMap.cend() && StartsWith(end->first, prefix)) {
+                ++end;
+            }
+
+            m_ProfileMap.erase(start, end);
+            m_bIniNeedFlush = true;
+            ret = true;
+        }
+    }
+
+    return ret;
+}
+
+void CProfile::Flush(bool bForce)
+{
+    if (m_hAppRegKey || (!bForce && !m_bIniNeedFlush)) {
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    m_bIniNeedFlush = false;
+
+    ASSERT(m_bIniFirstInit);
+    ASSERT(!m_IniPath.IsEmpty());
+
+    FILE* fp;
+    int fpStatus;
+    do { // Open the ini, retry if it is already being used by another process
+        fp = _wfsopen(m_IniPath, L"w, ccs=UTF-8", _SH_SECURE);
+        if (fp || (GetLastError() != ERROR_SHARING_VIOLATION)) {
+            break;
+        }
+        Sleep(100);
+    } while (true);
+    if (!fp) {
+        ASSERT(FALSE);
+        return;
+    }
+    CStdioFile file(fp);
+    CStringW line;
+    try {
+        file.WriteString(L"; MPC-HC\n");
+        for (auto it1 = m_ProfileMap.begin(); it1 != m_ProfileMap.end(); ++it1) {
+            line.Format(L"[%s]\n", it1->first.GetString());
+            file.WriteString(line);
+            for (auto it2 = it1->second.begin(); it2 != it1->second.end(); ++it2) {
+                line.Format(L"%s=%s\n", it2->first.GetString(), it2->second.GetString());
+                file.WriteString(line);
+            }
+        }
+    } catch (CFileException& e) {
+        // Fail silently if disk is full
+        UNREFERENCED_PARAMETER(e);
+        ASSERT(FALSE);
+    }
+
+    fpStatus = fclose(fp);
+    ASSERT(fpStatus == 0);
+}
+
+void CProfile::Clear()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (m_hAppRegKey) {
+        RegDeleteTreeW(m_hAppRegKey, nullptr);
+    } else {
+        ASSERT(!m_IniPath.IsEmpty());
+        CFile file;
+        if (file.Open(m_IniPath, CFile::modeWrite)) {
+            file.SetLength(0); // clear, but do not delete
+            file.Close();
+        }
+    }
+
+    m_ProfileMap.clear();
+    m_bIniNeedFlush = false;
+}
+
+bool CProfile::MigrateFromLegacy()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (m_hAppRegKey) {
+        // Registry: recursively copy the legacy MFC key into the new key,
+        // preserving native value types (REG_DWORD/REG_SZ/REG_BINARY/...).
+        HKEY hLegacy = nullptr;
+        if (ERROR_SUCCESS != RegOpenKeyExW(HKEY_CURRENT_USER, LEGACY_REG_KEY, 0, KEY_READ, &hLegacy)) {
+            return false;
+        }
+        LONG res = RegCopyTreeW(hLegacy, nullptr, m_hAppRegKey);
+        RegCloseKey(hLegacy);
+        return res == ERROR_SUCCESS;
+    }
+
+    // INI: parse the legacy <exe>.ini verbatim into the (new) map, then flush
+    // it to the new file. Old A-P binary values are read back later via the
+    // un-prefixed path in ReadBinary().
+    const CStringW legacyIni = GetLegacyIniPath();
+    if (legacyIni.CompareNoCase(m_IniPath) == 0) {
+        return false; // defensive: never import a file onto itself
+    }
+    ProfileMap legacyMap;
+    if (!ReadIniFileIntoMap(legacyIni, legacyMap)) {
+        return false;
+    }
+
+    InitIni(); // ensure the (new, likely empty) map is loaded before merging
+    for (const auto& sec : legacyMap) {
+        for (const auto& kv : sec.second) {
+            m_ProfileMap[sec.first][kv.first] = kv.second;
+        }
+    }
+    m_bIniNeedFlush = true;
+    Flush(true);
+    return true;
+}
+
+bool CProfile::ForkToLocalIni()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (m_hAppRegKey) {
+        RegCloseKey(m_hAppRegKey); // detach only; the shared registry store is left intact
+        m_hAppRegKey = nullptr;
+    }
+
+    m_IniPath = GetNewIniPath();
+    m_ProfileMap.clear();
+    m_bIniFirstInit = false; // force InitIni() to (re)read the local file if present
+    m_bIniNeedFlush = false;
+    InitIni();
+
+    return true;
+}
+
+SettingsLocation CProfile::GetSettingsLocation() const
+{
+    if (m_hAppRegKey) {
+        return SETS_REGISTRY;
+    }
+    return SETS_PROGRAMDIR;
+}

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -34,6 +34,7 @@ static const wchar_t* const PROFILE_REG_KEY = L"Software\\MPC-HC\\MPC-HC-setting
 static const wchar_t* const LEGACY_REG_KEY  = L"Software\\MPC-HC\\MPC-HC"; // pre-versioning MFC key
 static const wchar_t* const NEW_INI_SUFFIX  = L".settings.ini"; // <exe-basename>.settings.ini
 static const wchar_t* const OLD_INI_SUFFIX  = L".ini";          // legacy portable ini
+static const wchar_t* const HISTORY_INI_SUFFIX = L".history.ini"; // separate MediaHistory store
 
 // Prefix marking a NEW-format Base64 binary value in an INI. Legacy binary
 // values are A-P encoded (only chars 'A'..'P'), so this lowercase-led prefix
@@ -209,12 +210,23 @@ CProfile::CProfile()
     OpenRegistryKey();
 }
 
+CProfile::CProfile(const CStringW& iniFilePath)
+{
+    // Explicit INI mode at a fixed path; no registry, no auto-detection.
+    m_IniPath = iniFilePath;
+}
+
 CProfile::~CProfile()
 {
     if (m_hAppRegKey) {
         RegCloseKey(m_hAppRegKey);
         m_hAppRegKey = nullptr;
     }
+}
+
+CStringW CProfile::HistoryIniPath()
+{
+    return GetExeBasePath() + HISTORY_INI_SUFFIX;
 }
 
 LONG CProfile::OpenRegistryKey()
@@ -1064,6 +1076,64 @@ bool CProfile::MigrateFromLegacy()
     m_bIniNeedFlush = true;
     Flush(true);
     return true;
+}
+
+void CProfile::MoveSectionTree(const wchar_t* root, CProfile& dst)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (m_hAppRegKey) {
+        return; // the MediaHistory split only applies in INI mode
+    }
+
+    InitIni();
+    const CStringW rootStr(root);
+    const CStringW prefix(rootStr + L"\\");
+    bool moved = false;
+
+    for (auto it = m_ProfileMap.begin(); it != m_ProfileMap.end();) {
+        if (it->first.CompareNoCase(rootStr) == 0 || StartsWithNoCase(it->first, prefix)) {
+            for (const auto& kv : it->second) {
+                dst.WriteString(it->first, kv.first, kv.second); // raw value copy (already new-format)
+            }
+            it = m_ProfileMap.erase(it);
+            moved = true;
+        } else {
+            ++it;
+        }
+    }
+
+    if (moved) {
+        m_bIniNeedFlush = true;
+    }
+}
+
+bool CProfile::HasEntry(const wchar_t* section, const wchar_t* entry)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    bool ret = false;
+
+    if (m_hAppRegKey) {
+        CRegKey regkey;
+        if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
+            ret = (ERROR_SUCCESS == RegQueryValueExW(regkey.m_hKey, entry, nullptr, nullptr, nullptr, nullptr));
+            regkey.Close();
+        }
+    } else {
+        InitIni();
+        auto it1 = m_ProfileMap.find(section);
+        if (it1 != m_ProfileMap.end()) {
+            ret = (it1->second.find(entry) != it1->second.end());
+        }
+    }
+
+    return ret;
+}
+
+CStringW CProfile::GetRegistryKeyPath() const
+{
+    return m_hAppRegKey ? CStringW(PROFILE_REG_KEY) : CStringW();
 }
 
 bool CProfile::ForkToLocalIni()

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -30,23 +30,16 @@
 // old location (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini) untouched so older
 // builds stay downgrade-safe.
 // ---------------------------------------------------------------------------
-static const wchar_t* const COMPANY_REG_KEY  = L"Software\\MPC-HC";        // parent of all stores
-static const wchar_t* const LEGACY_REG_KEY   = L"Software\\MPC-HC\\MPC-HC"; // pre-versioning MFC key
-static const wchar_t* const OLD_INI_SUFFIX   = L".ini";                     // legacy portable ini
-static const wchar_t* const INDEX_INI_SUFFIX = L".settings.ini";           // version-independent index/manifest
-
-// Format-versioned store names are built from SETTINGS_FORMAT_VERSION /
-// HISTORY_FORMAT_VERSION so older builds only ever touch their own version's
-// store (Settings-<ver> / History-<ver>). The *For() variants build the names
-// for an arbitrary version (used to seed from an older store during migration).
-static CStringW SettingsRegKeyFor(const CStringW& version)
-{
-    return CStringW(COMPANY_REG_KEY) + L"\\Settings-" + version;
-}
-static CStringW SettingsRegKey()
-{
-    return SettingsRegKeyFor(SETTINGS_FORMAT_VERSION);
-}
+// The on-disk format version is NOT in the store name; each store records it in
+// a [Version] Format field. The new stores live ALONGSIDE the pre-versioning
+// legacy store (HKCU\Software\MPC-HC\MPC-HC and <exe>.ini), which is untouched.
+static const wchar_t* const LEGACY_REG_KEY     = L"Software\\MPC-HC\\MPC-HC";   // pre-versioning MFC key
+static const wchar_t* const SETTINGS_REG_KEY   = L"Software\\MPC-HC\\Settings"; // format in [Version]Format
+static const wchar_t* const OLD_INI_SUFFIX     = L".ini";                       // legacy portable ini
+static const wchar_t* const NEW_INI_SUFFIX     = L".settings.ini";             // <exe-basename>.settings.ini
+static const wchar_t* const HISTORY_INI_SUFFIX = L".history.ini";              // <exe-basename>.history.ini
+static const wchar_t* const LOCAL_INI_SUFFIX   = L".settings.local.ini";       // downgrade fork (settings)
+static const wchar_t* const HISTORY_LOCAL_SUFFIX = L".history.local.ini";      // downgrade fork (history)
 
 // Prefix marking a NEW-format Base64 binary value in an INI. Legacy binary
 // values are A-P encoded (only chars 'A'..'P'), so this lowercase-led prefix
@@ -64,13 +57,13 @@ static CStringW GetExeBasePath()
     return path;
 }
 
-static CStringW SettingsIniPathFor(const CStringW& version)
-{
-    return GetExeBasePath() + L".settings-" + version + L".ini";
-}
 static CStringW GetNewIniPath()
 {
-    return SettingsIniPathFor(SETTINGS_FORMAT_VERSION);
+    return GetExeBasePath() + NEW_INI_SUFFIX;
+}
+static CStringW GetLocalIniPath()
+{
+    return GetExeBasePath() + LOCAL_INI_SUFFIX;
 }
 
 static CStringW GetLegacyIniPath()
@@ -211,14 +204,10 @@ static bool ReadIniFileIntoMap(const CStringW& iniPath, ProfileMap& map)
 
 CProfile::CProfile()
 {
-    // Portable if any INI marker exists next to the executable: this version's
-    // settings file, the legacy .ini, or the version-independent index file.
-    // (The index persists portability across format-version bumps.)
+    // Portable if a settings INI (new or legacy) exists next to the executable.
     const CStringW newIni = GetNewIniPath();
-    if (::PathFileExistsW(newIni) ||
-        ::PathFileExistsW(GetLegacyIniPath()) ||
-        ::PathFileExistsW(GetExeBasePath() + INDEX_INI_SUFFIX)) {
-        m_IniPath = newIni; // write this version's file (alongside any legacy one)
+    if (::PathFileExistsW(newIni) || ::PathFileExistsW(GetLegacyIniPath())) {
+        m_IniPath = newIni; // write the new-format file (alongside any legacy one)
         return;
     }
 
@@ -243,17 +232,22 @@ CProfile::~CProfile()
 
 CStringW CProfile::HistoryIniPath()
 {
-    return GetExeBasePath() + L".history-" + HISTORY_FORMAT_VERSION + L".ini";
+    return GetExeBasePath() + HISTORY_INI_SUFFIX;
 }
 
-CStringW CProfile::SettingsIndexIniPath()
+CStringW CProfile::HistoryLocalIniPath()
 {
-    return GetExeBasePath() + INDEX_INI_SUFFIX;
+    return GetExeBasePath() + HISTORY_LOCAL_SUFFIX;
 }
 
 CStringW CProfile::DefaultIniPath()
 {
     return GetNewIniPath();
+}
+
+CStringW CProfile::LocalIniPath()
+{
+    return GetLocalIniPath();
 }
 
 LONG CProfile::OpenRegistryKey()
@@ -262,7 +256,7 @@ LONG CProfile::OpenRegistryKey()
 
     if (!m_hAppRegKey) {
         DWORD dwDisposition = 0;
-        lResult = RegCreateKeyExW(HKEY_CURRENT_USER, SettingsRegKey(), 0, nullptr, 0,
+        lResult = RegCreateKeyExW(HKEY_CURRENT_USER, SETTINGS_REG_KEY, 0, nullptr, 0,
                                   KEY_READ | KEY_WRITE, nullptr, &m_hAppRegKey, &dwDisposition);
         ASSERT(lResult == ERROR_SUCCESS);
     }
@@ -1157,6 +1151,74 @@ static void CopyRegistryTree(HKEY src, HKEY dst)
     }
 }
 
+// Enumerate a registry key recursively into a ProfileMap, converting each value
+// to the INI textual form CProfile uses (so a registry store can seed an INI
+// fork). `section` is the path built from subkeys ("" at the root).
+static void EnumerateRegistryTreeToMap(HKEY hKey, const CStringW& section, ProfileMap& out)
+{
+    DWORD valueNameChars, subKeyNameChars;
+    RegNameBufferSizes(hKey, valueNameChars, subKeyNameChars);
+    std::vector<WCHAR> name(valueNameChars);
+    std::vector<WCHAR> sub(subKeyNameChars);
+
+    if (!section.IsEmpty()) {
+        for (DWORD i = 0;; i++) {
+            DWORD nameLen = static_cast<DWORD>(name.size()), type = 0, dataLen = 0;
+            LONG r = RegEnumValueW(hKey, i, name.data(), &nameLen, nullptr, &type, nullptr, &dataLen);
+            if (r == ERROR_NO_MORE_ITEMS) {
+                break;
+            }
+            if (r != ERROR_SUCCESS || dataLen == 0) {
+                continue;
+            }
+            std::vector<BYTE> data(dataLen);
+            DWORD cb = dataLen;
+            if (RegQueryValueExW(hKey, name.data(), nullptr, &type, data.data(), &cb) != ERROR_SUCCESS) {
+                continue;
+            }
+            CStringW val;
+            switch (type) {
+                case REG_DWORD:
+                    if (cb < sizeof(DWORD)) continue;
+                    val.Format(L"%d", static_cast<int>(*reinterpret_cast<DWORD*>(data.data())));
+                    break;
+                case REG_QWORD:
+                    if (cb < sizeof(ULONGLONG)) continue;
+                    val.Format(L"%I64d", *reinterpret_cast<ULONGLONG*>(data.data()));
+                    break;
+                case REG_SZ:
+                case REG_EXPAND_SZ:
+                    val = CStringW(reinterpret_cast<LPCWSTR>(data.data()), static_cast<int>(cb / sizeof(WCHAR)));
+                    { int nul = val.Find(L'\0'); if (nul >= 0) val.Truncate(nul); }
+                    break;
+                case REG_BINARY:
+                    val = CStringW(BINARY_B64_PREFIX) + BinaryToBase64(data.data(), cb);
+                    break;
+                default:
+                    continue;
+            }
+            out[section][name.data()] = val;
+        }
+    }
+
+    for (DWORD i = 0;; i++) {
+        DWORD subLen = static_cast<DWORD>(sub.size());
+        LONG r = RegEnumKeyExW(hKey, i, sub.data(), &subLen, nullptr, nullptr, nullptr, nullptr);
+        if (r == ERROR_NO_MORE_ITEMS) {
+            break;
+        }
+        if (r != ERROR_SUCCESS) {
+            continue;
+        }
+        HKEY hSub;
+        if (RegOpenKeyExW(hKey, sub.data(), 0, KEY_READ, &hSub) == ERROR_SUCCESS) {
+            CStringW child = section.IsEmpty() ? CStringW(sub.data()) : (section + L"\\" + sub.data());
+            EnumerateRegistryTreeToMap(hSub, child, out);
+            RegCloseKey(hSub);
+        }
+    }
+}
+
 bool CProfile::MigrateFromLegacy()
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
@@ -1197,84 +1259,51 @@ bool CProfile::MigrateFromLegacy()
     return true;
 }
 
-bool CProfile::SeedFromVersion(const CStringW& fromVersion)
+bool CProfile::ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent)
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
 
-    if (m_bRegistryMode) {
-        HKEY hSrc = nullptr;
-        if (RegOpenKeyExW(HKEY_CURRENT_USER, SettingsRegKeyFor(fromVersion), 0, KEY_READ, &hSrc) != ERROR_SUCCESS) {
-            return false; // source store doesn't exist
+    // Capture the current store's contents first (if seeding a fresh fork).
+    ProfileMap seed;
+    if (seedFromCurrent) {
+        if (m_bRegistryMode) {
+            OpenRegistryKey();
+            if (m_hAppRegKey) {
+                EnumerateRegistryTreeToMap(m_hAppRegKey, CStringW(), seed);
+            }
+        } else {
+            InitIni();
+            seed = m_ProfileMap;
         }
-        OpenRegistryKey();
-        CopyRegistryTree(hSrc, m_hAppRegKey);
-        RegCloseKey(hSrc);
-        return true;
     }
 
-    ProfileMap srcMap;
-    if (!ReadIniFileIntoMap(SettingsIniPathFor(fromVersion), srcMap)) {
-        return false;
+    // Detach from the shared store WITHOUT deleting it (the newer store survives).
+    if (m_hAppRegKey) {
+        RegCloseKey(m_hAppRegKey);
+        m_hAppRegKey = nullptr;
     }
+    m_bRegistryMode = false;
+    m_IniPath = iniPath;
+    m_ProfileMap.clear();
+    m_bIniFirstInit = false; // force InitIni() to (re)read the local file if present
+    m_bIniNeedFlush = false;
     InitIni();
-    for (const auto& sec : srcMap) {
-        for (const auto& kv : sec.second) {
-            m_ProfileMap[sec.first][kv.first] = kv.second;
-        }
-    }
-    m_bIniNeedFlush = true;
-    Flush(true);
-    return true;
-}
 
-void CProfile::EnumSettingsStoreVersions(std::vector<CStringW>& versions)
-{
-    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
-    versions.clear();
-
-    if (m_bRegistryMode) {
-        // Read-only enumeration of the parent key; does not create our own store.
-        CRegKey parent;
-        if (parent.Open(HKEY_CURRENT_USER, COMPANY_REG_KEY, KEY_READ) == ERROR_SUCCESS) {
-            const CStringW pfx(L"Settings-");
-            WCHAR sub[256];
-            for (DWORD i = 0;; i++) {
-                DWORD subLen = _countof(sub); // key names are <= 255 chars
-                LONG r = RegEnumKeyExW(parent.m_hKey, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
-                if (r == ERROR_NO_MORE_ITEMS) {
-                    break;
-                }
-                if (r != ERROR_SUCCESS) {
-                    continue;
-                }
-                CStringW name(sub);
-                if (name.GetLength() > pfx.GetLength() && name.Left(pfx.GetLength()) == pfx) {
-                    versions.emplace_back(name.Mid(pfx.GetLength()));
+    // Fill in from the seed without overwriting anything already in an existing
+    // local fork file.
+    if (seedFromCurrent && !seed.empty()) {
+        for (const auto& sec : seed) {
+            for (const auto& kv : sec.second) {
+                auto& dst = m_ProfileMap[sec.first];
+                if (dst.find(kv.first) == dst.end()) {
+                    dst[kv.first] = kv.second;
+                    m_bIniNeedFlush = true;
                 }
             }
-            parent.Close();
-        }
-    } else {
-        // <exe>.settings-<ver>.ini (the dash distinguishes it from the
-        // version-independent <exe>.settings.ini index file).
-        const CStringW pattern = GetExeBasePath() + L".settings-*.ini";
-        WIN32_FIND_DATAW fd;
-        HANDLE h = FindFirstFileW(pattern, &fd);
-        if (h != INVALID_HANDLE_VALUE) {
-            do {
-                CStringW fn(fd.cFileName);
-                int a = fn.Find(L".settings-");
-                if (a >= 0) {
-                    CStringW rest = fn.Mid(a + 10); // after ".settings-"
-                    int b = rest.ReverseFind(L'.'); // strip ".ini"
-                    if (b > 0) {
-                        versions.emplace_back(rest.Left(b));
-                    }
-                }
-            } while (FindNextFileW(h, &fd));
-            FindClose(h);
         }
     }
+
+    return true;
 }
 
 void CProfile::MoveSectionTree(const wchar_t* root, CProfile& dst)
@@ -1333,7 +1362,7 @@ bool CProfile::HasEntry(const wchar_t* section, const wchar_t* entry)
 
 CStringW CProfile::GetRegistryKeyPath() const
 {
-    return m_bRegistryMode ? SettingsRegKey() : CStringW();
+    return m_bRegistryMode ? CStringW(SETTINGS_REG_KEY) : CStringW();
 }
 
 SettingsLocation CProfile::GetSettingsLocation() const

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -37,10 +37,15 @@ static const wchar_t* const INDEX_INI_SUFFIX = L".settings.ini";           // ve
 
 // Format-versioned store names are built from SETTINGS_FORMAT_VERSION /
 // HISTORY_FORMAT_VERSION so older builds only ever touch their own version's
-// store (Settings-<ver> / History-<ver>).
+// store (Settings-<ver> / History-<ver>). The *For() variants build the names
+// for an arbitrary version (used to seed from an older store during migration).
+static CStringW SettingsRegKeyFor(const CStringW& version)
+{
+    return CStringW(COMPANY_REG_KEY) + L"\\Settings-" + version;
+}
 static CStringW SettingsRegKey()
 {
-    return CStringW(COMPANY_REG_KEY) + L"\\Settings-" + SETTINGS_FORMAT_VERSION;
+    return SettingsRegKeyFor(SETTINGS_FORMAT_VERSION);
 }
 
 // Prefix marking a NEW-format Base64 binary value in an INI. Legacy binary
@@ -59,9 +64,13 @@ static CStringW GetExeBasePath()
     return path;
 }
 
+static CStringW SettingsIniPathFor(const CStringW& version)
+{
+    return GetExeBasePath() + L".settings-" + version + L".ini";
+}
 static CStringW GetNewIniPath()
 {
-    return GetExeBasePath() + L".settings-" + SETTINGS_FORMAT_VERSION + L".ini";
+    return SettingsIniPathFor(SETTINGS_FORMAT_VERSION);
 }
 
 static CStringW GetLegacyIniPath()
@@ -1125,6 +1134,35 @@ bool CProfile::MigrateFromLegacy()
 
     InitIni(); // ensure the (new, likely empty) map is loaded before merging
     for (const auto& sec : legacyMap) {
+        for (const auto& kv : sec.second) {
+            m_ProfileMap[sec.first][kv.first] = kv.second;
+        }
+    }
+    m_bIniNeedFlush = true;
+    Flush(true);
+    return true;
+}
+
+bool CProfile::SeedFromVersion(const CStringW& fromVersion)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (m_hAppRegKey) {
+        HKEY hSrc = nullptr;
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, SettingsRegKeyFor(fromVersion), 0, KEY_READ, &hSrc) != ERROR_SUCCESS) {
+            return false; // source store doesn't exist
+        }
+        CopyRegistryTree(hSrc, m_hAppRegKey);
+        RegCloseKey(hSrc);
+        return true;
+    }
+
+    ProfileMap srcMap;
+    if (!ReadIniFileIntoMap(SettingsIniPathFor(fromVersion), srcMap)) {
+        return false;
+    }
+    InitIni();
+    for (const auto& sec : srcMap) {
         for (const auto& kv : sec.second) {
             m_ProfileMap[sec.first][kv.first] = kv.second;
         }

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -38,8 +38,9 @@ static const wchar_t* const SETTINGS_REG_KEY   = L"Software\\MPC-HC\\Settings"; 
 static const wchar_t* const OLD_INI_SUFFIX     = L".ini";                       // legacy portable ini
 static const wchar_t* const NEW_INI_SUFFIX     = L".settings.ini";             // <exe-basename>.settings.ini
 static const wchar_t* const HISTORY_INI_SUFFIX = L".history.ini";              // <exe-basename>.history.ini
-static const wchar_t* const LOCAL_INI_SUFFIX   = L".settings.local.ini";       // downgrade fork (settings)
-static const wchar_t* const HISTORY_LOCAL_SUFFIX = L".history.local.ini";      // downgrade fork (history)
+// Downgrade-fork files carry THIS build's format version in the name, so two
+// different older builds forking from the same newer store don't collide and
+// each file is self-identifying: <exe>.settings.<ver>.local.ini / .history.<ver>.local.ini
 
 // Prefix marking a NEW-format Base64 binary value in an INI. Legacy binary
 // values are A-P encoded (only chars 'A'..'P'), so this lowercase-led prefix
@@ -63,7 +64,7 @@ static CStringW GetNewIniPath()
 }
 static CStringW GetLocalIniPath()
 {
-    return GetExeBasePath() + LOCAL_INI_SUFFIX;
+    return GetExeBasePath() + L".settings." + SETTINGS_FORMAT_VERSION + L".local.ini";
 }
 
 static CStringW GetLegacyIniPath()
@@ -237,7 +238,7 @@ CStringW CProfile::HistoryIniPath()
 
 CStringW CProfile::HistoryLocalIniPath()
 {
-    return GetExeBasePath() + HISTORY_LOCAL_SUFFIX;
+    return GetExeBasePath() + L".history." + HISTORY_FORMAT_VERSION + L".local.ini";
 }
 
 CStringW CProfile::DefaultIniPath()

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -222,7 +222,9 @@ CProfile::CProfile()
         return;
     }
 
-    OpenRegistryKey();
+    // Registry mode. Do NOT create the key here (this ctor runs at static-init
+    // time for the global theApp); it is opened lazily on first access.
+    m_bRegistryMode = true;
 }
 
 CProfile::CProfile(const CStringW& iniFilePath)
@@ -267,7 +269,7 @@ void CProfile::InitIni()
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
         return;
     }
 
@@ -292,7 +294,7 @@ bool CProfile::StoreSettingsTo(const SettingsLocation newLocation)
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
 
     if (newLocation == SETS_REGISTRY) {
-        if (m_hAppRegKey) {
+        if (m_bRegistryMode) {
             return true; // already in the registry
         }
 
@@ -301,24 +303,29 @@ bool CProfile::StoreSettingsTo(const SettingsLocation newLocation)
             return false; // ini can not be deleted; transfer canceled
         }
 
+        m_bRegistryMode = true;
         OpenRegistryKey();
         if (m_hAppRegKey) {
             m_IniPath.Empty();
             return true;
         }
-
+        m_bRegistryMode = false; // key creation failed; remain in INI mode
         return false;
     }
 
     // SETS_PROGRAMDIR
-    if (!m_IniPath.IsEmpty() && !m_hAppRegKey) {
+    if (!m_bRegistryMode && !m_IniPath.IsEmpty()) {
         return true; // already stored in the program folder
     }
 
-    if (m_hAppRegKey) {
-        RegDeleteTreeW(m_hAppRegKey, nullptr);
-        RegCloseKey(m_hAppRegKey);
-        m_hAppRegKey = nullptr;
+    if (m_bRegistryMode) {
+        OpenRegistryKey(); // ensure the handle so the registry store can be removed
+        if (m_hAppRegKey) {
+            RegDeleteTreeW(m_hAppRegKey, nullptr);
+            RegCloseKey(m_hAppRegKey);
+            m_hAppRegKey = nullptr;
+        }
+        m_bRegistryMode = false;
     }
 
     const CStringW newIniPath = GetNewIniPath();
@@ -357,7 +364,8 @@ bool CProfile::ReadInt(const wchar_t* section, const wchar_t* entry, int& value)
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             if (ERROR_SUCCESS == regkey.QueryDWORDValue(entry, *(DWORD*)&value)) {
@@ -400,7 +408,8 @@ bool CProfile::ReadUInt(const wchar_t* section, const wchar_t* entry, unsigned& 
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             if (ERROR_SUCCESS == regkey.QueryDWORDValue(entry, *(DWORD*)&value)) {
@@ -443,7 +452,8 @@ bool CProfile::ReadInt64(const wchar_t* section, const wchar_t* entry, __int64& 
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             if (ERROR_SUCCESS == regkey.QueryQWORDValue(entry, *(ULONGLONG*)&value)) {
@@ -486,7 +496,8 @@ bool CProfile::ReadDouble(const wchar_t* section, const wchar_t* entry, double& 
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             ULONG nChars = 0;
@@ -533,7 +544,8 @@ bool CProfile::ReadHex32(const wchar_t* section, const wchar_t* entry, unsigned&
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             if (ERROR_SUCCESS == regkey.QueryDWORDValue(entry, *(DWORD*)&value)) {
@@ -561,7 +573,8 @@ bool CProfile::ReadString(const wchar_t* section, const wchar_t* entry, CStringW
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             ULONG nChars = 0;
@@ -593,7 +606,8 @@ bool CProfile::ReadBinary(const wchar_t* section, const wchar_t* entry, BYTE** p
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             if (ERROR_SUCCESS == regkey.QueryBinaryValue(entry, nullptr, (ULONG*)&nbytes)) {
@@ -640,7 +654,8 @@ bool CProfile::WriteInt(const wchar_t* section, const wchar_t* entry, const int 
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
             if (ERROR_SUCCESS == regkey.SetDWORDValue(entry, (DWORD)value)) {
@@ -669,7 +684,8 @@ bool CProfile::WriteUInt(const wchar_t* section, const wchar_t* entry, const uns
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
             if (ERROR_SUCCESS == regkey.SetDWORDValue(entry, (DWORD)value)) {
@@ -698,7 +714,8 @@ bool CProfile::WriteInt64(const wchar_t* section, const wchar_t* entry, const __
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
             if (ERROR_SUCCESS == regkey.SetQWORDValue(entry, (ULONGLONG)value)) {
@@ -731,7 +748,8 @@ bool CProfile::WriteDouble(const wchar_t* section, const wchar_t* entry, const d
     CStringW valueStr;
     valueStr.Format(L"%.4f", value);
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
             if (ERROR_SUCCESS == regkey.SetStringValue(entry, valueStr)) {
@@ -758,7 +776,8 @@ bool CProfile::WriteHex32(const wchar_t* section, const wchar_t* entry, const un
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
             if (ERROR_SUCCESS == regkey.SetDWORDValue(entry, (DWORD)value)) {
@@ -787,7 +806,8 @@ bool CProfile::WriteString(const wchar_t* section, const wchar_t* entry, const C
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
             if (ERROR_SUCCESS == regkey.SetStringValue(entry, value)) {
@@ -814,7 +834,8 @@ bool CProfile::WriteBinary(const wchar_t* section, const wchar_t* entry, const B
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Create(m_hAppRegKey, section)) {
             if (ERROR_SUCCESS == regkey.SetBinaryValue(entry, pdata, nbytes)) {
@@ -845,7 +866,8 @@ void CProfile::EnumValueNames(const wchar_t* section, std::vector<CStringW>& val
 
     valuenames.clear();
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             DWORD cValues     = 0;
@@ -884,7 +906,8 @@ void CProfile::EnumSectionNames(const wchar_t* section, std::vector<CStringW>& s
 
     sectionnames.clear();
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             DWORD cSubKeys    = 0;
@@ -935,7 +958,8 @@ bool CProfile::DeleteValue(const wchar_t* section, const wchar_t* entry)
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_WRITE)) {
             if (ERROR_SUCCESS == regkey.DeleteValue(entry)) {
@@ -963,7 +987,8 @@ bool CProfile::DeleteSection(const wchar_t* section)
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, L"", KEY_WRITE)) {
             if (ERROR_SUCCESS == regkey.RecurseDeleteKey(section)) {
@@ -996,7 +1021,7 @@ bool CProfile::DeleteSection(const wchar_t* section)
 
 void CProfile::Flush(bool bForce)
 {
-    if (m_hAppRegKey || (!bForce && !m_bIniNeedFlush)) {
+    if (m_bRegistryMode || (!bForce && !m_bIniNeedFlush)) {
         return;
     }
 
@@ -1046,8 +1071,11 @@ void CProfile::Clear()
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
 
-    if (m_hAppRegKey) {
-        RegDeleteTreeW(m_hAppRegKey, nullptr);
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
+        if (m_hAppRegKey) {
+            RegDeleteTreeW(m_hAppRegKey, nullptr);
+        }
     } else {
         ASSERT(!m_IniPath.IsEmpty());
         CFile file;
@@ -1128,13 +1156,14 @@ bool CProfile::MigrateFromLegacy()
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
         // Registry: recursively copy the legacy MFC key into the new key,
         // preserving native value types (REG_DWORD/REG_SZ/REG_BINARY/...).
         HKEY hLegacy = nullptr;
         if (ERROR_SUCCESS != RegOpenKeyExW(HKEY_CURRENT_USER, LEGACY_REG_KEY, 0, KEY_READ, &hLegacy)) {
             return false;
         }
+        OpenRegistryKey();
         CopyRegistryTree(hLegacy, m_hAppRegKey);
         RegCloseKey(hLegacy);
         return true;
@@ -1167,11 +1196,12 @@ bool CProfile::SeedFromVersion(const CStringW& fromVersion)
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
         HKEY hSrc = nullptr;
         if (RegOpenKeyExW(HKEY_CURRENT_USER, SettingsRegKeyFor(fromVersion), 0, KEY_READ, &hSrc) != ERROR_SUCCESS) {
             return false; // source store doesn't exist
         }
+        OpenRegistryKey();
         CopyRegistryTree(hSrc, m_hAppRegKey);
         RegCloseKey(hSrc);
         return true;
@@ -1197,7 +1227,8 @@ void CProfile::EnumSettingsStoreVersions(std::vector<CStringW>& versions)
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
     versions.clear();
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        // Read-only enumeration of the parent key; does not create our own store.
         CRegKey parent;
         if (parent.Open(HKEY_CURRENT_USER, COMPANY_REG_KEY, KEY_READ) == ERROR_SUCCESS) {
             const CStringW pfx(L"Settings-");
@@ -1245,7 +1276,7 @@ void CProfile::MoveSectionTree(const wchar_t* root, CProfile& dst)
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
         return; // the MediaHistory split only applies in INI mode
     }
 
@@ -1277,7 +1308,8 @@ bool CProfile::HasEntry(const wchar_t* section, const wchar_t* entry)
 
     bool ret = false;
 
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
+        OpenRegistryKey();
         CRegKey regkey;
         if (ERROR_SUCCESS == regkey.Open(m_hAppRegKey, section, KEY_READ)) {
             ret = (ERROR_SUCCESS == RegQueryValueExW(regkey.m_hKey, entry, nullptr, nullptr, nullptr, nullptr));
@@ -1296,12 +1328,12 @@ bool CProfile::HasEntry(const wchar_t* section, const wchar_t* entry)
 
 CStringW CProfile::GetRegistryKeyPath() const
 {
-    return m_hAppRegKey ? SettingsRegKey() : CStringW();
+    return m_bRegistryMode ? SettingsRegKey() : CStringW();
 }
 
 SettingsLocation CProfile::GetSettingsLocation() const
 {
-    if (m_hAppRegKey) {
+    if (m_bRegistryMode) {
         return SETS_REGISTRY;
     }
     return SETS_PROGRAMDIR;

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -251,6 +251,11 @@ CStringW CProfile::SettingsIndexIniPath()
     return GetExeBasePath() + INDEX_INI_SUFFIX;
 }
 
+CStringW CProfile::DefaultIniPath()
+{
+    return GetNewIniPath();
+}
+
 LONG CProfile::OpenRegistryKey()
 {
     LONG lResult = ERROR_SUCCESS;

--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -229,6 +229,78 @@ CStringW CProfile::HistoryIniPath()
     return GetExeBasePath() + HISTORY_INI_SUFFIX;
 }
 
+CStringW CProfile::VersionedIniPath(const CStringW& version)
+{
+    if (version.IsEmpty()) {
+        return GetNewIniPath();
+    }
+    return GetExeBasePath() + L"." + version + NEW_INI_SUFFIX;
+}
+
+// Enumerate an open registry key recursively into a ProfileMap, converting each
+// value to the INI textual form CProfile would use (so a registry store can seed
+// an INI fork). `section` is the path built from subkeys ("" at the root).
+static void EnumerateRegistryTree(HKEY hKey, const CStringW& section, ProfileMap& out)
+{
+    if (!section.IsEmpty()) {
+        WCHAR name[512];
+        for (DWORD i = 0;; i++) {
+            DWORD nameLen = _countof(name), type = 0, dataLen = 0;
+            LONG r = RegEnumValueW(hKey, i, name, &nameLen, nullptr, &type, nullptr, &dataLen);
+            if (r == ERROR_NO_MORE_ITEMS) {
+                break;
+            }
+            if (r != ERROR_SUCCESS || dataLen == 0) {
+                continue;
+            }
+            std::vector<BYTE> data(dataLen);
+            DWORD cb = dataLen;
+            if (RegQueryValueExW(hKey, name, nullptr, &type, data.data(), &cb) != ERROR_SUCCESS) {
+                continue;
+            }
+            CStringW val;
+            switch (type) {
+                case REG_DWORD:
+                    if (cb < sizeof(DWORD)) continue;
+                    val.Format(L"%d", static_cast<int>(*reinterpret_cast<DWORD*>(data.data())));
+                    break;
+                case REG_QWORD:
+                    if (cb < sizeof(ULONGLONG)) continue;
+                    val.Format(L"%I64d", *reinterpret_cast<ULONGLONG*>(data.data()));
+                    break;
+                case REG_SZ:
+                case REG_EXPAND_SZ:
+                    val = reinterpret_cast<LPCWSTR>(data.data());
+                    break;
+                case REG_BINARY:
+                    val = CStringW(BINARY_B64_PREFIX) + BinaryToBase64(data.data(), cb);
+                    break;
+                default:
+                    continue;
+            }
+            out[section][name] = val;
+        }
+    }
+
+    WCHAR sub[256];
+    for (DWORD i = 0;; i++) {
+        DWORD subLen = _countof(sub);
+        LONG r = RegEnumKeyExW(hKey, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
+        if (r == ERROR_NO_MORE_ITEMS) {
+            break;
+        }
+        if (r != ERROR_SUCCESS) {
+            continue;
+        }
+        HKEY hSub;
+        if (RegOpenKeyExW(hKey, sub, 0, KEY_READ, &hSub) == ERROR_SUCCESS) {
+            CStringW child = section.IsEmpty() ? CStringW(sub) : (section + L"\\" + sub);
+            EnumerateRegistryTree(hSub, child, out);
+            RegCloseKey(hSub);
+        }
+    }
+}
+
 LONG CProfile::OpenRegistryKey()
 {
     LONG lResult = ERROR_SUCCESS;
@@ -1136,20 +1208,45 @@ CStringW CProfile::GetRegistryKeyPath() const
     return m_hAppRegKey ? CStringW(PROFILE_REG_KEY) : CStringW();
 }
 
-bool CProfile::ForkToLocalIni()
+bool CProfile::ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent)
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    // Capture the current store's contents first (if seeding a new fork).
+    ProfileMap seed;
+    if (seedFromCurrent) {
+        if (m_hAppRegKey) {
+            EnumerateRegistryTree(m_hAppRegKey, CStringW(), seed); // registry -> INI form
+        } else {
+            InitIni();
+            seed = m_ProfileMap; // already INI form (verbatim, incl. b64: values)
+        }
+    }
 
     if (m_hAppRegKey) {
         RegCloseKey(m_hAppRegKey); // detach only; the shared registry store is left intact
         m_hAppRegKey = nullptr;
     }
 
-    m_IniPath = GetNewIniPath();
+    m_IniPath = iniPath;
     m_ProfileMap.clear();
     m_bIniFirstInit = false; // force InitIni() to (re)read the local file if present
     m_bIniNeedFlush = false;
     InitIni();
+
+    if (seedFromCurrent && !seed.empty()) {
+        // Fill in from the seed without overwriting anything already in an
+        // existing fork file.
+        for (const auto& sec : seed) {
+            for (const auto& kv : sec.second) {
+                auto& dst = m_ProfileMap[sec.first];
+                if (dst.find(kv.first) == dst.end()) {
+                    dst[kv.first] = kv.second;
+                    m_bIniNeedFlush = true;
+                }
+            }
+        }
+    }
 
     return true;
 }

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -91,6 +91,10 @@ public:
     // Path of the version-independent index/manifest INI (<exe-basename>.settings.ini)
     // that records which settings/history format versions are present.
     static CStringW SettingsIndexIniPath();
+    // Path where a portable settings INI would be created for this build. Used to
+    // report a prospective target even in registry mode (e.g. for the "store to
+    // ini" option's write-permission check), where GetIniPath() is empty.
+    static CStringW DefaultIniPath();
 
 private:
     LONG OpenRegistryKey();

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -133,6 +133,12 @@ public:
     // legacy-format sunset. Caller guards against re-running.
     bool MigrateFromLegacy();
 
+    // Seed this (empty, current-version) store with the full contents of the
+    // Settings-<fromVersion> store, in this store's mode (registry or INI). Used
+    // by the migration driver before applying in-place format transforms.
+    // Returns true if the source store existed and was copied.
+    bool SeedFromVersion(const CStringW& fromVersion);
+
     // Move a section and all its subsections ("root" and "root\...") into
     // another profile (preserving raw values) and remove them from this one.
     // Used once to split MediaHistory out into its own store. INI mode.

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -46,8 +46,11 @@ enum SettingsLocation {
 // History-<ver>); bump the version when the layout changes incompatibly and add
 // a migration step. Older builds only know their own version and ignore newer
 // stores. See docs/settings-versioning.md.
-inline const wchar_t* const SETTINGS_FORMAT_VERSION = L"1.0";
-inline const wchar_t* const HISTORY_FORMAT_VERSION  = L"1.0";
+inline const wchar_t* const SETTINGS_FORMAT_VERSION = L"v1";
+inline const wchar_t* const HISTORY_FORMAT_VERSION  = L"v1";
+// The pre-versioned legacy layout is identical to the first format version, so
+// it seeds the migration chain as that version (not necessarily the current one).
+inline const wchar_t* const LEGACY_EQUIVALENT_VERSION = L"v1";
 
 // Sections and keys are matched case-insensitively; sections are kept ordered
 // (std::map) because EnumSectionNames() relies on the ordering to range-walk

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -19,16 +19,14 @@
  */
 
 // Settings store engine for MPC-HC, adapted from MPC-BE's CProfile
-// (src/DSUtil/Profile.{h,cpp}). This is the NEW versioned settings format;
-// the pre-existing inline profile code in CMPlayerCApp remains the LEGACY
-// format and is imported once (see the legacy importer, added separately).
-//
-// New-format store locations (see Profile.cpp for the name constants):
-//   - Program-dir INI  : a NEW .ini file next to the executable (portable).
-//   - Registry         : a NEW key SIBLING to the legacy one, under the
-//                        shared HKCU\Software\MPC-HC parent.
-// The legacy store (old .ini / old registry key) is left untouched so older
-// MPC-HC builds keep working (downgrade-safe).
+// (src/DSUtil/Profile.{h,cpp}). It replaces the old inline profile code in
+// CMPlayerCApp but keeps the SAME on-disk location and format, so external
+// tools and older builds keep reading the settings unchanged:
+//   - Registry  : HKCU\Software\MPC-HC\MPC-HC
+//   - Portable  : <exe-basename>.ini next to the executable
+// Binary values use the legacy A-P encoding for byte compatibility. The only
+// relocation is MediaHistory, which moves to <exe-basename>.history.ini in
+// portable mode (see mplayerc.cpp / SetupHistoryStore).
 
 #pragma once
 
@@ -41,16 +39,6 @@ enum SettingsLocation {
     SETS_REGISTRY,
     SETS_PROGRAMDIR
 };
-
-// On-disk format versions. The store name encodes the version (Settings-<ver> /
-// History-<ver>); bump the version when the layout changes incompatibly and add
-// a migration step. Older builds only know their own version and ignore newer
-// stores. See docs/settings-versioning.md.
-inline const wchar_t* const SETTINGS_FORMAT_VERSION = L"v1";
-inline const wchar_t* const HISTORY_FORMAT_VERSION  = L"v1";
-// The pre-versioned legacy layout is identical to the first format version, so
-// it seeds the migration chain as that version (not necessarily the current one).
-inline const wchar_t* const LEGACY_EQUIVALENT_VERSION = L"v1";
 
 // Sections and keys are matched case-insensitively; sections are kept ordered
 // (std::map) because EnumSectionNames() relies on the ordering to range-walk
@@ -86,12 +74,8 @@ public:
     explicit CProfile(const CStringW& iniFilePath);
     ~CProfile();
 
-    // Paths of the separate MediaHistory INI and its downgrade-fork counterpart.
+    // Path of the separate MediaHistory INI.
     static CStringW HistoryIniPath();       // <exe-basename>.history.ini
-    static CStringW HistoryLocalIniPath();  // <exe-basename>.history.local.ini
-    // Downgrade-fork settings file (<exe-basename>.settings.local.ini), used when
-    // this build finds a store written in a newer format than it understands.
-    static CStringW LocalIniPath();
     // Path where a portable settings INI would be created for this build. Used to
     // report a prospective target even in registry mode (e.g. for the "store to
     // ini" option's write-permission check), where GetIniPath() is empty.
@@ -137,21 +121,6 @@ public:
 
     void Flush(bool bForce);
     void Clear();
-
-    // One-time legacy import: copy the OLD MPC-HC settings (legacy registry key
-    // or legacy <exe>.ini) into this (new) store, in the matching storage mode.
-    // Registry is copied with native value types; INI is copied verbatim (old
-    // A-P binary values are read back via the un-prefixed path in ReadBinary).
-    // Returns true if a legacy store was found and imported. Deletable at the
-    // legacy-format sunset. Caller guards against re-running.
-    bool MigrateFromLegacy();
-
-    // Downgrade protection: switch this instance to a private INI at iniPath and
-    // DETACH from the shared store WITHOUT deleting it, so a newer-format store
-    // written by a newer build survives. If iniPath already exists it is loaded;
-    // if seedFromCurrent is set and iniPath is new, the current store's contents
-    // are copied in (registry values converted to INI form).
-    bool ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent = false);
 
     // Move a section and all its subsections ("root" and "root\...") into
     // another profile (preserving raw values) and remove them from this one.

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -73,6 +73,10 @@ public:
 
     // Path of the separate MediaHistory INI (<exe-basename>.history.ini).
     static CStringW HistoryIniPath();
+    // Path of a per-version settings INI used by the downgrade fork:
+    // <exe-basename>.<version>.settings.ini (falls back to the shared
+    // <exe-basename>.settings.ini when version is empty).
+    static CStringW VersionedIniPath(const CStringW& version);
 
 private:
     LONG OpenRegistryKey();
@@ -128,12 +132,12 @@ public:
     // Used once to split MediaHistory out into its own store. INI mode.
     void MoveSectionTree(const wchar_t* root, CProfile& dst);
 
-    // Downgrade protection: when an older build opens a store last written by a
-    // newer build, switch this instance to a private INI next to the executable
-    // (loaded if it already exists, else started empty) and DETACH from the
-    // shared store WITHOUT deleting it, so the newer build's settings survive.
-    // Registry mode only needs this; a portable store is already local.
-    bool ForkToLocalIni();
+    // Downgrade protection: switch this instance to a private INI at iniPath and
+    // DETACH from the shared store WITHOUT deleting it, so the newer build's
+    // settings survive. If iniPath already exists it is loaded (used as-is). If
+    // seedFromCurrent is set and iniPath is new, the current store's contents are
+    // copied in as a starting point (registry values are converted to INI form).
+    bool ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent = false);
 
     SettingsLocation GetSettingsLocation() const;
 

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -86,11 +86,12 @@ public:
     explicit CProfile(const CStringW& iniFilePath);
     ~CProfile();
 
-    // Path of the separate MediaHistory INI (<exe-basename>.history-<ver>.ini).
-    static CStringW HistoryIniPath();
-    // Path of the version-independent index/manifest INI (<exe-basename>.settings.ini)
-    // that records which settings/history format versions are present.
-    static CStringW SettingsIndexIniPath();
+    // Paths of the separate MediaHistory INI and its downgrade-fork counterpart.
+    static CStringW HistoryIniPath();       // <exe-basename>.history.ini
+    static CStringW HistoryLocalIniPath();  // <exe-basename>.history.local.ini
+    // Downgrade-fork settings file (<exe-basename>.settings.local.ini), used when
+    // this build finds a store written in a newer format than it understands.
+    static CStringW LocalIniPath();
     // Path where a portable settings INI would be created for this build. Used to
     // report a prospective target even in registry mode (e.g. for the "store to
     // ini" option's write-permission check), where GetIniPath() is empty.
@@ -145,16 +146,12 @@ public:
     // legacy-format sunset. Caller guards against re-running.
     bool MigrateFromLegacy();
 
-    // Seed this (empty, current-version) store with the full contents of the
-    // Settings-<fromVersion> store, in this store's mode (registry or INI). Used
-    // by the migration driver before applying in-place format transforms.
-    // Returns true if the source store existed and was copied.
-    bool SeedFromVersion(const CStringW& fromVersion);
-
-    // Format versions for which a Settings-<ver> store currently exists, in this
-    // store's mode (registry subkeys / <exe>.settings-<ver>.ini files). Used to
-    // pick the best older store to seed/migrate from.
-    void EnumSettingsStoreVersions(std::vector<CStringW>& versions);
+    // Downgrade protection: switch this instance to a private INI at iniPath and
+    // DETACH from the shared store WITHOUT deleting it, so a newer-format store
+    // written by a newer build survives. If iniPath already exists it is loaded;
+    // if seedFromCurrent is set and iniPath is new, the current store's contents
+    // are copied in (registry values converted to INI form).
+    bool ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent = false);
 
     // Move a section and all its subsections ("root" and "root\...") into
     // another profile (preserving raw values) and remove them from this one.

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -42,6 +42,13 @@ enum SettingsLocation {
     SETS_PROGRAMDIR
 };
 
+// On-disk format versions. The store name encodes the version (Settings-<ver> /
+// History-<ver>); bump the version when the layout changes incompatibly and add
+// a migration step. Older builds only know their own version and ignore newer
+// stores. See docs/settings-versioning.md.
+inline const wchar_t* const SETTINGS_FORMAT_VERSION = L"1.0";
+inline const wchar_t* const HISTORY_FORMAT_VERSION  = L"1.0";
+
 // Sections and keys are matched case-insensitively; sections are kept ordered
 // (std::map) because EnumSectionNames() relies on the ordering to range-walk
 // subsections by "<section>\" prefix.
@@ -71,12 +78,11 @@ public:
     explicit CProfile(const CStringW& iniFilePath);
     ~CProfile();
 
-    // Path of the separate MediaHistory INI (<exe-basename>.history.ini).
+    // Path of the separate MediaHistory INI (<exe-basename>.history-<ver>.ini).
     static CStringW HistoryIniPath();
-    // Path of a per-version settings INI used by the downgrade fork:
-    // <exe-basename>.<version>.settings.ini (falls back to the shared
-    // <exe-basename>.settings.ini when version is empty).
-    static CStringW VersionedIniPath(const CStringW& version);
+    // Path of the version-independent index/manifest INI (<exe-basename>.settings.ini)
+    // that records which settings/history format versions are present.
+    static CStringW SettingsIndexIniPath();
 
 private:
     LONG OpenRegistryKey();
@@ -131,13 +137,6 @@ public:
     // another profile (preserving raw values) and remove them from this one.
     // Used once to split MediaHistory out into its own store. INI mode.
     void MoveSectionTree(const wchar_t* root, CProfile& dst);
-
-    // Downgrade protection: switch this instance to a private INI at iniPath and
-    // DETACH from the shared store WITHOUT deleting it, so the newer build's
-    // settings survive. If iniPath already exists it is loaded (used as-is). If
-    // seedFromCurrent is set and iniPath is new, the current store's contents are
-    // copied in as a starting point (registry values are converted to INI form).
-    bool ForkToLocalIni(const CStringW& iniPath, bool seedFromCurrent = false);
 
     SettingsLocation GetSettingsLocation() const;
 

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -1,0 +1,176 @@
+/*
+ * (C) 2024 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Settings store engine for MPC-HC, adapted from MPC-BE's CProfile
+// (src/DSUtil/Profile.{h,cpp}). This is the NEW versioned settings format;
+// the pre-existing inline profile code in CMPlayerCApp remains the LEGACY
+// format and is imported once (see the legacy importer, added separately).
+//
+// New-format store locations (see Profile.cpp for the name constants):
+//   - Program-dir INI  : a NEW .ini file next to the executable (portable).
+//   - Registry         : a NEW key SIBLING to the legacy one, under the
+//                        shared HKCU\Software\MPC-HC parent.
+// The legacy store (old .ini / old registry key) is left untouched so older
+// MPC-HC builds keep working (downgrade-safe).
+
+#pragma once
+
+#include <mutex>
+#include <map>
+#include <vector>
+#include "DSUtil.h" // CStringUtils::IgnoreCaseLess
+
+enum SettingsLocation {
+    SETS_REGISTRY,
+    SETS_PROGRAMDIR
+};
+
+// Sections and keys are matched case-insensitively; sections are kept ordered
+// (std::map) because EnumSectionNames() relies on the ordering to range-walk
+// subsections by "<section>\" prefix.
+using ProfileSection = std::map<CStringW, CStringW, CStringUtils::IgnoreCaseLess>;
+using ProfileMap     = std::map<CStringW, ProfileSection, CStringUtils::IgnoreCaseLess>;
+
+class CProfile
+{
+private:
+    std::recursive_mutex m_Mutex;
+
+    // registry
+    HKEY m_hAppRegKey = nullptr;
+
+    // INI file
+    CStringW m_IniPath;
+
+    ProfileMap m_ProfileMap;
+    bool      m_bIniFirstInit = false;
+    bool      m_bIniNeedFlush = false;
+    ULONGLONG m_IniLastAccessTick = 0;
+
+public:
+    CProfile();
+    ~CProfile();
+
+private:
+    LONG OpenRegistryKey();
+    // read all the fields from the ini file
+    void InitIni();
+
+public:
+    bool StoreSettingsTo(const SettingsLocation newLocation);
+
+    bool ReadBool  (const wchar_t* section, const wchar_t* entry, bool&     value);
+    bool ReadInt   (const wchar_t* section, const wchar_t* entry, int&      value);
+    bool ReadInt   (const wchar_t* section, const wchar_t* entry, int&      value, const int lo, const int hi);
+    bool ReadUInt  (const wchar_t* section, const wchar_t* entry, unsigned& value);
+    bool ReadUInt  (const wchar_t* section, const wchar_t* entry, unsigned& value, const unsigned lo, const unsigned hi);
+    bool ReadInt64 (const wchar_t* section, const wchar_t* entry, __int64&  value);
+    bool ReadInt64 (const wchar_t* section, const wchar_t* entry, __int64&  value, const __int64 lo, const __int64 hi);
+    bool ReadDouble(const wchar_t* section, const wchar_t* entry, double&   value);
+    bool ReadDouble(const wchar_t* section, const wchar_t* entry, double&   value, const double lo, const double hi);
+    bool ReadHex32 (const wchar_t* section, const wchar_t* entry, unsigned& value);
+    bool ReadString(const wchar_t* section, const wchar_t* entry, CStringW& value);
+    bool ReadBinary(const wchar_t* section, const wchar_t* entry, BYTE** ppdata, unsigned& nbytes);
+
+    bool WriteBool  (const wchar_t* section, const wchar_t* entry, const bool      value);
+    bool WriteInt   (const wchar_t* section, const wchar_t* entry, const int       value);
+    bool WriteUInt  (const wchar_t* section, const wchar_t* entry, const unsigned  value);
+    bool WriteInt64 (const wchar_t* section, const wchar_t* entry, const __int64   value);
+    bool WriteDouble(const wchar_t* section, const wchar_t* entry, const double    value);
+    bool WriteHex32 (const wchar_t* section, const wchar_t* entry, const unsigned  value);
+    bool WriteString(const wchar_t* section, const wchar_t* entry, const CStringW& value);
+    bool WriteBinary(const wchar_t* section, const wchar_t* entry, const BYTE* pdata, const unsigned nbytes);
+
+    void EnumValueNames(const wchar_t* section, std::vector<CStringW>& valuenames);
+    void EnumSectionNames(const wchar_t* section, std::vector<CStringW>& sectionnames);
+
+    bool DeleteValue(const wchar_t* section, const wchar_t* entry);
+    bool DeleteSection(const wchar_t* section);
+
+    void Flush(bool bForce);
+    void Clear();
+
+    // One-time legacy import: copy the OLD MPC-HC settings (legacy registry key
+    // or legacy <exe>.ini) into this (new) store, in the matching storage mode.
+    // Registry is copied with native value types; INI is copied verbatim (old
+    // A-P binary values are read back via the un-prefixed path in ReadBinary).
+    // Returns true if a legacy store was found and imported. Deletable at the
+    // legacy-format sunset. Caller guards against re-running.
+    bool MigrateFromLegacy();
+
+    // Downgrade protection: when an older build opens a store last written by a
+    // newer build, switch this instance to a private INI next to the executable
+    // (loaded if it already exists, else started empty) and DETACH from the
+    // shared store WITHOUT deleting it, so the newer build's settings survive.
+    // Registry mode only needs this; a portable store is already local.
+    bool ForkToLocalIni();
+
+    SettingsLocation GetSettingsLocation() const;
+
+    CStringW GetIniPath() const {
+        return m_IniPath;
+    }
+};
+
+// App base class that routes MFC's profile calls to CProfile, so existing
+// call sites (theApp.GetProfileInt(...) etc.) keep working unchanged.
+// CMPlayerCApp will derive from this instead of CWinAppEx (wired separately).
+class CModApp : public CWinAppEx
+{
+public:
+    CProfile m_Profile;
+
+    // Must override GetProfile/WriteProfile, because MFC and other MFC
+    // dependent libraries use them.
+    UINT GetProfileInt(LPCTSTR lpszSection, LPCTSTR lpszEntry, int nDefault) override {
+        int value;
+        if (m_Profile.ReadInt(lpszSection, lpszEntry, value)) {
+            return value;
+        }
+        return nDefault;
+    }
+    BOOL WriteProfileInt(LPCTSTR lpszSection, LPCTSTR lpszEntry, int nValue) override {
+        return m_Profile.WriteInt(lpszSection, lpszEntry, nValue);
+    }
+    CString GetProfileString(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPCTSTR lpszDefault = nullptr) override {
+        CStringW value;
+        if (!m_Profile.ReadString(lpszSection, lpszEntry, value) && lpszDefault) {
+            value = lpszDefault;
+        }
+        return value;
+    }
+    BOOL WriteProfileString(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPCTSTR lpszValue) override {
+        if (!lpszValue) {
+            if (!lpszEntry) {
+                return m_Profile.DeleteSection(lpszSection);
+            }
+            return m_Profile.DeleteValue(lpszSection, lpszEntry);
+        }
+        return m_Profile.WriteString(lpszSection, lpszEntry, lpszValue);
+    }
+    BOOL GetProfileBinary(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPBYTE* ppData, UINT* pBytes) override {
+        return m_Profile.ReadBinary(lpszSection, lpszEntry, ppData, *pBytes) ? TRUE : FALSE;
+    }
+    BOOL WriteProfileBinary(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPBYTE pData, UINT nBytes) override {
+        return m_Profile.WriteBinary(lpszSection, lpszEntry, pData, nBytes);
+    }
+};
+
+#define AfxGetProfile() static_cast<CModApp*>(AfxGetApp())->m_Profile

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -66,7 +66,13 @@ private:
 
 public:
     CProfile();
+    // Force INI mode bound to a specific file (used for the separate
+    // MediaHistory store), bypassing the portable/registry auto-detection.
+    explicit CProfile(const CStringW& iniFilePath);
     ~CProfile();
+
+    // Path of the separate MediaHistory INI (<exe-basename>.history.ini).
+    static CStringW HistoryIniPath();
 
 private:
     LONG OpenRegistryKey();
@@ -101,6 +107,8 @@ public:
     void EnumValueNames(const wchar_t* section, std::vector<CStringW>& valuenames);
     void EnumSectionNames(const wchar_t* section, std::vector<CStringW>& sectionnames);
 
+    bool HasEntry(const wchar_t* section, const wchar_t* entry);
+
     bool DeleteValue(const wchar_t* section, const wchar_t* entry);
     bool DeleteSection(const wchar_t* section);
 
@@ -115,6 +123,11 @@ public:
     // legacy-format sunset. Caller guards against re-running.
     bool MigrateFromLegacy();
 
+    // Move a section and all its subsections ("root" and "root\...") into
+    // another profile (preserving raw values) and remove them from this one.
+    // Used once to split MediaHistory out into its own store. INI mode.
+    void MoveSectionTree(const wchar_t* root, CProfile& dst);
+
     // Downgrade protection: when an older build opens a store last written by a
     // newer build, switch this instance to a private INI next to the executable
     // (loaded if it already exists, else started empty) and DETACH from the
@@ -124,53 +137,15 @@ public:
 
     SettingsLocation GetSettingsLocation() const;
 
+    // Registry path ("Software\\MPC-HC\\...") of the store when in registry
+    // mode, empty otherwise. Used by settings export.
+    CStringW GetRegistryKeyPath() const;
+
     CStringW GetIniPath() const {
         return m_IniPath;
     }
 };
 
-// App base class that routes MFC's profile calls to CProfile, so existing
-// call sites (theApp.GetProfileInt(...) etc.) keep working unchanged.
-// CMPlayerCApp will derive from this instead of CWinAppEx (wired separately).
-class CModApp : public CWinAppEx
-{
-public:
-    CProfile m_Profile;
-
-    // Must override GetProfile/WriteProfile, because MFC and other MFC
-    // dependent libraries use them.
-    UINT GetProfileInt(LPCTSTR lpszSection, LPCTSTR lpszEntry, int nDefault) override {
-        int value;
-        if (m_Profile.ReadInt(lpszSection, lpszEntry, value)) {
-            return value;
-        }
-        return nDefault;
-    }
-    BOOL WriteProfileInt(LPCTSTR lpszSection, LPCTSTR lpszEntry, int nValue) override {
-        return m_Profile.WriteInt(lpszSection, lpszEntry, nValue);
-    }
-    CString GetProfileString(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPCTSTR lpszDefault = nullptr) override {
-        CStringW value;
-        if (!m_Profile.ReadString(lpszSection, lpszEntry, value) && lpszDefault) {
-            value = lpszDefault;
-        }
-        return value;
-    }
-    BOOL WriteProfileString(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPCTSTR lpszValue) override {
-        if (!lpszValue) {
-            if (!lpszEntry) {
-                return m_Profile.DeleteSection(lpszSection);
-            }
-            return m_Profile.DeleteValue(lpszSection, lpszEntry);
-        }
-        return m_Profile.WriteString(lpszSection, lpszEntry, lpszValue);
-    }
-    BOOL GetProfileBinary(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPBYTE* ppData, UINT* pBytes) override {
-        return m_Profile.ReadBinary(lpszSection, lpszEntry, ppData, *pBytes) ? TRUE : FALSE;
-    }
-    BOOL WriteProfileBinary(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPBYTE pData, UINT nBytes) override {
-        return m_Profile.WriteBinary(lpszSection, lpszEntry, pData, nBytes);
-    }
-};
-
-#define AfxGetProfile() static_cast<CModApp*>(AfxGetApp())->m_Profile
+// CMPlayerCApp owns a CProfile (m_Profile) and delegates MFC's GetProfile*/
+// WriteProfile* overrides to it (see mplayerc.cpp).
+#define AfxGetProfile() (AfxGetMyApp()->m_Profile)

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -63,7 +63,12 @@ class CProfile
 private:
     std::recursive_mutex m_Mutex;
 
-    // registry
+    // registry. m_bRegistryMode is the store-location flag decided (read-only) at
+    // construction; m_hAppRegKey is opened/created LAZILY on first actual access
+    // (OpenRegistryKey), so no registry key is materialized at static-init time -
+    // only when the running app truly reads/writes settings. Registry-branch code
+    // must gate on m_bRegistryMode (not the handle) and call OpenRegistryKey().
+    bool m_bRegistryMode = false;
     HKEY m_hAppRegKey = nullptr;
 
     // INI file

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -142,6 +142,11 @@ public:
     // Returns true if the source store existed and was copied.
     bool SeedFromVersion(const CStringW& fromVersion);
 
+    // Format versions for which a Settings-<ver> store currently exists, in this
+    // store's mode (registry subkeys / <exe>.settings-<ver>.ini files). Used to
+    // pick the best older store to seed/migrate from.
+    void EnumSettingsStoreVersions(std::vector<CStringW>& versions);
+
     // Move a section and all its subsections ("root" and "root\...") into
     // another profile (preserving raw values) and remove them from this one.
     // Used once to split MediaHistory out into its own store. INI mode.

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -132,6 +132,7 @@
 #define IDS_RS_CONFIRM_FILE_DELETE          _T("ConfirmFileDelete")
 #define IDS_RS_LIBASS_FOR_SRT               _T("UseLibassForSRT")
 #define IDS_RS_SHOW_VOLUME_PERCENTAGE       _T("ShowVolumePercentage")
+#define IDS_RS_HISTORY_IN_APPDATA           _T("HistoryInAppData")
 #define IDS_RS_TIME_ON_SEEKBAR              _T("TimeOnSeekBar")
 #define IDS_RS_TIME_ON_SEEKBAR_LEFT         _T("TimeOnSeekBarLeft")
 #define IDS_RS_CUSTOM_PRESET_CONTROLSTATE   _T("CustomPresetControlState")

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -312,6 +312,16 @@
 #define IDS_RS_COUNTRY                      _T("Country")
 
 #define IDS_R_DVB                           _T("DVBConfiguration")
+// Version-qualified home for saved DVB channels, under the top-level "v2"
+// namespace ("v2\<section>") that old builds never read or write. Kept at the
+// top level (not a subkey of the data section) so the legacy section stays a
+// plain leaf key: old builds clear it with MFC's non-recursive RegDeleteKey,
+// which would fail if we nested a subkey inside it. The channel serialization
+// carries a format-version token and an older build THROWS on a newer token,
+// drops the channel, and overwrites it on save. New builds store channels only
+// under v2; the legacy channel entries are left frozen so a downgrade keeps
+// its own channels instead of losing the newer ones.
+#define IDS_R_DVB_V2                        _T("v2\\") IDS_R_DVB
 //#define IDS_RS_BDA_NETWORKPROVIDER          _T("BDANetworkProvider")
 #define IDS_RS_BDA_TUNER                    _T("BDATuner")
 #define IDS_RS_BDA_RECEIVER                 _T("BDAReceiver")

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -313,16 +313,15 @@
 #define IDS_RS_COUNTRY                      _T("Country")
 
 #define IDS_R_DVB                           _T("DVBConfiguration")
-// Version-qualified home for saved DVB channels, under the top-level "v2"
-// namespace ("v2\<section>") that old builds never read or write. Kept at the
-// top level (not a subkey of the data section) so the legacy section stays a
-// plain leaf key: old builds clear it with MFC's non-recursive RegDeleteKey,
-// which would fail if we nested a subkey inside it. The channel serialization
-// carries a format-version token and an older build THROWS on a newer token,
-// drops the channel, and overwrites it on save. New builds store channels only
-// under v2; the legacy channel entries are left frozen so a downgrade keeps
-// its own channels instead of losing the newer ones.
-#define IDS_R_DVB_V2                        _T("v2\\") IDS_R_DVB
+// Replacement section for the DVB settings (same pattern as Commands2 and
+// FileFormats2), which old builds never read or write. The channel
+// serialization carries a format-version token and an older build THROWS on a
+// newer token, drops the channel, and — since channels are rewritten on every
+// save — destroys the newer list just by running. The legacy section is left
+// frozen so a downgrade keeps its own last-known-good DVB settings. A sibling
+// key (not a subkey of the legacy section) also keeps the legacy section a
+// plain leaf key, which old builds clear with MFC's non-recursive RegDeleteKey.
+#define IDS_R_DVB2                          _T("DVBConfiguration2")
 //#define IDS_RS_BDA_NETWORKPROVIDER          _T("BDANetworkProvider")
 #define IDS_RS_BDA_TUNER                    _T("BDATuner")
 #define IDS_RS_BDA_RECEIVER                 _T("BDAReceiver")

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -3053,6 +3053,7 @@ BEGIN
     IDS_PLAYLIST_POSITION_RIGHT "&Right"
     IDS_PLAYLIST_POSITION_BOTTOM "&Bottom"
     IDS_PLAYLIST_POSITION_FLOAT "&Floating"
+    IDS_SETTINGS_NEWER_VERSION "These settings were last written by a newer version of MPC-HC.\n\nDo you want to use a separate local settings file for this version instead of changing the newer settings?"
 END
 
 STRINGTABLE

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -3053,7 +3053,6 @@ BEGIN
     IDS_PLAYLIST_POSITION_RIGHT "&Right"
     IDS_PLAYLIST_POSITION_BOTTOM "&Bottom"
     IDS_PLAYLIST_POSITION_FLOAT "&Floating"
-    IDS_SETTINGS_NEWER_VERSION "A newer version of MPC-HC has updated the settings. This version will keep using its own settings and ignore the newer ones."
 END
 
 STRINGTABLE

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -3053,7 +3053,7 @@ BEGIN
     IDS_PLAYLIST_POSITION_RIGHT "&Right"
     IDS_PLAYLIST_POSITION_BOTTOM "&Bottom"
     IDS_PLAYLIST_POSITION_FLOAT "&Floating"
-    IDS_SETTINGS_NEWER_VERSION "These settings were last written by a newer version of MPC-HC.\n\nDo you want to use a separate local settings file for this version instead of changing the newer settings?"
+    IDS_SETTINGS_NEWER_VERSION "A newer version of MPC-HC has updated the settings. This version will keep using its own settings and ignore the newer ones."
 END
 
 STRINGTABLE

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -264,6 +264,7 @@ if not exist "$(OutDir)LAVFilters" if exist "$(SolutionDir)bin\mpc-hc_x86\LAVFil
     <ClCompile Include="Playlist.cpp" />
     <ClCompile Include="PnSPresetsDlg.cpp" />
     <ClCompile Include="PPageAccelTbl.cpp" />
+    <ClCompile Include="Profile.cpp" />
     <ClCompile Include="PPageAdvanced.cpp" />
     <ClCompile Include="PPageAudioRenderer.cpp" />
     <ClCompile Include="PPageAudioSwitcher.cpp" />
@@ -448,6 +449,7 @@ if not exist "$(OutDir)LAVFilters" if exist "$(SolutionDir)bin\mpc-hc_x86\LAVFil
     <ClInclude Include="MPCPngImage.h" />
     <ClInclude Include="Mpeg2SectionData.h" />
     <ClInclude Include="mplayerc.h" />
+    <ClInclude Include="Profile.h" />
     <ClInclude Include="MultiMonitor.h" />
     <ClInclude Include="OpenDirHelper.h" />
     <ClInclude Include="OpenDlg.h" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -393,6 +393,7 @@
     <ClCompile Include="MainFrm.cpp" />
     <ClCompile Include="MainFrmControls.cpp" />
     <ClCompile Include="mplayerc.cpp" />
+    <ClCompile Include="Profile.cpp" />
     <ClCompile Include="Playlist.cpp" />
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="UpdateChecker.cpp" />
@@ -962,6 +963,7 @@
     <ClInclude Include="MainFrm.h" />
     <ClInclude Include="MainFrmControls.h" />
     <ClInclude Include="mplayerc.h" />
+    <ClInclude Include="Profile.h" />
     <ClInclude Include="Playlist.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -807,46 +807,174 @@ static int CompareVersionStrings(const CStringW& a, const CStringW& b)
     return 0;
 }
 
-// MediaHistory on-disk format version, versioned independently of the app.
-// Bump when the MediaHistory layout changes incompatibly.
-static const wchar_t* const MEDIA_HISTORY_FORMAT_VERSION = L"1.0";
+// ---------------------------------------------------------------------------
+// Settings format migration framework.
+//
+// Each store is named by its on-disk format version (Settings-<ver> /
+// History-<ver>, see Profile.h). When the format changes incompatibly, bump
+// SETTINGS_FORMAT_VERSION and add a step below that transforms the previous
+// version's store into the new one; the driver applies the chain in order. An
+// older build only knows its own version and never touches a newer store.
+//
+// There is only version 1.0 today, so the table is empty and no step runs
+// (a fresh 1.0 store is populated by the legacy import instead).
+// ---------------------------------------------------------------------------
+typedef void (*SettingsMigrationFn)(CProfile& profile);
+struct SettingsMigrationStep {
+    const wchar_t* from;
+    const wchar_t* to;
+    SettingsMigrationFn apply;
+};
+static const std::vector<SettingsMigrationStep> s_settingsMigrations = {
+    // { L"1.0", L"1.1", &Migrate_Settings_1_0_to_1_1 },  // example for the future
+};
 
-void CMPlayerCApp::SetupSettingsStore()
+// Number of migration steps to chain from `from` up to `to` (0 if already there),
+// or -1 if no complete chain of steps connects them.
+static int CountSettingsMigrations(const CStringW& from, const CStringW& to)
 {
-    // If this exact build previously forked to its own per-version settings file,
-    // that file is known-compatible with this build: use it directly and skip the
-    // shared-store version check.
-    const CStringW versionedPath = CProfile::VersionedIniPath(CStringW(m_strVersion));
-    if (PathUtils::Exists(versionedPath)) {
-        m_Profile.ForkToLocalIni(versionedPath); // load our own file, no seeding
-    } else {
-        CStringW lastWritten;
-        const bool bHasStore = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), lastWritten) && !lastWritten.IsEmpty();
+    CStringW cur = from;
+    int steps = 0;
+    while (CompareVersionStrings(cur, to) < 0) {
+        const SettingsMigrationStep* found = nullptr;
+        for (const auto& s : s_settingsMigrations) {
+            if (cur == s.from) {
+                found = &s;
+                break;
+            }
+        }
+        if (!found || ++steps > 100) {
+            return -1; // no path forward (or runaway guard)
+        }
+        cur = found->to;
+    }
+    return (cur == to) ? steps : -1;
+}
 
-        if (!bHasStore) {
-            // First run of the new settings format: import the legacy settings
-            // (old INI / old registry key), if any. Non-destructive - the legacy
-            // store is never deleted.
-            m_Profile.MigrateFromLegacy();
-        } else if (CompareVersionStrings(CStringW(m_strVersion), lastWritten) < 0) {
-            // This build is older than the one that last wrote the shared store.
-            // Offer to use a private, per-version settings file (seeded from the
-            // shared store) rather than modify the newer settings.
-            int res = MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION),
-                                 _T("MPC-HC"), MB_ICONWARNING | MB_YESNO);
-            if (res == IDYES) {
-                m_Profile.ForkToLocalIni(versionedPath, true /*seedFromCurrent*/);
+// Apply the chain of steps that takes `from` up to `to`. Returns the number of
+// steps applied, or -1 if there is no complete path.
+static int ApplySettingsMigrations(CProfile& profile, const CStringW& from, const CStringW& to)
+{
+    if (CountSettingsMigrations(from, to) < 0) {
+        return -1;
+    }
+    CStringW cur = from;
+    int steps = 0;
+    while (cur != to) {
+        for (const auto& s : s_settingsMigrations) {
+            if (cur == s.from) {
+                if (s.apply) {
+                    s.apply(profile);
+                }
+                cur = s.to;
+                steps++;
+                break;
             }
         }
     }
+    return steps;
+}
 
-    // Stamp this build as the last writer of the (possibly forked) store.
+// max(a, b) by version comparison, treating empty as lowest.
+static CStringW MaxVersion(const CStringW& a, const CStringW& b)
+{
+    if (a.IsEmpty()) {
+        return b;
+    }
+    if (b.IsEmpty()) {
+        return a;
+    }
+    return CompareVersionStrings(a, b) >= 0 ? a : b;
+}
+
+// The version-independent index records which settings/history format versions
+// are present, so an older build can tell that a newer store exists (and warn)
+// without scanning. Registry: values under HKCU\Software\MPC-HC. Portable: the
+// <exe>.settings.ini manifest.
+static void ReadSettingsIndex(bool portable, CStringW& settingsVer, CStringW& historyVer)
+{
+    settingsVer.Empty();
+    historyVer.Empty();
+    if (portable) {
+        CProfile index(CProfile::SettingsIndexIniPath());
+        index.ReadString(L"Version", L"Settings", settingsVer);
+        index.ReadString(L"Version", L"History", historyVer);
+    } else {
+        CRegKey key;
+        if (key.Open(HKEY_CURRENT_USER, L"Software\\MPC-HC", KEY_READ) == ERROR_SUCCESS) {
+            ULONG n = 0;
+            if (key.QueryStringValue(L"SettingsVersion", nullptr, &n) == ERROR_SUCCESS && n > 0) {
+                key.QueryStringValue(L"SettingsVersion", settingsVer.GetBufferSetLength(n - 1), &n);
+                settingsVer.ReleaseBuffer();
+            }
+            n = 0;
+            if (key.QueryStringValue(L"HistoryVersion", nullptr, &n) == ERROR_SUCCESS && n > 0) {
+                key.QueryStringValue(L"HistoryVersion", historyVer.GetBufferSetLength(n - 1), &n);
+                historyVer.ReleaseBuffer();
+            }
+        }
+    }
+}
+
+static void WriteSettingsIndex(bool portable, const CStringW& settingsVer, const CStringW& historyVer)
+{
+    if (portable) {
+        CProfile index(CProfile::SettingsIndexIniPath());
+        index.WriteString(L"Version", L"Settings", settingsVer);
+        index.WriteString(L"Version", L"History", historyVer);
+        index.Flush(true);
+    } else {
+        CRegKey key;
+        if (key.Create(HKEY_CURRENT_USER, L"Software\\MPC-HC") == ERROR_SUCCESS) {
+            key.SetStringValue(L"SettingsVersion", settingsVer);
+            key.SetStringValue(L"HistoryVersion", historyVer);
+        }
+    }
+}
+
+void CMPlayerCApp::SetupSettingsStore()
+{
+    const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
+    const CStringW myS = SETTINGS_FORMAT_VERSION;
+    const CStringW myH = HISTORY_FORMAT_VERSION;
+
+    // What the newest build here has established (empty on a first run).
+    CStringW idxS, idxH;
+    ReadSettingsIndex(portable, idxS, idxH);
+
+    // Populate this version's store if empty: migrate up from an older format
+    // store if one exists and a path is defined, else import the pre-versioned
+    // legacy settings. Both are non-destructive - older stores are left in place.
+    CStringW tmp;
+    const bool bInitialized = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), tmp) && !tmp.IsEmpty();
+    if (!bInitialized) {
+        if (!idxS.IsEmpty() && CompareVersionStrings(idxS, myS) < 0 &&
+            ApplySettingsMigrations(m_Profile, idxS, myS) >= 0) {
+            // migrated an older format store up to ours
+        } else {
+            m_Profile.MigrateFromLegacy();
+        }
+    }
+
+    // If a newer settings format exists, operate on our own version and warn once
+    // (per newer version) that the newer settings are being ignored.
+    if (!idxS.IsEmpty() && CompareVersionStrings(idxS, myS) > 0) {
+        CStringW warnedFor;
+        m_Profile.ReadString(_T("Version"), _T("NewerWarnedFor"), warnedFor);
+        if (warnedFor != idxS) {
+            MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION), _T("MPC-HC"), MB_ICONINFORMATION | MB_OK);
+            m_Profile.WriteString(_T("Version"), _T("NewerWarnedFor"), idxS);
+        }
+    }
+
+    // Stamp the store and raise the index to our version (never lower it).
     m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
     m_Profile.Flush(true);
+    WriteSettingsIndex(portable, MaxVersion(idxS, myS), MaxVersion(idxH, myH));
 
-    // Phase B: in portable (INI) mode, keep MediaHistory in its own (shared) file.
-    // Registry installs keep history in the registry (no separate store).
-    if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
+    // In portable (INI) mode keep MediaHistory in its own versioned file.
+    // Registry installs keep history inside the settings store.
+    if (portable) {
         m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
 
         // One-time: move any MediaHistory still in the main store into it.
@@ -856,9 +984,8 @@ void CMPlayerCApp::SetupSettingsStore()
             m_Profile.Flush(true);
         }
 
-        // Stamp the history file with its own format version plus the app version
-        // that last wrote it (written straight to the history store, not routed).
-        m_HistoryProfile->WriteString(_T("Version"), _T("MediaHistoryVersion"), MEDIA_HISTORY_FORMAT_VERSION);
+        // Self-describing history stamp (the filename already encodes the version).
+        m_HistoryProfile->WriteString(_T("Version"), _T("MediaHistoryVersion"), CStringW(HISTORY_FORMAT_VERSION));
         m_HistoryProfile->WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
         m_HistoryProfile->Flush(true);
     }

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -938,7 +938,6 @@ void CMPlayerCApp::SetupSettingsStore()
 {
     const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
     const CStringW myS = SETTINGS_FORMAT_VERSION;
-    const CStringW myH = HISTORY_FORMAT_VERSION;
 
     // What the newest build here has established (empty on a first run).
     CStringW idxS, idxH;
@@ -963,22 +962,6 @@ void CMPlayerCApp::SetupSettingsStore()
         }
     }
 
-    // If a newer settings format exists, operate on our own version and warn once
-    // (per newer version) that the newer settings are being ignored.
-    if (!idxS.IsEmpty() && CompareVersionStrings(idxS, myS) > 0) {
-        CStringW warnedFor;
-        m_Profile.ReadString(_T("Version"), _T("NewerWarnedFor"), warnedFor);
-        if (warnedFor != idxS) {
-            MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION), _T("MPC-HC"), MB_ICONINFORMATION | MB_OK);
-            m_Profile.WriteString(_T("Version"), _T("NewerWarnedFor"), idxS);
-        }
-    }
-
-    // Stamp the store and raise the index to our version (never lower it).
-    m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
-    m_Profile.Flush(true);
-    WriteSettingsIndex(portable, MaxVersion(idxS, myS), MaxVersion(idxH, myH));
-
     // In portable (INI) mode keep MediaHistory in its own versioned file.
     // Registry installs keep history inside the settings store.
     if (portable) {
@@ -990,11 +973,58 @@ void CMPlayerCApp::SetupSettingsStore()
             m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
             m_Profile.Flush(true);
         }
+    }
 
+    // Stamp the store as initialized (version + index + history stamps). The
+    // "newer settings" warning and the HKLM import are user-visible policies and
+    // run later (ApplySettingsPolicies), only for a committed normal launch.
+    StampSettingsStoreInitialized();
+}
+
+// Mark the current store as initialized so the next launch does not treat it as
+// a first run and re-import legacy settings over the current ones. Shared by
+// SetupSettingsStore and ChangeSettingsLocation.
+void CMPlayerCApp::StampSettingsStoreInitialized()
+{
+    const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
+
+    CStringW idxS, idxH;
+    ReadSettingsIndex(portable, idxS, idxH);
+
+    m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
+    m_Profile.Flush(true);
+
+    // Raise the index to our version, never lower it (a newer store may exist).
+    WriteSettingsIndex(portable, MaxVersion(idxS, SETTINGS_FORMAT_VERSION), MaxVersion(idxH, HISTORY_FORMAT_VERSION));
+
+    if (portable && m_HistoryProfile) {
         // Self-describing history stamp (the filename already encodes the version).
         m_HistoryProfile->WriteString(_T("Version"), _T("MediaHistoryVersion"), CStringW(HISTORY_FORMAT_VERSION));
         m_HistoryProfile->WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
         m_HistoryProfile->Flush(true);
+    }
+}
+
+// User-visible settings policies, deferred until a normal interactive launch is
+// committed (so utility invocations like /help, /close, /regvid, /admin don't
+// pop a modal or apply machine policy). See InitInstance.
+void CMPlayerCApp::ApplySettingsPolicies()
+{
+    const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
+
+    CStringW idxS, idxH;
+    ReadSettingsIndex(portable, idxS, idxH);
+
+    // If a newer settings format exists, operate on our own version and warn
+    // once (per newer version) that the newer settings are being ignored.
+    if (!idxS.IsEmpty() && CompareVersionStrings(idxS, CStringW(SETTINGS_FORMAT_VERSION)) > 0) {
+        CStringW warnedFor;
+        m_Profile.ReadString(_T("Version"), _T("NewerWarnedFor"), warnedFor);
+        if (warnedFor != idxS) {
+            MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION), _T("MPC-HC"), MB_ICONINFORMATION | MB_OK);
+            m_Profile.WriteString(_T("Version"), _T("NewerWarnedFor"), idxS);
+            m_Profile.Flush(true);
+        }
     }
 
     // Apply machine-wide default settings pushed via HKLM (issue #2347).
@@ -1175,6 +1205,11 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
     } else {
         m_HistoryProfile.reset(); // registry keeps history in the registry
     }
+
+    // Stamp the new store as initialized. Without this the next launch would see
+    // an empty Version/LastWrittenBy, treat the store as a first run, and
+    // re-import the (still-present) legacy settings over the current ones.
+    StampSettingsStoreInitialized();
 
     // Save favorites to the new location
     m_s->SetFav(FAV_FILE, filesFav);
@@ -2157,6 +2192,12 @@ BOOL CMPlayerCApp::InitInstance()
             key.SetStringValue(_T("ExePath"), PathUtils::GetProgramPath(true));
         }
     }
+
+    // Now that a normal interactive launch is committed (utility switches and
+    // single-instance forwarding have returned above), apply the deferred
+    // settings policies (newer-version warning + HKLM machine defaults) before
+    // settings are read.
+    ApplySettingsPolicies();
 
     m_s->MigrateSettings(); // migrate old settings
     m_s->LoadSettings();    // read settings

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -821,11 +821,7 @@ void CMPlayerCApp::SetupSettingsStore()
         // This build is older than the one that last wrote the settings. Offer
         // to use a private local settings file rather than downgrade (and
         // possibly corrupt) the newer settings.
-        // TODO: localize this prompt via a string resource (IDS_...).
-        int res = MessageBox(nullptr,
-                             _T("These settings were last written by a newer version of MPC-HC.\n\n")
-                             _T("Do you want to use a separate local settings file for this version ")
-                             _T("instead of changing the newer settings?"),
+        int res = MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION),
                              _T("MPC-HC"), MB_ICONWARNING | MB_YESNO);
         if (res == IDYES) {
             m_Profile.ForkToLocalIni();
@@ -1050,6 +1046,20 @@ bool CMPlayerCApp::ExportSettings(CString savePath, CString subKey)
 
     if (IsIniValid()) {
         success = !!CopyFile(GetIniPath(), savePath, FALSE);
+        // MediaHistory lives in a separate INI now; export it alongside as
+        // "<name>.history.ini" so a full export isn't missing the history.
+        if (success && subKey.IsEmpty() && m_HistoryProfile) {
+            CString historySrc = m_HistoryProfile->GetIniPath();
+            if (PathUtils::Exists(historySrc)) {
+                CString historyDst = savePath;
+                int dot = historyDst.ReverseFind(_T('.'));
+                if (dot >= 0) {
+                    historyDst = historyDst.Left(dot);
+                }
+                historyDst += _T(".history.ini");
+                CopyFile(historySrc, historyDst, FALSE); // best-effort companion
+            }
+        }
     } else {
         CString regKey = m_Profile.GetRegistryKeyPath();
         if (!subKey.IsEmpty()) {

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -788,8 +788,9 @@ bool CMPlayerCApp::IsIniValid() const
     return m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR;
 }
 
-// Compare two dotted version strings (e.g. "2.3.1.234"), numerically per
-// component. Returns <0 if a<b, 0 if equal, >0 if a>b.
+// Compare two version tokens numerically per component, ignoring non-digit
+// characters (so "v1"/"v2"/"v11" and dotted "2.3.1.234" both work); e.g.
+// "v2" < "v11". Returns <0 if a<b, 0 if equal, >0 if a>b.
 static int CompareVersionStrings(const CStringW& a, const CStringW& b)
 {
     int ia = 0, ib = 0;
@@ -815,11 +816,11 @@ static int CompareVersionStrings(const CStringW& a, const CStringW& b)
 // SETTINGS_FORMAT_VERSION and add a step below. A step transforms a store IN
 // PLACE from its `from` format to `to`; the driver first seeds the new store
 // from the source version's data (CProfile::SeedFromVersion, or
-// MigrateFromLegacy for the pre-versioned 1.0 layout) and then applies the chain
+// MigrateFromLegacy for the pre-versioned v1 layout) and then applies the chain
 // of in-place transforms in order. An older build only knows its own version and
 // never touches a newer store.
 //
-// There is only version 1.0 today, so the table is empty and no step runs.
+// There is only version v1 today, so the table is empty and no step runs.
 // ---------------------------------------------------------------------------
 typedef void (*SettingsMigrationFn)(CProfile& profile);
 struct SettingsMigrationStep {
@@ -939,21 +940,29 @@ void CMPlayerCApp::SetupSettingsStore()
     const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
     const CStringW myS = SETTINGS_FORMAT_VERSION;
 
-    // What the newest build here has established (empty on a first run).
-    CStringW idxS, idxH;
-    ReadSettingsIndex(portable, idxS, idxH);
-
     // Populate this version's store if empty: seed it from the best available
     // older source, then apply in-place format transforms up to our version.
     // The source is the newest existing older versioned store, or (failing that)
-    // the pre-versioned legacy settings, which are the 1.0 layout. Seeding is
+    // the pre-versioned legacy settings, which are the v1 layout. Seeding is
     // non-destructive - older stores are left in place.
     CStringW tmp;
     const bool bInitialized = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), tmp) && !tmp.IsEmpty();
     if (!bInitialized) {
+        // Find the highest existing versioned store strictly below ours to seed
+        // from (there may be several, and the index only records the max — which
+        // could be a newer store we must not read). Fall back to the legacy store.
+        std::vector<CStringW> existing;
+        m_Profile.EnumSettingsStoreVersions(existing);
+        CStringW best;
+        for (const auto& v : existing) {
+            if (CompareVersionStrings(v, myS) < 0 && (best.IsEmpty() || CompareVersionStrings(v, best) > 0)) {
+                best = v;
+            }
+        }
+
         CStringW seededFrom;
-        if (!idxS.IsEmpty() && CompareVersionStrings(idxS, myS) < 0 && m_Profile.SeedFromVersion(idxS)) {
-            seededFrom = idxS;           // seeded from an older versioned store
+        if (!best.IsEmpty() && m_Profile.SeedFromVersion(best)) {
+            seededFrom = best;           // seeded from the best older versioned store
         } else if (m_Profile.MigrateFromLegacy()) {
             seededFrom = LEGACY_EQUIVALENT_VERSION;  // pre-versioned legacy == the first format
         }
@@ -1036,11 +1045,20 @@ void CMPlayerCApp::ApplySettingsPolicies()
 // path ("" at the HKLM root, whose own values are control values, not settings).
 void CMPlayerCApp::ImportHKLMTree(HKEY hKey, const CStringW& section)
 {
+    // Size name buffers from the key's maxima so long value/subkey names aren't
+    // silently dropped (RegEnumValue returns ERROR_MORE_DATA on a short buffer).
+    DWORD maxValueName = 0, maxSubKeyName = 0;
+    if (RegQueryInfoKeyW(hKey, nullptr, nullptr, nullptr, nullptr, &maxSubKeyName,
+                         nullptr, nullptr, &maxValueName, nullptr, nullptr, nullptr) != ERROR_SUCCESS) {
+        maxValueName = 16383;
+        maxSubKeyName = 255;
+    }
+
     if (!section.IsEmpty()) {
-        WCHAR name[512];
+        std::vector<WCHAR> name(maxValueName + 1);
         for (DWORD i = 0;; i++) {
-            DWORD nameLen = _countof(name), type = 0, dataLen = 0;
-            LONG r = RegEnumValueW(hKey, i, name, &nameLen, nullptr, &type, nullptr, &dataLen);
+            DWORD nameLen = static_cast<DWORD>(name.size()), type = 0, dataLen = 0;
+            LONG r = RegEnumValueW(hKey, i, name.data(), &nameLen, nullptr, &type, nullptr, &dataLen);
             if (r == ERROR_NO_MORE_ITEMS) {
                 break;
             }
@@ -1049,28 +1067,45 @@ void CMPlayerCApp::ImportHKLMTree(HKEY hKey, const CStringW& section)
             }
             std::vector<BYTE> data(dataLen);
             DWORD cb = dataLen;
-            if (RegQueryValueExW(hKey, name, nullptr, &type, data.data(), &cb) != ERROR_SUCCESS) {
+            if (RegQueryValueExW(hKey, name.data(), nullptr, &type, data.data(), &cb) != ERROR_SUCCESS) {
                 continue;
             }
             switch (type) {
                 case REG_DWORD:
                     if (cb >= sizeof(DWORD)) {
-                        WriteProfileInt(section, name, *reinterpret_cast<DWORD*>(data.data()));
+                        WriteProfileInt(section, name.data(), *reinterpret_cast<DWORD*>(data.data()));
                     }
                     break;
                 case REG_QWORD:
                     if (cb >= sizeof(ULONGLONG)) {
                         CStringW s;
                         s.Format(_T("%I64u"), *reinterpret_cast<ULONGLONG*>(data.data()));
-                        WriteProfileString(section, name, s);
+                        WriteProfileString(section, name.data(), s);
                     }
                     break;
                 case REG_SZ:
-                case REG_EXPAND_SZ:
-                    WriteProfileString(section, name, reinterpret_cast<LPCWSTR>(data.data()));
+                case REG_EXPAND_SZ: {
+                    // Registry strings are not guaranteed NUL-terminated; build a
+                    // bounded string from cb bytes and trim at any embedded NUL.
+                    CStringW s(reinterpret_cast<LPCWSTR>(data.data()), static_cast<int>(cb / sizeof(WCHAR)));
+                    int nul = s.Find(L'\0');
+                    if (nul >= 0) {
+                        s.Truncate(nul);
+                    }
+                    if (type == REG_EXPAND_SZ) {
+                        DWORD need = ExpandEnvironmentStringsW(s, nullptr, 0);
+                        if (need > 0) {
+                            CStringW expanded;
+                            ExpandEnvironmentStringsW(s, expanded.GetBufferSetLength(need - 1), need);
+                            expanded.ReleaseBuffer();
+                            s = expanded;
+                        }
+                    }
+                    WriteProfileString(section, name.data(), s);
                     break;
+                }
                 case REG_BINARY:
-                    WriteProfileBinary(section, name, data.data(), cb);
+                    WriteProfileBinary(section, name.data(), data.data(), cb);
                     break;
                 default:
                     break; // unsupported types are ignored
@@ -1078,10 +1113,10 @@ void CMPlayerCApp::ImportHKLMTree(HKEY hKey, const CStringW& section)
         }
     }
 
-    WCHAR sub[MAX_REGKEY_LEN];
+    std::vector<WCHAR> sub(maxSubKeyName + 1);
     for (DWORD i = 0;; i++) {
-        DWORD subLen = _countof(sub);
-        LONG r = RegEnumKeyExW(hKey, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
+        DWORD subLen = static_cast<DWORD>(sub.size());
+        LONG r = RegEnumKeyExW(hKey, i, sub.data(), &subLen, nullptr, nullptr, nullptr, nullptr);
         if (r == ERROR_NO_MORE_ITEMS) {
             break;
         }
@@ -1089,8 +1124,8 @@ void CMPlayerCApp::ImportHKLMTree(HKEY hKey, const CStringW& section)
             continue;
         }
         HKEY hSub;
-        if (RegOpenKeyExW(hKey, sub, 0, KEY_READ, &hSub) == ERROR_SUCCESS) {
-            CStringW child = section.IsEmpty() ? CStringW(sub) : (section + L"\\" + sub);
+        if (RegOpenKeyExW(hKey, sub.data(), 0, KEY_READ, &hSub) == ERROR_SUCCESS) {
+            CStringW child = section.IsEmpty() ? CStringW(sub.data()) : (section + L"\\" + sub.data());
             ImportHKLMTree(hSub, child);
             RegCloseKey(hSub);
         }

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -849,6 +849,129 @@ void CMPlayerCApp::SetupSettingsStore()
             m_Profile.Flush(true);
         }
     }
+
+    // Apply machine-wide default settings pushed via HKLM (issue #2347).
+    ApplyHKLMDefaults();
+}
+
+// Recursively copy an HKLM defaults subtree into the user store, preserving
+// value types. `section` is the user-store section path built from the subkey
+// path ("" at the HKLM root, whose own values are control values, not settings).
+void CMPlayerCApp::ImportHKLMTree(HKEY hKey, const CStringW& section)
+{
+    if (!section.IsEmpty()) {
+        WCHAR name[512];
+        for (DWORD i = 0;; i++) {
+            DWORD nameLen = _countof(name), type = 0, dataLen = 0;
+            LONG r = RegEnumValueW(hKey, i, name, &nameLen, nullptr, &type, nullptr, &dataLen);
+            if (r == ERROR_NO_MORE_ITEMS) {
+                break;
+            }
+            if (r != ERROR_SUCCESS || dataLen == 0) {
+                continue;
+            }
+            std::vector<BYTE> data(dataLen);
+            DWORD cb = dataLen;
+            if (RegQueryValueExW(hKey, name, nullptr, &type, data.data(), &cb) != ERROR_SUCCESS) {
+                continue;
+            }
+            switch (type) {
+                case REG_DWORD:
+                    if (cb >= sizeof(DWORD)) {
+                        WriteProfileInt(section, name, *reinterpret_cast<DWORD*>(data.data()));
+                    }
+                    break;
+                case REG_QWORD:
+                    if (cb >= sizeof(ULONGLONG)) {
+                        CStringW s;
+                        s.Format(_T("%I64u"), *reinterpret_cast<ULONGLONG*>(data.data()));
+                        WriteProfileString(section, name, s);
+                    }
+                    break;
+                case REG_SZ:
+                case REG_EXPAND_SZ:
+                    WriteProfileString(section, name, reinterpret_cast<LPCWSTR>(data.data()));
+                    break;
+                case REG_BINARY:
+                    WriteProfileBinary(section, name, data.data(), cb);
+                    break;
+                default:
+                    break; // unsupported types are ignored
+            }
+        }
+    }
+
+    WCHAR sub[MAX_REGKEY_LEN];
+    for (DWORD i = 0;; i++) {
+        DWORD subLen = _countof(sub);
+        LONG r = RegEnumKeyExW(hKey, i, sub, &subLen, nullptr, nullptr, nullptr, nullptr);
+        if (r == ERROR_NO_MORE_ITEMS) {
+            break;
+        }
+        if (r != ERROR_SUCCESS) {
+            continue;
+        }
+        HKEY hSub;
+        if (RegOpenKeyExW(hKey, sub, 0, KEY_READ, &hSub) == ERROR_SUCCESS) {
+            CStringW child = section.IsEmpty() ? CStringW(sub) : (section + L"\\" + sub);
+            ImportHKLMTree(hSub, child);
+            RegCloseKey(hSub);
+        }
+    }
+}
+
+void CMPlayerCApp::ApplyHKLMDefaults()
+{
+    HKEY hRoot;
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, _T("Software\\MPC-HC"), 0, KEY_READ, &hRoot) != ERROR_SUCCESS) {
+        return; // no machine-wide defaults configured
+    }
+
+    // Control values live at the root of HKLM\Software\MPC-HC.
+    DWORD type = 0, cb;
+    DWORD reset = 0;
+    cb = sizeof(reset);
+    const bool hasReset = RegQueryValueExW(hRoot, _T("SettingsReset"), nullptr, &type, (BYTE*)&reset, &cb) == ERROR_SUCCESS && type == REG_DWORD;
+    ULONGLONG ts = 0;
+    cb = sizeof(ts);
+    const bool hasTs = RegQueryValueExW(hRoot, _T("SettingsTimestamp"), nullptr, &type, (BYTE*)&ts, &cb) == ERROR_SUCCESS && (type == REG_QWORD || type == REG_DWORD);
+
+    // What we've already applied (kept in the user store).
+    const DWORD appliedReset = static_cast<DWORD>(GetProfileInt(_T("HKLMState"), _T("AppliedReset"), 0));
+    const ULONGLONG appliedTs = _wcstoui64(GetProfileString(_T("HKLMState"), _T("AppliedTimestamp"), _T("0")), nullptr, 10);
+
+    const bool doReset = hasReset && reset != appliedReset;
+    const bool doImport = doReset || (hasTs && ts > appliedTs);
+
+    if (!doImport) {
+        RegCloseKey(hRoot);
+        return;
+    }
+
+    if (doReset) {
+        // Force user settings back to defaults, then re-seed from HKLM.
+        m_Profile.Clear();
+        if (m_HistoryProfile) {
+            m_HistoryProfile->Clear();
+        }
+        m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
+        m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
+    }
+
+    ImportHKLMTree(hRoot, CStringW());
+
+    // Record what we applied so this runs only once per change.
+    if (hasReset) {
+        WriteProfileInt(_T("HKLMState"), _T("AppliedReset"), static_cast<int>(reset));
+    }
+    if (hasTs) {
+        CStringW s;
+        s.Format(_T("%I64u"), ts);
+        WriteProfileString(_T("HKLMState"), _T("AppliedTimestamp"), s);
+    }
+
+    FlushProfile(true);
+    RegCloseKey(hRoot);
 }
 
 bool CMPlayerCApp::GetAppSavePath(CString& path)

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -816,7 +816,7 @@ void CMPlayerCApp::SetupSettingsStore()
 // one-time split of MediaHistory out of the main settings file.
 void CMPlayerCApp::SetupHistoryStore()
 {
-    m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
+    m_HistoryProfile = std::make_unique<CProfile>(ResolveHistoryIniPath());
 
     // One-time: move any MediaHistory still in the main settings store into it.
     if (!m_Profile.HasEntry(_T("Version"), _T("HistorySplit"))) {
@@ -981,6 +981,68 @@ void CMPlayerCApp::ApplyHKLMDefaults()
     RegCloseKey(hRoot);
 }
 
+bool CMPlayerCApp::UseAppDataForHistory()
+{
+    // Read the raw option value so this works before LoadSettings() has run.
+    bool inAppData = false;
+    m_Profile.ReadBool(IDS_R_SETTINGS, IDS_RS_HISTORY_IN_APPDATA, inAppData);
+    return inAppData;
+}
+
+CStringW CMPlayerCApp::ResolveHistoryIniPath()
+{
+    const CStringW programPath = CProfile::HistoryIniPath();
+
+    CString appDataDir;
+    if (!GetAppDataPath(appDataDir)) {
+        return programPath;
+    }
+    CPath historyFileName(programPath);
+    historyFileName.StripPath(); // filename incl. extension (PathUtils::FileName drops the extension)
+    const CStringW appDataPath = PathUtils::CombinePaths(appDataDir, historyFileName);
+
+    bool useAppData = UseAppDataForHistory();
+    if (!useAppData && !PathUtils::Exists(programPath)) {
+        // Fall back to %APPDATA% when the history file cannot be created next
+        // to the executable (e.g. installed in a read-only folder but running
+        // portable off a shared settings INI).
+        HANDLE hProbe = ::CreateFileW(programPath, GENERIC_WRITE, 0, nullptr,
+                                      CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hProbe == INVALID_HANDLE_VALUE) {
+            useAppData = true;
+        } else {
+            ::CloseHandle(hProbe);
+            ::DeleteFileW(programPath); // probe only, leave no empty file behind
+        }
+    }
+
+    const CStringW target = useAppData ? appDataPath : programPath;
+    const CStringW other  = useAppData ? programPath : appDataPath;
+    if (useAppData) {
+        ::CreateDirectoryW(appDataDir, nullptr);
+    }
+    // Carry an existing history file over when the location changes (option
+    // toggled, or the fallback newly triggered), so history is not lost.
+    if (!PathUtils::Exists(target) && PathUtils::Exists(other)) {
+        if (!::MoveFileExW(other, target, MOVEFILE_COPY_ALLOWED)) {
+            ::CopyFileW(other, target, TRUE); // source not deletable; copy is enough
+        }
+    }
+
+    return target;
+}
+
+bool CMPlayerCApp::GetPlaylistSavePath(CString& path)
+{
+    // The saved playlist lives next to the MediaHistory store, so the
+    // HistoryInAppData option (and the unwritable-folder fallback) moves both.
+    if (m_HistoryProfile) {
+        path = PathUtils::DirName(m_HistoryProfile->GetIniPath());
+        return !path.IsEmpty();
+    }
+    return GetAppSavePath(path);
+}
+
 bool CMPlayerCApp::GetAppSavePath(CString& path)
 {
     if (IsIniValid()) { // If settings ini file found, store stuff in the same folder as the exe file
@@ -1030,7 +1092,7 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
     // Point the MediaHistory store at the new location before SaveSettings()
     // below re-writes the full in-memory history there in the correct format.
     if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
-        m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
+        m_HistoryProfile = std::make_unique<CProfile>(ResolveHistoryIniPath());
         m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1")); // history is separate here
     } else {
         m_HistoryProfile.reset(); // registry keeps history in the registry
@@ -1907,7 +1969,7 @@ BOOL CMPlayerCApp::InitInstance()
 
         // Remove the current playlist if it exists
         CString strSavePath;
-        if (GetAppSavePath(strSavePath)) {
+        if (GetPlaylistSavePath(strSavePath)) {
             CPath playlistPath;
             playlistPath.Combine(strSavePath, _T("default.mpcpl"));
 

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -820,14 +820,12 @@ static int CompareVersionStrings(const CStringW& a, const CStringW& b)
 // ---------------------------------------------------------------------------
 // Settings format migration framework.
 //
-// Each store is named by its on-disk format version (Settings-<ver> /
-// History-<ver>, see Profile.h). When the format changes incompatibly, bump
-// SETTINGS_FORMAT_VERSION and add a step below. A step transforms a store IN
-// PLACE from its `from` format to `to`; the driver first seeds the new store
-// from the source version's data (CProfile::SeedFromVersion, or
-// MigrateFromLegacy for the pre-versioned v1 layout) and then applies the chain
-// of in-place transforms in order. An older build only knows its own version and
-// never touches a newer store.
+// A store records its on-disk format version in a [Version] Format field. When
+// the format changes incompatibly, bump SETTINGS_FORMAT_VERSION and add a step
+// below that transforms a store IN PLACE from its `from` format to `to`; the
+// driver applies the chain in order. A build that finds a store with an OLDER
+// Format upgrades it in place; one that finds a NEWER Format forks to a private
+// local file (see SetupSettingsStore) so the newer store is never corrupted.
 //
 // There is only version v1 today, so the table is empty and no step runs.
 // ---------------------------------------------------------------------------
@@ -887,137 +885,80 @@ static int ApplySettingsMigrations(CProfile& profile, const CStringW& from, cons
     return steps;
 }
 
-// max(a, b) by version comparison, treating empty as lowest.
-static CStringW MaxVersion(const CStringW& a, const CStringW& b)
-{
-    if (a.IsEmpty()) {
-        return b;
-    }
-    if (b.IsEmpty()) {
-        return a;
-    }
-    return CompareVersionStrings(a, b) >= 0 ? a : b;
-}
-
-// The version-independent index records which settings/history format versions
-// are present, so an older build can tell that a newer store exists (and warn)
-// without scanning. Registry: values under HKCU\Software\MPC-HC. Portable: the
-// <exe>.settings.ini manifest.
-static void ReadSettingsIndex(bool portable, CStringW& settingsVer, CStringW& historyVer)
-{
-    settingsVer.Empty();
-    historyVer.Empty();
-    if (portable) {
-        CProfile index(CProfile::SettingsIndexIniPath());
-        index.ReadString(L"Version", L"Settings", settingsVer);
-        index.ReadString(L"Version", L"History", historyVer);
-    } else {
-        CRegKey key;
-        if (key.Open(HKEY_CURRENT_USER, L"Software\\MPC-HC", KEY_READ) == ERROR_SUCCESS) {
-            ULONG n = 0;
-            if (key.QueryStringValue(L"SettingsVersion", nullptr, &n) == ERROR_SUCCESS && n > 0) {
-                key.QueryStringValue(L"SettingsVersion", settingsVer.GetBufferSetLength(n - 1), &n);
-                settingsVer.ReleaseBuffer();
-            }
-            n = 0;
-            if (key.QueryStringValue(L"HistoryVersion", nullptr, &n) == ERROR_SUCCESS && n > 0) {
-                key.QueryStringValue(L"HistoryVersion", historyVer.GetBufferSetLength(n - 1), &n);
-                historyVer.ReleaseBuffer();
-            }
-        }
-    }
-}
-
-static void WriteSettingsIndex(bool portable, const CStringW& settingsVer, const CStringW& historyVer)
-{
-    if (portable) {
-        CProfile index(CProfile::SettingsIndexIniPath());
-        index.WriteString(L"Version", L"Settings", settingsVer);
-        index.WriteString(L"Version", L"History", historyVer);
-        index.Flush(true);
-    } else {
-        CRegKey key;
-        if (key.Create(HKEY_CURRENT_USER, L"Software\\MPC-HC") == ERROR_SUCCESS) {
-            key.SetStringValue(L"SettingsVersion", settingsVer);
-            key.SetStringValue(L"HistoryVersion", historyVer);
-        }
-    }
-}
-
 void CMPlayerCApp::SetupSettingsStore()
 {
-    const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
     const CStringW myS = SETTINGS_FORMAT_VERSION;
 
-    // Populate this version's store if empty: seed it from the best available
-    // older source, then apply in-place format transforms up to our version.
-    // The source is the newest existing older versioned store, or (failing that)
-    // the pre-versioned legacy settings, which are the v1 layout. Seeding is
-    // non-destructive - older stores are left in place.
-    CStringW tmp;
-    const bool bInitialized = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), tmp) && !tmp.IsEmpty();
-    if (!bInitialized) {
-        // Find the highest existing versioned store strictly below ours to seed
-        // from (there may be several, and the index only records the max — which
-        // could be a newer store we must not read). Fall back to the legacy store.
-        std::vector<CStringW> existing;
-        m_Profile.EnumSettingsStoreVersions(existing);
-        CStringW best;
-        for (const auto& v : existing) {
-            if (CompareVersionStrings(v, myS) < 0 && (best.IsEmpty() || CompareVersionStrings(v, best) > 0)) {
-                best = v;
-            }
-        }
+    // Read the store's declared format (empty => uninitialized / first run).
+    CStringW fmt;
+    const bool haveStore = m_Profile.ReadString(_T("Version"), _T("Format"), fmt) && !fmt.IsEmpty();
 
-        CStringW seededFrom;
-        if (!best.IsEmpty() && m_Profile.SeedFromVersion(best)) {
-            seededFrom = best;           // seeded from the best older versioned store
-        } else if (m_Profile.MigrateFromLegacy()) {
-            seededFrom = LEGACY_EQUIVALENT_VERSION;  // pre-versioned legacy == the first format
+    if (!haveStore) {
+        // First run of the new format: import the pre-versioned legacy settings
+        // (which are the v1 layout), if any, then migrate up. Non-destructive -
+        // the legacy store is left in place.
+        if (m_Profile.MigrateFromLegacy()) {
+            ApplySettingsMigrations(m_Profile, CStringW(LEGACY_EQUIVALENT_VERSION), myS);
         }
-        if (!seededFrom.IsEmpty()) {
-            ApplySettingsMigrations(m_Profile, seededFrom, myS);
-        }
+    } else if (CompareVersionStrings(fmt, myS) < 0) {
+        // Older format: upgrade this store in place.
+        ApplySettingsMigrations(m_Profile, fmt, myS);
+    } else if (CompareVersionStrings(fmt, myS) > 0) {
+        // Newer format than we understand: fork to a private local file so the
+        // newer store (written by a newer build) is never corrupted. Reuse an
+        // existing fork if present (and don't re-warn); otherwise create one
+        // seeded from the current store and warn (deferred to a normal launch).
+        const CStringW localPath = CProfile::LocalIniPath();
+        const bool localExisted = PathUtils::Exists(localPath);
+        m_Profile.ForkToLocalIni(localPath, !localExisted);
+        m_bWarnNewerFormat = !localExisted;
     }
 
-    // In portable (INI) mode keep MediaHistory in its own versioned file.
-    // Registry installs keep history inside the settings store.
-    if (portable) {
-        m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
-
-        // One-time: move any MediaHistory still in the main store into it.
-        if (!m_Profile.HasEntry(_T("Version"), _T("HistorySplit"))) {
-            m_Profile.MoveSectionTree(_T("MediaHistory"), *m_HistoryProfile);
-            m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
-            m_Profile.Flush(true);
-        }
+    // MediaHistory: a separate file in portable (INI) mode; in registry mode it
+    // stays inside the settings key. A fork above turns the store portable, so
+    // GetSettingsLocation() reflects the effective mode here.
+    if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
+        SetupHistoryStore();
     }
 
-    // Stamp the store as initialized (version + index + history stamps). The
-    // "newer settings" warning and the HKLM import are user-visible policies and
-    // run later (ApplySettingsPolicies), only for a committed normal launch.
+    // Stamp the (possibly migrated/forked) store as initialized.
     StampSettingsStoreInitialized();
 }
 
-// Mark the current store as initialized so the next launch does not treat it as
-// a first run and re-import legacy settings over the current ones. Shared by
-// SetupSettingsStore and ChangeSettingsLocation.
+// Set up the separate MediaHistory store (portable/INI mode). Forks to a local
+// file if it finds a newer history format, and performs the one-time split of
+// MediaHistory out of the main settings store.
+void CMPlayerCApp::SetupHistoryStore()
+{
+    m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
+
+    CStringW fmt;
+    if (m_HistoryProfile->ReadString(_T("Version"), _T("Format"), fmt) && !fmt.IsEmpty() &&
+        CompareVersionStrings(fmt, CStringW(HISTORY_FORMAT_VERSION)) > 0) {
+        const CStringW localPath = CProfile::HistoryLocalIniPath();
+        m_HistoryProfile->ForkToLocalIni(localPath, !PathUtils::Exists(localPath));
+    }
+
+    // One-time: move any MediaHistory still in the main settings store into it.
+    if (!m_Profile.HasEntry(_T("Version"), _T("HistorySplit"))) {
+        m_Profile.MoveSectionTree(_T("MediaHistory"), *m_HistoryProfile);
+        m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
+        m_Profile.Flush(true);
+    }
+}
+
+// Mark the current store(s) as initialized so the next launch does not treat
+// them as a first run and re-import legacy settings. Records the on-disk format
+// version and the app version that last wrote it. Shared by SetupSettingsStore
+// and ChangeSettingsLocation.
 void CMPlayerCApp::StampSettingsStoreInitialized()
 {
-    const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
-
-    CStringW idxS, idxH;
-    ReadSettingsIndex(portable, idxS, idxH);
-
+    m_Profile.WriteString(_T("Version"), _T("Format"), CStringW(SETTINGS_FORMAT_VERSION));
     m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
     m_Profile.Flush(true);
 
-    // Raise the index to our version, never lower it (a newer store may exist).
-    WriteSettingsIndex(portable, MaxVersion(idxS, SETTINGS_FORMAT_VERSION), MaxVersion(idxH, HISTORY_FORMAT_VERSION));
-
-    if (portable && m_HistoryProfile) {
-        // Self-describing history stamp (the filename already encodes the version).
-        m_HistoryProfile->WriteString(_T("Version"), _T("MediaHistoryVersion"), CStringW(HISTORY_FORMAT_VERSION));
+    if (m_HistoryProfile) {
+        m_HistoryProfile->WriteString(_T("Version"), _T("Format"), CStringW(HISTORY_FORMAT_VERSION));
         m_HistoryProfile->WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
         m_HistoryProfile->Flush(true);
     }
@@ -1028,21 +969,11 @@ void CMPlayerCApp::StampSettingsStoreInitialized()
 // pop a modal or apply machine policy). See InitInstance.
 void CMPlayerCApp::ApplySettingsPolicies()
 {
-    const bool portable = (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR);
-
-    CStringW idxS, idxH;
-    ReadSettingsIndex(portable, idxS, idxH);
-
-    // If a newer settings format exists, operate on our own version and warn
-    // once (per newer version) that the newer settings are being ignored.
-    if (!idxS.IsEmpty() && CompareVersionStrings(idxS, CStringW(SETTINGS_FORMAT_VERSION)) > 0) {
-        CStringW warnedFor;
-        m_Profile.ReadString(_T("Version"), _T("NewerWarnedFor"), warnedFor);
-        if (warnedFor != idxS) {
-            MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION), _T("MPC-HC"), MB_ICONINFORMATION | MB_OK);
-            m_Profile.WriteString(_T("Version"), _T("NewerWarnedFor"), idxS);
-            m_Profile.Flush(true);
-        }
+    // We forked away from a newer-format store during setup - tell the user once
+    // that this older build is now using its own separate settings file.
+    if (m_bWarnNewerFormat) {
+        m_bWarnNewerFormat = false;
+        MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION), _T("MPC-HC"), MB_ICONINFORMATION | MB_OK);
     }
 
     // Apply machine-wide default settings pushed via HKLM (issue #2347).
@@ -1175,6 +1106,7 @@ void CMPlayerCApp::ApplyHKLMDefaults()
         if (m_HistoryProfile) {
             m_HistoryProfile->Clear();
         }
+        m_Profile.WriteString(_T("Version"), _T("Format"), CStringW(SETTINGS_FORMAT_VERSION));
         m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
         m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
     }
@@ -2115,9 +2047,10 @@ BOOL CMPlayerCApp::InitInstance()
             }
         }
 
-        // Remove the settings, then re-stamp the writer version so the next run
-        // does not treat this as a fresh install and re-import legacy settings.
+        // Remove the settings, then re-stamp the format/writer version so the next
+        // run does not treat this as a fresh install and re-import legacy settings.
         m_Profile.Clear();
+        m_Profile.WriteString(_T("Version"), _T("Format"), CStringW(SETTINGS_FORMAT_VERSION));
         m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), m_strVersion);
         m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1")); // history is separate; don't re-split
         m_Profile.Flush(true);

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -812,12 +812,14 @@ static int CompareVersionStrings(const CStringW& a, const CStringW& b)
 //
 // Each store is named by its on-disk format version (Settings-<ver> /
 // History-<ver>, see Profile.h). When the format changes incompatibly, bump
-// SETTINGS_FORMAT_VERSION and add a step below that transforms the previous
-// version's store into the new one; the driver applies the chain in order. An
-// older build only knows its own version and never touches a newer store.
+// SETTINGS_FORMAT_VERSION and add a step below. A step transforms a store IN
+// PLACE from its `from` format to `to`; the driver first seeds the new store
+// from the source version's data (CProfile::SeedFromVersion, or
+// MigrateFromLegacy for the pre-versioned 1.0 layout) and then applies the chain
+// of in-place transforms in order. An older build only knows its own version and
+// never touches a newer store.
 //
-// There is only version 1.0 today, so the table is empty and no step runs
-// (a fresh 1.0 store is populated by the legacy import instead).
+// There is only version 1.0 today, so the table is empty and no step runs.
 // ---------------------------------------------------------------------------
 typedef void (*SettingsMigrationFn)(CProfile& profile);
 struct SettingsMigrationStep {
@@ -942,17 +944,22 @@ void CMPlayerCApp::SetupSettingsStore()
     CStringW idxS, idxH;
     ReadSettingsIndex(portable, idxS, idxH);
 
-    // Populate this version's store if empty: migrate up from an older format
-    // store if one exists and a path is defined, else import the pre-versioned
-    // legacy settings. Both are non-destructive - older stores are left in place.
+    // Populate this version's store if empty: seed it from the best available
+    // older source, then apply in-place format transforms up to our version.
+    // The source is the newest existing older versioned store, or (failing that)
+    // the pre-versioned legacy settings, which are the 1.0 layout. Seeding is
+    // non-destructive - older stores are left in place.
     CStringW tmp;
     const bool bInitialized = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), tmp) && !tmp.IsEmpty();
     if (!bInitialized) {
-        if (!idxS.IsEmpty() && CompareVersionStrings(idxS, myS) < 0 &&
-            ApplySettingsMigrations(m_Profile, idxS, myS) >= 0) {
-            // migrated an older format store up to ours
-        } else {
-            m_Profile.MigrateFromLegacy();
+        CStringW seededFrom;
+        if (!idxS.IsEmpty() && CompareVersionStrings(idxS, myS) < 0 && m_Profile.SeedFromVersion(idxS)) {
+            seededFrom = idxS;           // seeded from an older versioned store
+        } else if (m_Profile.MigrateFromLegacy()) {
+            seededFrom = L"1.0";         // pre-versioned legacy == the 1.0 layout
+        }
+        if (!seededFrom.IsEmpty()) {
+            ApplySettingsMigrations(m_Profile, seededFrom, myS);
         }
     }
 

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -828,7 +828,7 @@ struct SettingsMigrationStep {
     SettingsMigrationFn apply;
 };
 static const std::vector<SettingsMigrationStep> s_settingsMigrations = {
-    // { L"1.0", L"1.1", &Migrate_Settings_1_0_to_1_1 },  // example for the future
+    // { L"v1", L"v2", &Migrate_Settings_v1_to_v2 },  // example for the future
 };
 
 // Number of migration steps to chain from `from` up to `to` (0 if already there),
@@ -956,7 +956,7 @@ void CMPlayerCApp::SetupSettingsStore()
         if (!idxS.IsEmpty() && CompareVersionStrings(idxS, myS) < 0 && m_Profile.SeedFromVersion(idxS)) {
             seededFrom = idxS;           // seeded from an older versioned store
         } else if (m_Profile.MigrateFromLegacy()) {
-            seededFrom = L"1.0";         // pre-versioned legacy == the 1.0 layout
+            seededFrom = LEGACY_EQUIVALENT_VERSION;  // pre-versioned legacy == the first format
         }
         if (!seededFrom.IsEmpty()) {
             ApplySettingsMigrations(m_Profile, seededFrom, myS);

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -794,7 +794,12 @@ CString CMPlayerCApp::GetIniPath() const
 
 bool CMPlayerCApp::IsIniValid() const
 {
-    return m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR;
+    return !IsUsingRegistry();
+}
+
+bool CMPlayerCApp::IsUsingRegistry() const
+{
+    return m_Profile.GetSettingsLocation() == SETS_REGISTRY;
 }
 
 void CMPlayerCApp::SetupSettingsStore()
@@ -802,12 +807,13 @@ void CMPlayerCApp::SetupSettingsStore()
     // The store stays at its historical location (HKCU\Software\MPC-HC\MPC-HC or
     // <exe>.ini) so external tools and older builds keep reading it unchanged.
     // Scalar settings evolve additively; the one format-fragile composite field
-    // (saved DVB channels) is version-qualified at its own call sites, so no
-    // store-wide format/migration machinery is needed here.
+    // (saved DVB channels) moved to a replacement section (DVBConfiguration2)
+    // at its own call sites, so no store-wide format/migration machinery is
+    // needed here.
     //
     // MediaHistory is the one structural change: in portable (INI) mode it moves
     // to a separate file; in registry mode it stays inside the settings key.
-    if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
+    if (!IsUsingRegistry()) {
         SetupHistoryStore();
     }
 }
@@ -983,10 +989,19 @@ void CMPlayerCApp::ApplyHKLMDefaults()
 
 bool CMPlayerCApp::UseAppDataForHistory()
 {
-    // Read the raw option value so this works before LoadSettings() has run.
-    bool inAppData = false;
-    m_Profile.ReadBool(IDS_R_SETTINGS, IDS_RS_HISTORY_IN_APPDATA, inAppData);
-    return inAppData;
+    if (m_iHistoryInAppData < 0) {
+        // First call happens before LoadSettings() has run, so read the raw
+        // option value once; later calls use the cached copy.
+        bool inAppData = false;
+        m_Profile.ReadBool(IDS_R_SETTINGS, IDS_RS_HISTORY_IN_APPDATA, inAppData);
+        m_iHistoryInAppData = inAppData ? 1 : 0;
+    }
+    return m_iHistoryInAppData > 0;
+}
+
+void CMPlayerCApp::SetHistoryInAppData(bool inAppData)
+{
+    m_iHistoryInAppData = inAppData ? 1 : 0;
 }
 
 CStringW CMPlayerCApp::ResolveHistoryIniPath()
@@ -1091,7 +1106,7 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
 
     // Point the MediaHistory store at the new location before SaveSettings()
     // below re-writes the full in-memory history there in the correct format.
-    if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
+    if (!IsUsingRegistry()) {
         m_HistoryProfile = std::make_unique<CProfile>(ResolveHistoryIniPath());
         m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1")); // history is separate here
     } else {

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -807,24 +807,36 @@ static int CompareVersionStrings(const CStringW& a, const CStringW& b)
     return 0;
 }
 
+// MediaHistory on-disk format version, versioned independently of the app.
+// Bump when the MediaHistory layout changes incompatibly.
+static const wchar_t* const MEDIA_HISTORY_FORMAT_VERSION = L"1.0";
+
 void CMPlayerCApp::SetupSettingsStore()
 {
-    CStringW lastWritten;
-    const bool bHasStore = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), lastWritten) && !lastWritten.IsEmpty();
+    // If this exact build previously forked to its own per-version settings file,
+    // that file is known-compatible with this build: use it directly and skip the
+    // shared-store version check.
+    const CStringW versionedPath = CProfile::VersionedIniPath(CStringW(m_strVersion));
+    if (PathUtils::Exists(versionedPath)) {
+        m_Profile.ForkToLocalIni(versionedPath); // load our own file, no seeding
+    } else {
+        CStringW lastWritten;
+        const bool bHasStore = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), lastWritten) && !lastWritten.IsEmpty();
 
-    if (!bHasStore) {
-        // First run of the new settings format: import the legacy settings
-        // (old INI / old registry key), if any. Non-destructive - the legacy
-        // store is never deleted.
-        m_Profile.MigrateFromLegacy();
-    } else if (CompareVersionStrings(CStringW(m_strVersion), lastWritten) < 0) {
-        // This build is older than the one that last wrote the settings. Offer
-        // to use a private local settings file rather than downgrade (and
-        // possibly corrupt) the newer settings.
-        int res = MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION),
-                             _T("MPC-HC"), MB_ICONWARNING | MB_YESNO);
-        if (res == IDYES) {
-            m_Profile.ForkToLocalIni();
+        if (!bHasStore) {
+            // First run of the new settings format: import the legacy settings
+            // (old INI / old registry key), if any. Non-destructive - the legacy
+            // store is never deleted.
+            m_Profile.MigrateFromLegacy();
+        } else if (CompareVersionStrings(CStringW(m_strVersion), lastWritten) < 0) {
+            // This build is older than the one that last wrote the shared store.
+            // Offer to use a private, per-version settings file (seeded from the
+            // shared store) rather than modify the newer settings.
+            int res = MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION),
+                                 _T("MPC-HC"), MB_ICONWARNING | MB_YESNO);
+            if (res == IDYES) {
+                m_Profile.ForkToLocalIni(versionedPath, true /*seedFromCurrent*/);
+            }
         }
     }
 
@@ -832,7 +844,7 @@ void CMPlayerCApp::SetupSettingsStore()
     m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
     m_Profile.Flush(true);
 
-    // Phase B: in portable (INI) mode, keep MediaHistory in its own file.
+    // Phase B: in portable (INI) mode, keep MediaHistory in its own (shared) file.
     // Registry installs keep history in the registry (no separate store).
     if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
         m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
@@ -841,9 +853,14 @@ void CMPlayerCApp::SetupSettingsStore()
         if (!m_Profile.HasEntry(_T("Version"), _T("HistorySplit"))) {
             m_Profile.MoveSectionTree(_T("MediaHistory"), *m_HistoryProfile);
             m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
-            m_HistoryProfile->Flush(true);
             m_Profile.Flush(true);
         }
+
+        // Stamp the history file with its own format version plus the app version
+        // that last wrote it (written straight to the history store, not routed).
+        m_HistoryProfile->WriteString(_T("Version"), _T("MediaHistoryVersion"), MEDIA_HISTORY_FORMAT_VERSION);
+        m_HistoryProfile->WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
+        m_HistoryProfile->Flush(true);
     }
 
     // Apply machine-wide default settings pushed via HKLM (issue #2347).

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -782,7 +782,14 @@ bool CMPlayerCApp::StoreSettingsToRegistry()
 
 CString CMPlayerCApp::GetIniPath() const
 {
-    return m_Profile.GetIniPath();
+    // In registry mode the live ini path is empty; return the prospective path
+    // (where a portable ini would be created) so callers like the "store to ini"
+    // option's write-permission check have a real target to test.
+    CString path = m_Profile.GetIniPath();
+    if (path.IsEmpty()) {
+        path = CProfile::DefaultIniPath();
+    }
+    return path;
 }
 
 bool CMPlayerCApp::IsIniValid() const

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -797,147 +797,26 @@ bool CMPlayerCApp::IsIniValid() const
     return m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR;
 }
 
-// Compare two version tokens numerically per component, ignoring non-digit
-// characters (so "v1"/"v2"/"v11" and dotted "2.3.1.234" both work); e.g.
-// "v2" < "v11". Returns <0 if a<b, 0 if equal, >0 if a>b.
-static int CompareVersionStrings(const CStringW& a, const CStringW& b)
-{
-    int ia = 0, ib = 0;
-    const int la = a.GetLength(), lb = b.GetLength();
-    while (ia < la || ib < lb) {
-        int va = 0, vb = 0;
-        while (ia < la && a[ia] >= L'0' && a[ia] <= L'9') { va = va * 10 + (a[ia] - L'0'); ia++; }
-        while (ib < lb && b[ib] >= L'0' && b[ib] <= L'9') { vb = vb * 10 + (b[ib] - L'0'); ib++; }
-        if (va != vb) {
-            return va < vb ? -1 : 1;
-        }
-        while (ia < la && (a[ia] < L'0' || a[ia] > L'9')) { ia++; } // skip separators
-        while (ib < lb && (b[ib] < L'0' || b[ib] > L'9')) { ib++; }
-    }
-    return 0;
-}
-
-// ---------------------------------------------------------------------------
-// Settings format migration framework.
-//
-// A store records its on-disk format version in a [Version] Format field. When
-// the format changes incompatibly, bump SETTINGS_FORMAT_VERSION and add a step
-// below that transforms a store IN PLACE from its `from` format to `to`; the
-// driver applies the chain in order. A build that finds a store with an OLDER
-// Format upgrades it in place; one that finds a NEWER Format forks to a private
-// local file (see SetupSettingsStore) so the newer store is never corrupted.
-//
-// There is only version v1 today, so the table is empty and no step runs.
-// ---------------------------------------------------------------------------
-typedef void (*SettingsMigrationFn)(CProfile& profile);
-struct SettingsMigrationStep {
-    const wchar_t* from;
-    const wchar_t* to;
-    SettingsMigrationFn apply;
-};
-static const std::vector<SettingsMigrationStep> s_settingsMigrations = {
-    // { L"v1", L"v2", &Migrate_Settings_v1_to_v2 },  // example for the future
-};
-
-// Number of migration steps to chain from `from` up to `to` (0 if already there),
-// or -1 if no complete chain of steps connects them.
-static int CountSettingsMigrations(const CStringW& from, const CStringW& to)
-{
-    CStringW cur = from;
-    int steps = 0;
-    while (CompareVersionStrings(cur, to) < 0) {
-        const SettingsMigrationStep* found = nullptr;
-        for (const auto& s : s_settingsMigrations) {
-            if (cur == s.from) {
-                found = &s;
-                break;
-            }
-        }
-        if (!found || ++steps > 100) {
-            return -1; // no path forward (or runaway guard)
-        }
-        cur = found->to;
-    }
-    return (cur == to) ? steps : -1;
-}
-
-// Apply the chain of steps that takes `from` up to `to`. Returns the number of
-// steps applied, or -1 if there is no complete path.
-static int ApplySettingsMigrations(CProfile& profile, const CStringW& from, const CStringW& to)
-{
-    if (CountSettingsMigrations(from, to) < 0) {
-        return -1;
-    }
-    CStringW cur = from;
-    int steps = 0;
-    while (cur != to) {
-        for (const auto& s : s_settingsMigrations) {
-            if (cur == s.from) {
-                if (s.apply) {
-                    s.apply(profile);
-                }
-                cur = s.to;
-                steps++;
-                break;
-            }
-        }
-    }
-    return steps;
-}
-
 void CMPlayerCApp::SetupSettingsStore()
 {
-    const CStringW myS = SETTINGS_FORMAT_VERSION;
-
-    // Read the store's declared format (empty => uninitialized / first run).
-    CStringW fmt;
-    const bool haveStore = m_Profile.ReadString(_T("Version"), _T("Format"), fmt) && !fmt.IsEmpty();
-
-    if (!haveStore) {
-        // First run of the new format: import the pre-versioned legacy settings
-        // (which are the v1 layout), if any, then migrate up. Non-destructive -
-        // the legacy store is left in place.
-        if (m_Profile.MigrateFromLegacy()) {
-            ApplySettingsMigrations(m_Profile, CStringW(LEGACY_EQUIVALENT_VERSION), myS);
-        }
-    } else if (CompareVersionStrings(fmt, myS) < 0) {
-        // Older format: upgrade this store in place.
-        ApplySettingsMigrations(m_Profile, fmt, myS);
-    } else if (CompareVersionStrings(fmt, myS) > 0) {
-        // Newer format than we understand: fork to a private local file so the
-        // newer store (written by a newer build) is never corrupted. Reuse an
-        // existing fork if present (and don't re-warn); otherwise create one
-        // seeded from the current store and warn (deferred to a normal launch).
-        const CStringW localPath = CProfile::LocalIniPath();
-        const bool localExisted = PathUtils::Exists(localPath);
-        m_Profile.ForkToLocalIni(localPath, !localExisted);
-        m_bWarnNewerFormat = !localExisted;
-    }
-
-    // MediaHistory: a separate file in portable (INI) mode; in registry mode it
-    // stays inside the settings key. A fork above turns the store portable, so
-    // GetSettingsLocation() reflects the effective mode here.
+    // The store stays at its historical location (HKCU\Software\MPC-HC\MPC-HC or
+    // <exe>.ini) so external tools and older builds keep reading it unchanged.
+    // Scalar settings evolve additively; the one format-fragile composite field
+    // (saved DVB channels) is version-qualified at its own call sites, so no
+    // store-wide format/migration machinery is needed here.
+    //
+    // MediaHistory is the one structural change: in portable (INI) mode it moves
+    // to a separate file; in registry mode it stays inside the settings key.
     if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
         SetupHistoryStore();
     }
-
-    // Stamp the (possibly migrated/forked) store as initialized.
-    StampSettingsStoreInitialized();
 }
 
-// Set up the separate MediaHistory store (portable/INI mode). Forks to a local
-// file if it finds a newer history format, and performs the one-time split of
-// MediaHistory out of the main settings store.
+// Set up the separate MediaHistory store (portable/INI mode) and perform the
+// one-time split of MediaHistory out of the main settings file.
 void CMPlayerCApp::SetupHistoryStore()
 {
     m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
-
-    CStringW fmt;
-    if (m_HistoryProfile->ReadString(_T("Version"), _T("Format"), fmt) && !fmt.IsEmpty() &&
-        CompareVersionStrings(fmt, CStringW(HISTORY_FORMAT_VERSION)) > 0) {
-        const CStringW localPath = CProfile::HistoryLocalIniPath();
-        m_HistoryProfile->ForkToLocalIni(localPath, !PathUtils::Exists(localPath));
-    }
 
     // One-time: move any MediaHistory still in the main settings store into it.
     if (!m_Profile.HasEntry(_T("Version"), _T("HistorySplit"))) {
@@ -947,35 +826,11 @@ void CMPlayerCApp::SetupHistoryStore()
     }
 }
 
-// Mark the current store(s) as initialized so the next launch does not treat
-// them as a first run and re-import legacy settings. Records the on-disk format
-// version and the app version that last wrote it. Shared by SetupSettingsStore
-// and ChangeSettingsLocation.
-void CMPlayerCApp::StampSettingsStoreInitialized()
-{
-    m_Profile.WriteString(_T("Version"), _T("Format"), CStringW(SETTINGS_FORMAT_VERSION));
-    m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
-    m_Profile.Flush(true);
-
-    if (m_HistoryProfile) {
-        m_HistoryProfile->WriteString(_T("Version"), _T("Format"), CStringW(HISTORY_FORMAT_VERSION));
-        m_HistoryProfile->WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
-        m_HistoryProfile->Flush(true);
-    }
-}
-
 // User-visible settings policies, deferred until a normal interactive launch is
 // committed (so utility invocations like /help, /close, /regvid, /admin don't
 // pop a modal or apply machine policy). See InitInstance.
 void CMPlayerCApp::ApplySettingsPolicies()
 {
-    // We forked away from a newer-format store during setup - tell the user once
-    // that this older build is now using its own separate settings file.
-    if (m_bWarnNewerFormat) {
-        m_bWarnNewerFormat = false;
-        MessageBox(nullptr, ResStr(IDS_SETTINGS_NEWER_VERSION), _T("MPC-HC"), MB_ICONINFORMATION | MB_OK);
-    }
-
     // Apply machine-wide default settings pushed via HKLM (issue #2347).
     ApplyHKLMDefaults();
 }
@@ -1106,8 +961,7 @@ void CMPlayerCApp::ApplyHKLMDefaults()
         if (m_HistoryProfile) {
             m_HistoryProfile->Clear();
         }
-        m_Profile.WriteString(_T("Version"), _T("Format"), CStringW(SETTINGS_FORMAT_VERSION));
-        m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
+        // Keep the split marker so the (now-empty) main store isn't re-split.
         m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
     }
 
@@ -1177,15 +1031,11 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
     // below re-writes the full in-memory history there in the correct format.
     if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
         m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
-        m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
+        m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1")); // history is separate here
     } else {
         m_HistoryProfile.reset(); // registry keeps history in the registry
     }
-
-    // Stamp the new store as initialized. Without this the next launch would see
-    // an empty Version/LastWrittenBy, treat the store as a first run, and
-    // re-import the (still-present) legacy settings over the current ones.
-    StampSettingsStoreInitialized();
+    m_Profile.Flush(true);
 
     // Save favorites to the new location
     m_s->SetFav(FAV_FILE, filesFav);
@@ -1228,7 +1078,7 @@ static bool AddFileToZip(zipFile zf, const CStringW& srcPath, const CStringA& na
 }
 
 // Bundle the settings store and the separate MediaHistory store into one zip,
-// each stored under its real (versioned) filename so restoring a backup is just
+// each stored under its real filename so restoring a backup is just
 // "extract into the program folder" - no renaming, and neither file is missed.
 bool CMPlayerCApp::ExportSettingsZip(const CString& zipPath)
 {
@@ -2018,9 +1868,8 @@ BOOL CMPlayerCApp::InitInstance()
 
     PreProcessCommandLine();
 
-    // The versioned settings store auto-detects its location (portable INI or
-    // registry) on construction. Import legacy settings on first run and guard
-    // against an older build clobbering newer settings.
+    // The settings store auto-detects its location (portable INI or registry) on
+    // construction. In portable mode this splits MediaHistory into its own file.
     SetupSettingsStore();
 
     m_s->ParseCommandLine(m_cmdln);
@@ -2047,11 +1896,9 @@ BOOL CMPlayerCApp::InitInstance()
             }
         }
 
-        // Remove the settings, then re-stamp the format/writer version so the next
-        // run does not treat this as a fresh install and re-import legacy settings.
+        // Remove the settings, then re-mark the history split so the next run
+        // does not try to re-split an already-empty store.
         m_Profile.Clear();
-        m_Profile.WriteString(_T("Version"), _T("Format"), CStringW(SETTINGS_FORMAT_VERSION));
-        m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), m_strVersion);
         m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1")); // history is separate; don't re-split
         m_Profile.Flush(true);
         if (m_HistoryProfile) {

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -39,6 +39,8 @@
 #include "WebServer.h"
 #include "WinAPIUtils.h"
 #include "mpc-hc_config.h"
+#include "zlib/minizip/zip.h"
+#include "zlib/minizip/iowin32.h"
 #include "winddk/ntddcdvd.h"
 #include <afxsock.h>
 #include <atlsync.h>
@@ -1260,26 +1262,72 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
     return success;
 }
 
+// Add one on-disk file to an open zip under nameInZip (ASCII). Returns false on
+// any I/O error. Best-effort skip if the source file is missing.
+static bool AddFileToZip(zipFile zf, const CStringW& srcPath, const CStringA& nameInZip)
+{
+    CFile src;
+    if (!src.Open(srcPath, CFile::modeRead | CFile::shareDenyWrite | CFile::typeBinary)) {
+        return true; // nothing to add (e.g. history file not created yet)
+    }
+    zip_fileinfo zi = {};
+    if (zipOpenNewFileInZip(zf, nameInZip, &zi, nullptr, 0, nullptr, 0, nullptr,
+                            Z_DEFLATED, Z_DEFAULT_COMPRESSION) != ZIP_OK) {
+        return false;
+    }
+    bool ok = true;
+    BYTE buf[64 * 1024];
+    UINT n;
+    while ((n = src.Read(buf, sizeof(buf))) > 0) {
+        if (zipWriteInFileInZip(zf, buf, n) != ZIP_OK) {
+            ok = false;
+            break;
+        }
+    }
+    zipCloseFileInZip(zf);
+    return ok;
+}
+
+// Bundle the settings store and the separate MediaHistory store into one zip,
+// each stored under its real (versioned) filename so restoring a backup is just
+// "extract into the program folder" - no renaming, and neither file is missed.
+bool CMPlayerCApp::ExportSettingsZip(const CString& zipPath)
+{
+    zlib_filefunc64_def ffunc;
+    fill_win32_filefunc64W(&ffunc); // Unicode-safe archive path
+    zipFile zf = zipOpen2_64(zipPath.GetString(), APPEND_STATUS_CREATE, nullptr, &ffunc);
+    if (!zf) {
+        return false;
+    }
+
+    const CStringW settingsSrc = GetIniPath();
+    CStringA settingsName(settingsSrc.Mid(settingsSrc.ReverseFind(L'\\') + 1));
+    bool ok = AddFileToZip(zf, settingsSrc, settingsName);
+
+    if (ok && m_HistoryProfile) {
+        const CStringW histSrc = m_HistoryProfile->GetIniPath();
+        CStringA histName(histSrc.Mid(histSrc.ReverseFind(L'\\') + 1));
+        ok = AddFileToZip(zf, histSrc, histName);
+    }
+
+    zipClose(zf, nullptr);
+    if (!ok) {
+        DeleteFile(zipPath);
+    }
+    return ok;
+}
+
 bool CMPlayerCApp::ExportSettings(CString savePath, CString subKey)
 {
     bool success = false;
     m_s->SaveSettings();
 
     if (IsIniValid()) {
-        success = !!CopyFile(GetIniPath(), savePath, FALSE);
-        // MediaHistory lives in a separate INI now; export it alongside as
-        // "<name>.history.ini" so a full export isn't missing the history.
-        if (success && subKey.IsEmpty() && m_HistoryProfile) {
-            CString historySrc = m_HistoryProfile->GetIniPath();
-            if (PathUtils::Exists(historySrc)) {
-                CString historyDst = savePath;
-                int dot = historyDst.ReverseFind(_T('.'));
-                if (dot >= 0) {
-                    historyDst = historyDst.Left(dot);
-                }
-                historyDst += _T(".history.ini");
-                CopyFile(historySrc, historyDst, FALSE); // best-effort companion
-            }
+        if (subKey.IsEmpty()) {
+            // Full export: bundle settings + separate MediaHistory into one zip.
+            success = ExportSettingsZip(savePath);
+        } else {
+            success = !!CopyFile(GetIniPath(), savePath, FALSE);
         }
     } else {
         CString regKey = m_Profile.GetRegistryKeyPath();

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -651,9 +651,6 @@ void SetHandCursor(HWND m_hWnd, UINT nID)
 CMPlayerCApp::CMPlayerCApp()
     : m_hNTDLL(nullptr)
     , m_bDelayingIdle(false)
-    , m_bProfileInitialized(false)
-    , m_bQueuedProfileFlush(false)
-    , m_dwProfileLastAccessTick(0)
     , m_fClosingState(false)
     , m_bThemeLoaded(false)
 {
@@ -773,39 +770,85 @@ HWND g_hWnd = nullptr;
 
 bool CMPlayerCApp::StoreSettingsToIni()
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    CString ini = GetIniPath();
-    free((void*)m_pszRegistryKey);
-    m_pszRegistryKey = nullptr;
-    free((void*)m_pszProfileName);
-    m_pszProfileName = _tcsdup(ini);
-
-    return true;
+    return m_Profile.StoreSettingsTo(SETS_PROGRAMDIR);
 }
 
 bool CMPlayerCApp::StoreSettingsToRegistry()
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    free((void*)m_pszRegistryKey);
-    m_pszRegistryKey = nullptr;
-
-    SetRegistryKey(_T("MPC-HC"));
-
-    return true;
+    return m_Profile.StoreSettingsTo(SETS_REGISTRY);
 }
 
 CString CMPlayerCApp::GetIniPath() const
 {
-    CString path = PathUtils::GetProgramPath(true);
-    path = path.Left(path.ReverseFind('.') + 1) + _T("ini");
-    return path;
+    return m_Profile.GetIniPath();
 }
 
 bool CMPlayerCApp::IsIniValid() const
 {
-    return PathUtils::Exists(GetIniPath());
+    return m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR;
+}
+
+// Compare two dotted version strings (e.g. "2.3.1.234"), numerically per
+// component. Returns <0 if a<b, 0 if equal, >0 if a>b.
+static int CompareVersionStrings(const CStringW& a, const CStringW& b)
+{
+    int ia = 0, ib = 0;
+    const int la = a.GetLength(), lb = b.GetLength();
+    while (ia < la || ib < lb) {
+        int va = 0, vb = 0;
+        while (ia < la && a[ia] >= L'0' && a[ia] <= L'9') { va = va * 10 + (a[ia] - L'0'); ia++; }
+        while (ib < lb && b[ib] >= L'0' && b[ib] <= L'9') { vb = vb * 10 + (b[ib] - L'0'); ib++; }
+        if (va != vb) {
+            return va < vb ? -1 : 1;
+        }
+        while (ia < la && (a[ia] < L'0' || a[ia] > L'9')) { ia++; } // skip separators
+        while (ib < lb && (b[ib] < L'0' || b[ib] > L'9')) { ib++; }
+    }
+    return 0;
+}
+
+void CMPlayerCApp::SetupSettingsStore()
+{
+    CStringW lastWritten;
+    const bool bHasStore = m_Profile.ReadString(_T("Version"), _T("LastWrittenBy"), lastWritten) && !lastWritten.IsEmpty();
+
+    if (!bHasStore) {
+        // First run of the new settings format: import the legacy settings
+        // (old INI / old registry key), if any. Non-destructive - the legacy
+        // store is never deleted.
+        m_Profile.MigrateFromLegacy();
+    } else if (CompareVersionStrings(CStringW(m_strVersion), lastWritten) < 0) {
+        // This build is older than the one that last wrote the settings. Offer
+        // to use a private local settings file rather than downgrade (and
+        // possibly corrupt) the newer settings.
+        // TODO: localize this prompt via a string resource (IDS_...).
+        int res = MessageBox(nullptr,
+                             _T("These settings were last written by a newer version of MPC-HC.\n\n")
+                             _T("Do you want to use a separate local settings file for this version ")
+                             _T("instead of changing the newer settings?"),
+                             _T("MPC-HC"), MB_ICONWARNING | MB_YESNO);
+        if (res == IDYES) {
+            m_Profile.ForkToLocalIni();
+        }
+    }
+
+    // Stamp this build as the last writer of the (possibly forked) store.
+    m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), CStringW(m_strVersion));
+    m_Profile.Flush(true);
+
+    // Phase B: in portable (INI) mode, keep MediaHistory in its own file.
+    // Registry installs keep history in the registry (no separate store).
+    if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
+        m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
+
+        // One-time: move any MediaHistory still in the main store into it.
+        if (!m_Profile.HasEntry(_T("Version"), _T("HistorySplit"))) {
+            m_Profile.MoveSectionTree(_T("MediaHistory"), *m_HistoryProfile);
+            m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
+            m_HistoryProfile->Flush(true);
+            m_Profile.Flush(true);
+        }
+    }
 }
 
 bool CMPlayerCApp::GetAppSavePath(CString& path)
@@ -837,8 +880,6 @@ bool CMPlayerCApp::GetAppDataPath(CString& path)
 
 bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
     bool success;
 
     // Load favorites so that they can be correctly saved to the new location
@@ -854,6 +895,15 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
     } else {
         success = StoreSettingsToRegistry();
         _tremove(GetIniPath());
+    }
+
+    // Point the MediaHistory store at the new location before SaveSettings()
+    // below re-writes the full in-memory history there in the correct format.
+    if (m_Profile.GetSettingsLocation() == SETS_PROGRAMDIR) {
+        m_HistoryProfile = std::make_unique<CProfile>(CProfile::HistoryIniPath());
+        m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1"));
+    } else {
+        m_HistoryProfile.reset(); // registry keeps history in the registry
     }
 
     // Save favorites to the new location
@@ -878,11 +928,9 @@ bool CMPlayerCApp::ExportSettings(CString savePath, CString subKey)
     if (IsIniValid()) {
         success = !!CopyFile(GetIniPath(), savePath, FALSE);
     } else {
-        CString regKey;
-        if (subKey.IsEmpty()) {
-            regKey.Format(_T("Software\\%s\\%s"), m_pszRegistryKey, m_pszProfileName);
-        } else {
-            regKey.Format(_T("Software\\%s\\%s\\%s"), m_pszRegistryKey, m_pszProfileName, subKey.GetString());
+        CString regKey = m_Profile.GetRegistryKeyPath();
+        if (!subKey.IsEmpty()) {
+            regKey += _T("\\") + subKey;
         }
 
         FILE* fStream;
@@ -901,489 +949,115 @@ bool CMPlayerCApp::ExportSettings(CString savePath, CString subKey)
     return success;
 }
 
-void CMPlayerCApp::InitProfile()
+// True for the "MediaHistory" section and its "MediaHistory\..." subsections.
+static bool IsMediaHistorySection(LPCWSTR lpszSection)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
+    static const wchar_t* const mh = L"MediaHistory";
+    static const size_t n = wcslen(mh);
+    return lpszSection && _wcsnicmp(lpszSection, mh, n) == 0 &&
+           (lpszSection[n] == L'\0' || lpszSection[n] == L'\\');
+}
 
-    if (!m_pszRegistryKey) {
-        // Don't reread mpc-hc.ini if the cache needs to be flushed or it was accessed recently
-        if (m_bProfileInitialized && (m_bQueuedProfileFlush || GetTickCount64() - m_dwProfileLastAccessTick < 100ULL)) {
-            m_dwProfileLastAccessTick = GetTickCount64();
-            return;
-        }
-
-        m_bProfileInitialized = true;
-        m_dwProfileLastAccessTick = GetTickCount64();
-
-        ASSERT(m_pszProfileName);
-        if (!PathUtils::Exists(m_pszProfileName)) {
-            return;
-        }
-
-        FILE* fp;
-        int fpStatus;
-        do { // Open mpc-hc.ini in UNICODE mode, retry if it is already being used by another process
-            fp = _tfsopen(m_pszProfileName, _T("r, ccs=UNICODE"), _SH_SECURE);
-            if (fp || (GetLastError() != ERROR_SHARING_VIOLATION)) {
-                break;
-            }
-            Sleep(100);
-        } while (true);
-        if (!fp) {
-            ASSERT(FALSE);
-            return;
-        }
-        if (_ftell_nolock(fp) == 0L) {
-            // No BOM was consumed, assume mpc-hc.ini is ANSI encoded
-            fpStatus = fclose(fp);
-            ASSERT(fpStatus == 0);
-            do { // Reopen mpc-hc.ini in ANSI mode, retry if it is already being used by another process
-                fp = _tfsopen(m_pszProfileName, _T("r"), _SH_SECURE);
-                if (fp || (GetLastError() != ERROR_SHARING_VIOLATION)) {
-                    break;
-                }
-                Sleep(100);
-            } while (true);
-            if (!fp) {
-                ASSERT(FALSE);
-                return;
-            }
-        }
-
-        CStdioFile file(fp);
-
-        ASSERT(!m_bQueuedProfileFlush);
-        m_ProfileMap.clear();
-
-        CString line, section, var, val;
-        while (file.ReadString(line)) {
-            // Parse mpc-hc.ini file, this parser:
-            //  - doesn't trim whitespaces
-            //  - doesn't remove quotation marks
-            //  - omits keys with empty names
-            //  - omits unnamed sections
-            int pos = 0;
-            if (line[0] == _T('[')) {
-                pos = line.Find(_T(']'));
-                if (pos == -1) {
-                    continue;
-                }
-                section = line.Mid(1, pos - 1);
-            } else if (line[0] != _T(';')) {
-                pos = line.Find(_T('='));
-                if (pos == -1) {
-                    continue;
-                }
-                var = line.Mid(0, pos);
-                val = line.Mid(pos + 1);
-                if (!section.IsEmpty() && !var.IsEmpty()) {
-                    m_ProfileMap[section][var] = val;
-                }
-            }
-        }
-        fpStatus = fclose(fp);
-        ASSERT(fpStatus == 0);
-
-        m_dwProfileLastAccessTick = GetTickCount64();
+CProfile& CMPlayerCApp::ProfileForSection(LPCWSTR lpszSection)
+{
+    if (m_HistoryProfile && IsMediaHistorySection(lpszSection)) {
+        return *m_HistoryProfile;
     }
+    return m_Profile;
 }
 
 void CMPlayerCApp::FlushProfile(bool bForce/* = true*/)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    if (!m_pszRegistryKey) {
-        if (!bForce && !m_bQueuedProfileFlush) {
-            return;
-        }
-
-        m_bQueuedProfileFlush = false;
-
-        ASSERT(m_bProfileInitialized);
-        ASSERT(m_pszProfileName);
-
-        FILE* fp;
-        int fpStatus;
-        do { // Open mpc-hc.ini, retry if it is already being used by another process
-            fp = _tfsopen(m_pszProfileName, _T("w, ccs=UTF-8"), _SH_SECURE);
-            if (fp || (GetLastError() != ERROR_SHARING_VIOLATION)) {
-                break;
-            }
-            Sleep(100);
-        } while (true);
-        if (!fp) {
-            ASSERT(FALSE);
-            return;
-        }
-        CStdioFile file(fp);
-        CString line;
-        try {
-            file.WriteString(_T("; MPC-HC\n"));
-            for (auto it1 = m_ProfileMap.begin(); it1 != m_ProfileMap.end(); ++it1) {
-                line.Format(_T("[%s]\n"), it1->first.GetString());
-                file.WriteString(line);
-                for (auto it2 = it1->second.begin(); it2 != it1->second.end(); ++it2) {
-                    line.Format(_T("%s=%s\n"), it2->first.GetString(), it2->second.GetString());
-                    file.WriteString(line);
-                }
-            }
-        } catch (CFileException& e) {
-            // Fail silently if disk is full
-            UNREFERENCED_PARAMETER(e);
-            ASSERT(FALSE);
-        }
-        fpStatus = fclose(fp);
-        ASSERT(fpStatus == 0);
+    m_Profile.Flush(bForce);
+    if (m_HistoryProfile) {
+        m_HistoryProfile->Flush(bForce);
     }
 }
 
 BOOL CMPlayerCApp::GetProfileBinary(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPBYTE* ppData, UINT* pBytes)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    if (m_pszRegistryKey) {
-        return CWinAppEx::GetProfileBinary(lpszSection, lpszEntry, ppData, pBytes);
-    } else {
-        if (!lpszSection || !lpszEntry || !ppData || !pBytes) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString sectionStr(lpszSection);
-        CString keyStr(lpszEntry);
-        if (sectionStr.IsEmpty() || keyStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString valueStr;
-
-        InitProfile();
-        auto it1 = m_ProfileMap.find(sectionStr);
-        if (it1 != m_ProfileMap.end()) {
-            auto it2 = it1->second.find(keyStr);
-            if (it2 != it1->second.end()) {
-                valueStr = it2->second;
-            }
-        }
-        if (valueStr.IsEmpty()) {
-            return FALSE;
-        }
-        int length = valueStr.GetLength();
-        // Encoding: each 4-bit sequence is coded in one character, from 'A' for 0x0 to 'P' for 0xf
-        if (length % 2) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        for (int i = 0; i < length; i++) {
-            if (valueStr[i] < 'A' || valueStr[i] > 'P') {
-                ASSERT(FALSE);
-                return FALSE;
-            }
-        }
-        *pBytes = length / 2;
-        *ppData = new (std::nothrow) BYTE[*pBytes];
-        if (!(*ppData)) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        for (UINT i = 0; i < *pBytes; i++) {
-            (*ppData)[i] = BYTE((valueStr[i * 2] - 'A') | ((valueStr[i * 2 + 1] - 'A') << 4));
-        }
-        return TRUE;
+    if (!lpszSection || !lpszEntry || !ppData || !pBytes) {
+        ASSERT(FALSE);
+        return FALSE;
     }
+    return ProfileForSection(lpszSection).ReadBinary(lpszSection, lpszEntry, ppData, *pBytes) ? TRUE : FALSE;
 }
 
 UINT CMPlayerCApp::GetProfileInt(LPCTSTR lpszSection, LPCTSTR lpszEntry, int nDefault)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    int res = nDefault;
-    if (m_pszRegistryKey) {
-        res = CWinAppEx::GetProfileInt(lpszSection, lpszEntry, nDefault);
-    } else {
-        if (!lpszSection || !lpszEntry) {
-            ASSERT(FALSE);
-            return res;
-        }
-        CString sectionStr(lpszSection);
-        CString keyStr(lpszEntry);
-        if (sectionStr.IsEmpty() || keyStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return res;
-        }
-
-        InitProfile();
-        auto it1 = m_ProfileMap.find(sectionStr);
-        if (it1 != m_ProfileMap.end()) {
-            auto it2 = it1->second.find(keyStr);
-            if (it2 != it1->second.end()) {
-                res = _ttoi(it2->second);
-            }
-        }
-    }
-    return res;
+    int value;
+    return ProfileForSection(lpszSection).ReadInt(lpszSection, lpszEntry, value) ? static_cast<UINT>(value) : static_cast<UINT>(nDefault);
 }
 
-std::list<CStringW> CMPlayerCApp::GetSectionSubKeys(LPCWSTR lpszSection) {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
+std::list<CStringW> CMPlayerCApp::GetSectionSubKeys(LPCWSTR lpszSection)
+{
     std::list<CStringW> keys;
-
-    if (m_pszRegistryKey) {
-        WCHAR    achKey[MAX_REGKEY_LEN];   // buffer for subkey name
-        DWORD    cbName;                   // size of name string 
-        DWORD    cSubKeys = 0;             // number of subkeys 
-
-        if (HKEY hAppKey = GetAppRegistryKey()) {
-            HKEY hSectionKey;
-            if (ERROR_SUCCESS == RegOpenKeyExW(hAppKey, lpszSection, 0, KEY_READ, &hSectionKey)) {
-                RegQueryInfoKeyW(hSectionKey, NULL, NULL, NULL, &cSubKeys, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-                if (cSubKeys) {
-                    for (DWORD i = 0; i < cSubKeys; i++) {
-                        cbName = MAX_REGKEY_LEN;
-                        if (ERROR_SUCCESS == RegEnumKeyExW(hSectionKey, i, achKey, &cbName, NULL, NULL, NULL, NULL)){
-                            keys.push_back(achKey);
-                        }
-                    }
-                }
-            }
-        }
-    } else {
-        if (!lpszSection) {
-            ASSERT(FALSE);
-            return keys;
-        }
-        CStringW sectionStr(lpszSection);
-        if (sectionStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return keys;
-        }
-        InitProfile();
-        auto it1 = m_ProfileMap.begin();
-        while (it1 != m_ProfileMap.end()) {
-            if (it1->first.Find(sectionStr + L"\\") == 0) {
-                CStringW subKey = it1->first.Mid(sectionStr.GetLength() + 1);
-                if (subKey.Find(L"\\") == -1) {
-                    keys.push_back(subKey);
-                }
-            }
-            it1++;
-        }
-
+    if (!lpszSection || !*lpszSection) {
+        ASSERT(FALSE);
+        return keys;
     }
+    std::vector<CStringW> names;
+    ProfileForSection(lpszSection).EnumSectionNames(lpszSection, names);
+    keys.assign(names.begin(), names.end());
     return keys;
 }
 
 
 CString CMPlayerCApp::GetProfileString(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPCTSTR lpszDefault)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    CString res;
-    if (m_pszRegistryKey) {
-        res = CWinAppEx::GetProfileString(lpszSection, lpszEntry, lpszDefault);
-    } else {
-        if (!lpszSection || !lpszEntry) {
-            ASSERT(FALSE);
-            return res;
-        }
-        CString sectionStr(lpszSection);
-        CString keyStr(lpszEntry);
-        if (sectionStr.IsEmpty() || keyStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return res;
-        }
-        if (lpszDefault) {
-            res = lpszDefault;
-        }
-
-        InitProfile();
-        auto it1 = m_ProfileMap.find(sectionStr);
-        if (it1 != m_ProfileMap.end()) {
-            auto it2 = it1->second.find(keyStr);
-            if (it2 != it1->second.end()) {
-                res = it2->second;
-            }
-        }
+    CStringW value;
+    if (!ProfileForSection(lpszSection).ReadString(lpszSection, lpszEntry, value) && lpszDefault) {
+        value = lpszDefault;
     }
-    return res;
+    return value;
 }
 
 BOOL CMPlayerCApp::WriteProfileBinary(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPBYTE pData, UINT nBytes)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    if (m_pszRegistryKey) {
-        return CWinAppEx::WriteProfileBinary(lpszSection, lpszEntry, pData, nBytes);
-    } else {
-        if (!lpszSection || !lpszEntry || !pData || !nBytes) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString sectionStr(lpszSection);
-        CString keyStr(lpszEntry);
-        if (sectionStr.IsEmpty() || keyStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString valueStr;
-
-        TCHAR* buffer = valueStr.GetBufferSetLength(nBytes * 2);
-        // Encoding: each 4-bit sequence is coded in one character, from 'A' for 0x0 to 'P' for 0xf
-        for (UINT i = 0; i < nBytes; i++) {
-            buffer[i * 2] = 'A' + (pData[i] & 0xf);
-            buffer[i * 2 + 1] = 'A' + (pData[i] >> 4 & 0xf);
-        }
-        valueStr.ReleaseBufferSetLength(nBytes * 2);
-
-        InitProfile();
-        CString& old = m_ProfileMap[sectionStr][keyStr];
-        if (old != valueStr) {
-            old = valueStr;
-            m_bQueuedProfileFlush = true;
-        }
-        return TRUE;
+    if (!lpszSection || !lpszEntry || !pData || !nBytes) {
+        ASSERT(FALSE);
+        return FALSE;
     }
+    return ProfileForSection(lpszSection).WriteBinary(lpszSection, lpszEntry, pData, nBytes) ? TRUE : FALSE;
 }
 
-LONG CMPlayerCApp::RemoveProfileKey(LPCWSTR lpszSection, LPCWSTR lpszEntry) {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    if (m_pszRegistryKey) {
-        if (HKEY hAppKey = GetAppRegistryKey()) {
-            HKEY hSectionKey;
-            if (ERROR_SUCCESS == RegOpenKeyEx(hAppKey, lpszSection, 0, KEY_READ, &hSectionKey)) {
-                return CWinAppEx::DelRegTree(hSectionKey, lpszEntry);
-            }
-        }
-    } else {
-        if (!lpszSection || !lpszEntry) {
-            ASSERT(FALSE);
-            return 1;
-        }
-        CString sectionStr(lpszSection);
-        CString keyStr(lpszEntry);
-        if (sectionStr.IsEmpty() || keyStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return 1;
-        }
-
-        InitProfile();
-        auto it1 = m_ProfileMap.find(sectionStr + L"\\" + keyStr);
-        if (it1 != m_ProfileMap.end()) {
-            m_ProfileMap.erase(it1);
-            m_bQueuedProfileFlush = true;
-        }
+LONG CMPlayerCApp::RemoveProfileKey(LPCWSTR lpszSection, LPCWSTR lpszEntry)
+{
+    // Historically this removes the whole subsection [section\entry].
+    if (!lpszSection || !lpszEntry || !*lpszSection || !*lpszEntry) {
+        ASSERT(FALSE);
+        return 1;
     }
+    ProfileForSection(lpszSection).DeleteSection(CStringW(lpszSection) + L"\\" + lpszEntry);
     return 0;
 }
 
 BOOL CMPlayerCApp::WriteProfileInt(LPCTSTR lpszSection, LPCTSTR lpszEntry, int nValue)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    if (m_pszRegistryKey) {
-        return CWinAppEx::WriteProfileInt(lpszSection, lpszEntry, nValue);
-    } else {
-        if (!lpszSection || !lpszEntry) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString sectionStr(lpszSection);
-        CString keyStr(lpszEntry);
-        if (sectionStr.IsEmpty() || keyStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString valueStr;
-        valueStr.Format(_T("%d"), nValue);
-
-        InitProfile();
-        CString& old = m_ProfileMap[sectionStr][keyStr];
-        if (old != valueStr) {
-            old = valueStr;
-            m_bQueuedProfileFlush = true;
-        }
-        return TRUE;
-    }
+    return ProfileForSection(lpszSection).WriteInt(lpszSection, lpszEntry, nValue) ? TRUE : FALSE;
 }
 
 BOOL CMPlayerCApp::WriteProfileString(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPCTSTR lpszValue)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    if (m_pszRegistryKey) {
-        return CWinAppEx::WriteProfileString(lpszSection, lpszEntry, lpszValue);
-    } else {
-        if (!lpszSection) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString sectionStr(lpszSection);
-        if (sectionStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-        CString keyStr(lpszEntry);
-        if (lpszEntry && keyStr.IsEmpty()) {
-            ASSERT(FALSE);
-            return FALSE;
-        }
-
-        InitProfile();
-
-        // Mimic CWinAppEx::WriteProfileString() behavior
-        if (lpszEntry) {
-            if (lpszValue) {
-                CString& old = m_ProfileMap[sectionStr][keyStr];
-                if (old != lpszValue) {
-                    old = lpszValue;
-                    m_bQueuedProfileFlush = true;
-                }
-            } else { // Delete key
-                auto it = m_ProfileMap.find(sectionStr);
-                if (it != m_ProfileMap.end()) {
-                    if (it->second.erase(keyStr)) {
-                        m_bQueuedProfileFlush = true;
-                    }
-                }
-            }
-        } else { // Delete section
-            if (m_ProfileMap.erase(sectionStr)) {
-                m_bQueuedProfileFlush = true;
-            }
-        }
-        return TRUE;
+    if (!lpszSection) {
+        ASSERT(FALSE);
+        return FALSE;
     }
+    CProfile& profile = ProfileForSection(lpszSection);
+    // Mimic CWinAppEx::WriteProfileString() behavior
+    if (!lpszEntry) { // Delete section
+        profile.DeleteSection(lpszSection);
+    } else if (!lpszValue) { // Delete key
+        profile.DeleteValue(lpszSection, lpszEntry);
+    } else {
+        profile.WriteString(lpszSection, lpszEntry, lpszValue);
+    }
+    return TRUE;
 }
 
 bool CMPlayerCApp::HasProfileEntry(LPCTSTR lpszSection, LPCTSTR lpszEntry)
 {
-    std::lock_guard<std::recursive_mutex> lock(m_profileMutex);
-
-    bool ret = false;
-    if (m_pszRegistryKey) {
-        if (HKEY hAppKey = GetAppRegistryKey()) {
-            HKEY hSectionKey;
-            if (RegOpenKeyEx(hAppKey, lpszSection, 0, KEY_READ, &hSectionKey) == ERROR_SUCCESS) {
-                LONG lResult = RegQueryValueEx(hSectionKey, lpszEntry, nullptr, nullptr, nullptr, nullptr);
-                ret = (lResult == ERROR_SUCCESS);
-                VERIFY(RegCloseKey(hSectionKey) == ERROR_SUCCESS);
-            }
-            VERIFY(RegCloseKey(hAppKey) == ERROR_SUCCESS);
-        } else {
-            ASSERT(FALSE);
-        }
-    } else {
-        InitProfile();
-        auto it1 = m_ProfileMap.find(lpszSection);
-        if (it1 != m_ProfileMap.end()) {
-            auto& sectionMap = it1->second;
-            auto it2 = sectionMap.find(lpszEntry);
-            ret = (it2 != sectionMap.end());
-        }
-    }
-    return ret;
+    return ProfileForSection(lpszSection).HasEntry(lpszSection, lpszEntry);
 }
 
 std::vector<int> CMPlayerCApp::GetProfileVectorInt(CString strSection, CString strKey) {
@@ -2003,11 +1677,10 @@ BOOL CMPlayerCApp::InitInstance()
 
     PreProcessCommandLine();
 
-    if (IsIniValid()) {
-        StoreSettingsToIni();
-    } else {
-        StoreSettingsToRegistry();
-    }
+    // The versioned settings store auto-detects its location (portable INI or
+    // registry) on construction. Import legacy settings on first run and guard
+    // against an older build clobbering newer settings.
+    SetupSettingsStore();
 
     m_s->ParseCommandLine(m_cmdln);
 
@@ -2033,35 +1706,14 @@ BOOL CMPlayerCApp::InitInstance()
             }
         }
 
-        // If the profile was already cached, it should be cleared here
-        ASSERT(!m_bProfileInitialized);
-
-        // Remove the settings
-        if (IsIniValid()) {
-            FILE* fp;
-            do { // Open mpc-hc.ini, retry if it is already being used by another process
-                fp = _tfsopen(m_pszProfileName, _T("w"), _SH_SECURE);
-                if (fp || (GetLastError() != ERROR_SHARING_VIOLATION)) {
-                    break;
-                }
-                Sleep(100);
-            } while (true);
-            if (fp) {
-                // Close without writing anything, it should produce empty file
-                VERIFY(fclose(fp) == 0);
-            } else {
-                ASSERT(FALSE);
-            }
-        } else {
-            CRegKey key;
-            // Clear settings
-            key.Attach(GetAppRegistryKey());
-            VERIFY(key.RecurseDeleteKey(_T("")) == ERROR_SUCCESS);
-            VERIFY(key.Close() == ERROR_SUCCESS);
-            // Set ExePath value to prevent settings migration
-            key.Attach(GetAppRegistryKey());
-            VERIFY(key.SetStringValue(_T("ExePath"), PathUtils::GetProgramPath(true)) == ERROR_SUCCESS);
-            VERIFY(key.Close() == ERROR_SUCCESS);
+        // Remove the settings, then re-stamp the writer version so the next run
+        // does not treat this as a fresh install and re-import legacy settings.
+        m_Profile.Clear();
+        m_Profile.WriteString(_T("Version"), _T("LastWrittenBy"), m_strVersion);
+        m_Profile.WriteString(_T("Version"), _T("HistorySplit"), _T("1")); // history is separate; don't re-split
+        m_Profile.Flush(true);
+        if (m_HistoryProfile) {
+            m_HistoryProfile->Clear();
         }
 
         // Remove the current playlist if it exists

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -168,6 +168,14 @@ public:
     bool ExportSettingsZip(const CString& zipPath);
 
 private:
+    // True when the HistoryInAppData option is set in the settings store. Reads
+    // the raw value so it works before LoadSettings() has run.
+    bool UseAppDataForHistory();
+    // Resolved location of the MediaHistory INI (portable mode): next to the
+    // executable by default, %APPDATA%\MPC-HC when the HistoryInAppData option
+    // is set or the program folder is not writable. Carries an existing file
+    // over when the location changes.
+    CStringW ResolveHistoryIniPath();
     // Set up the settings store: in portable (INI) mode, create the separate
     // MediaHistory store and perform the one-time split out of the main file.
     void SetupSettingsStore();
@@ -210,6 +218,10 @@ public:
 
     bool GetAppSavePath(CString& path);
     bool GetAppDataPath(CString& path);
+    // Folder for the saved playlist (default.mpcpl). Follows the MediaHistory
+    // store's folder in portable mode, so the HistoryInAppData option (and the
+    // unwritable-program-folder fallback) relocates both together.
+    bool GetPlaylistSavePath(CString& path);
 
     bool m_fClosingState;
     bool m_bThemeLoaded;

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -165,6 +165,7 @@ public:
     bool IsIniValid() const;
     bool ChangeSettingsLocation(bool useIni);
     bool ExportSettings(CString savePath, CString subKey = _T(""));
+    bool ExportSettingsZip(const CString& zipPath);
 
 private:
     // Set up the versioned settings store: detect location, import legacy

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -167,9 +167,16 @@ public:
     bool ExportSettings(CString savePath, CString subKey = _T(""));
 
 private:
-    // Import legacy settings on first run and protect newer settings from
-    // being clobbered by an older build (downgrade fork). See mplayerc.cpp.
+    // Set up the versioned settings store: detect location, import legacy
+    // settings on first run, migrate older formats forward, stamp the store.
     void SetupSettingsStore();
+    // User-visible settings policies deferred until a normal launch is committed
+    // (skipped for /help, /close, file-association and other utility switches):
+    // the "newer settings exist" warning and the HKLM machine-defaults import.
+    void ApplySettingsPolicies();
+    // Mark the current store as initialized (version stamp + index) so the next
+    // launch does not treat it as a first run and re-import legacy settings.
+    void StampSettingsStoreInitialized();
     // Route a section to the MediaHistory store when applicable, else m_Profile.
     CProfile& ProfileForSection(LPCWSTR lpszSection);
     // Import machine-wide default settings from HKLM\Software\MPC-HC into the

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -168,22 +168,16 @@ public:
     bool ExportSettingsZip(const CString& zipPath);
 
 private:
-    // Set up the versioned settings store: detect location, import legacy
-    // settings on first run, migrate older formats forward, stamp the store.
+    // Set up the settings store: in portable (INI) mode, create the separate
+    // MediaHistory store and perform the one-time split out of the main file.
     void SetupSettingsStore();
     // Set up the separate MediaHistory store (portable/INI mode) incl. the
-    // one-time split and newer-format fork.
+    // one-time split of MediaHistory out of the main settings file.
     void SetupHistoryStore();
-    // Set when setup forked away from a newer-format store; ApplySettingsPolicies
-    // shows the one-time notice on the next committed normal launch.
-    bool m_bWarnNewerFormat = false;
     // User-visible settings policies deferred until a normal launch is committed
     // (skipped for /help, /close, file-association and other utility switches):
-    // the "newer settings exist" warning and the HKLM machine-defaults import.
+    // currently just the HKLM machine-defaults import.
     void ApplySettingsPolicies();
-    // Mark the current store as initialized (version stamp + index) so the next
-    // launch does not treat it as a first run and re-import legacy settings.
-    void StampSettingsStoreInitialized();
     // Route a section to the MediaHistory store when applicable, else m_Profile.
     CProfile& ProfileForSection(LPCWSTR lpszSection);
     // Import machine-wide default settings from HKLM\Software\MPC-HC into the
@@ -192,8 +186,9 @@ private:
     void ImportHKLMTree(HKEY hKey, const CStringW& section);
 
 public:
-    // The versioned settings store. All GetProfile*/WriteProfile* overrides
-    // below delegate to it (via ProfileForSection).
+    // The settings store (HKCU\Software\MPC-HC\MPC-HC or <exe>.ini). All
+    // GetProfile*/WriteProfile* overrides below delegate to it (via
+    // ProfileForSection).
     CProfile m_Profile;
     // Separate MediaHistory store (INI mode only; registry installs keep
     // history in the registry). Null in registry mode.

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -171,6 +171,12 @@ private:
     // Set up the versioned settings store: detect location, import legacy
     // settings on first run, migrate older formats forward, stamp the store.
     void SetupSettingsStore();
+    // Set up the separate MediaHistory store (portable/INI mode) incl. the
+    // one-time split and newer-format fork.
+    void SetupHistoryStore();
+    // Set when setup forked away from a newer-format store; ApplySettingsPolicies
+    // shows the one-time notice on the next committed normal launch.
+    bool m_bWarnNewerFormat = false;
     // User-visible settings policies deferred until a normal launch is committed
     // (skipped for /help, /close, file-association and other utility switches):
     // the "newer settings exist" warning and the HKLM machine-defaults import.

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -163,13 +163,22 @@ public:
     bool StoreSettingsToRegistry();
     CString GetIniPath() const;
     bool IsIniValid() const;
+    // True when settings are stored in the registry (as opposed to an INI file).
+    bool IsUsingRegistry() const;
+    // Keep the cached HistoryInAppData option in sync when it is changed
+    // through the advanced options (see UseAppDataForHistory).
+    void SetHistoryInAppData(bool inAppData);
     bool ChangeSettingsLocation(bool useIni);
     bool ExportSettings(CString savePath, CString subKey = _T(""));
     bool ExportSettingsZip(const CString& zipPath);
 
 private:
-    // True when the HistoryInAppData option is set in the settings store. Reads
-    // the raw value so it works before LoadSettings() has run.
+    // Cached HistoryInAppData option; -1 until first read.
+    int m_iHistoryInAppData = -1;
+    // True when the HistoryInAppData option is set in the settings store. The
+    // first call reads the raw value (it happens before LoadSettings() has
+    // run); afterwards the cached copy is used, kept in sync by
+    // SetHistoryInAppData().
     bool UseAppDataForHistory();
     // Resolved location of the MediaHistory INI (portable mode): next to the
     // executable by default, %APPDATA%\MPC-HC when the HistoryInAppData option

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -172,6 +172,10 @@ private:
     void SetupSettingsStore();
     // Route a section to the MediaHistory store when applicable, else m_Profile.
     CProfile& ProfileForSection(LPCWSTR lpszSection);
+    // Import machine-wide default settings from HKLM\Software\MPC-HC into the
+    // user store once, gated by SettingsReset / SettingsTimestamp (issue #2347).
+    void ApplyHKLMDefaults();
+    void ImportHKLMTree(HKEY hKey, const CStringW& section);
 
 public:
     // The versioned settings store. All GetProfile*/WriteProfile* overrides

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -28,6 +28,7 @@
 #include "EventDispatcher.h"
 #include "DpiHelper.h"
 #include "AppSettings.h"
+#include "Profile.h"
 #include "../filters/renderer/VideoRenderers/RenderersSettings.h"
 #include "resource.h"
 
@@ -166,14 +167,20 @@ public:
     bool ExportSettings(CString savePath, CString subKey = _T(""));
 
 private:
-    std::map<CString, std::map<CString, CString, CStringUtils::IgnoreCaseLess>, CStringUtils::IgnoreCaseLess> m_ProfileMap;
-    bool m_bProfileInitialized;
-    bool m_bQueuedProfileFlush;
-    void InitProfile();
-    std::recursive_mutex m_profileMutex;
-    ULONGLONG m_dwProfileLastAccessTick;
+    // Import legacy settings on first run and protect newer settings from
+    // being clobbered by an older build (downgrade fork). See mplayerc.cpp.
+    void SetupSettingsStore();
+    // Route a section to the MediaHistory store when applicable, else m_Profile.
+    CProfile& ProfileForSection(LPCWSTR lpszSection);
 
 public:
+    // The versioned settings store. All GetProfile*/WriteProfile* overrides
+    // below delegate to it (via ProfileForSection).
+    CProfile m_Profile;
+    // Separate MediaHistory store (INI mode only; registry installs keep
+    // history in the registry). Null in registry mode.
+    std::unique_ptr<CProfile> m_HistoryProfile;
+
     void FlushProfile(bool bForce = true);
     virtual BOOL GetProfileBinary(LPCTSTR lpszSection, LPCTSTR lpszEntry, LPBYTE* ppData, UINT* pBytes) override;
     virtual UINT GetProfileInt(LPCTSTR lpszSection, LPCTSTR lpszEntry, int nDefault) override;

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -1830,6 +1830,7 @@
 #define IDS_PLAYLIST_POSITION_RIGHT     58022
 #define IDS_PLAYLIST_POSITION_BOTTOM    58023
 #define IDS_PLAYLIST_POSITION_FLOAT     58024
+#define IDS_SETTINGS_NEWER_VERSION      58025
 
 // Next default values for new objects
 // 

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -1830,7 +1830,6 @@
 #define IDS_PLAYLIST_POSITION_RIGHT     58022
 #define IDS_PLAYLIST_POSITION_BOTTOM    58023
 #define IDS_PLAYLIST_POSITION_FLOAT     58024
-#define IDS_SETTINGS_NEWER_VERSION      58025
 
 // Next default values for new objects
 // 

--- a/src/thirdparty/zlib/minizip/iowin32.c
+++ b/src/thirdparty/zlib/minizip/iowin32.c
@@ -13,7 +13,7 @@
 
 #include <stdlib.h>
 
-#include "zlib.h"
+#include "../zlib.h"
 #include "ioapi.h"
 #include "iowin32.h"
 

--- a/src/thirdparty/zlib/minizip/zip.c
+++ b/src/thirdparty/zlib/minizip/zip.c
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <time.h>
-#include "zlib.h"
+#include "../zlib.h"
 #include "zip.h"
 
 #ifdef STDC

--- a/src/thirdparty/zlib/minizip/zip.h
+++ b/src/thirdparty/zlib/minizip/zip.h
@@ -47,7 +47,7 @@ extern "C" {
 //#define HAVE_BZIP2
 
 #ifndef _ZLIB_H
-#include "zlib.h"
+#include "../zlib.h"
 #endif
 
 #ifndef _ZLIBIOAPI_H

--- a/src/thirdparty/zlib/zlib.vcxproj
+++ b/src/thirdparty/zlib/zlib.vcxproj
@@ -60,7 +60,9 @@
     <ClCompile Include="inflate.c" />
     <ClCompile Include="inftrees.c" />
     <ClCompile Include="minizip\ioapi.c" />
+    <ClCompile Include="minizip\iowin32.c" />
     <ClCompile Include="minizip\unzip.c" />
+    <ClCompile Include="minizip\zip.c" />
     <ClCompile Include="trees.c" />
     <ClCompile Include="uncompr.c" />
     <ClCompile Include="zutil.c" />

--- a/src/thirdparty/zlib/zlib.vcxproj.filters
+++ b/src/thirdparty/zlib/zlib.vcxproj.filters
@@ -62,6 +62,12 @@
     <ClCompile Include="minizip\ioapi.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="minizip\iowin32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="minizip\zip.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="crc32.h">


### PR DESCRIPTION
Implements the settings changes requested in #2347: machine-wide default
settings from HKLM and a separate MediaHistory file, plus targeted downgrade
protection for the one value an older build corrupts just by running.

The settings store itself is intentionally **unchanged**: same location
(`HKCU\Software\MPC-HC\MPC-HC` or `<exe>.ini`), same layout, same legacy binary
encoding — external tools that read the player's settings (e.g. madVR) and
older MPC-HC builds keep working with no migration and no import step.

## Summary of changes

- New `CProfile` settings-store engine (`src/mpc-hc/Profile.{h,cpp}`), adapted
  from MPC-BE's `CProfile`. `CMPlayerCApp` owns it and routes its
  `GetProfile*`/`WriteProfile*` overrides through it, replacing the previous
  inline profile code. Registry and INI backends behind one typed API; a
  byte-compatible drop-in at the existing store location (INI binary values use
  the legacy A-P encoding; the registry key is opened lazily on first access
  rather than at static-init time).
- **HKLM machine-wide defaults** (the core #2347 request).
- **MediaHistory** moved to its own file in portable mode.
- **DVB saved channels** protected from downgrades under a `v2` namespace.
- Hardened the audio-renderer binary `double` reads (`CycleDelta`,
  `TargetSyncOffset`, `ControlLimit`) with a size check before dereferencing.

## HKLM machine defaults

Administrators can push default settings via `HKLM\Software\MPC-HC`, using
native registry value types mirroring the user store's sections. Two control
values gate the one-time import into the user store:

- `SettingsTimestamp` (REG_QWORD): when newer than the last applied stamp, the
  HKLM tree is imported over the user settings once. Bump it to push updates.
- `SettingsReset` (REG_DWORD): when changed, the user settings are cleared
  first, then reseeded from HKLM.

The import runs only once a normal interactive launch is committed, so utility
invocations (`/help`, `/close`, `/regvid`, `/admin`, second instances) neither
apply machine policy nor touch the store. Absent HKLM key ⇒ no behavior change.

## Separate MediaHistory file (portable mode)

MediaHistory is rewritten constantly during playback and grows with every file
opened; keeping it in the main INI made that file large and churn-heavy. In
portable mode it now lives in `<exe>.history.ini`, split out of the main INI
once (marker: `[Version] HistorySplit`). Routing happens inside the generic
profile accessors, so the MediaHistory code itself is unchanged. Registry
installs keep history in the registry key as before. INI-mode settings export
bundles both files into a single zip.

A new advanced option **`HistoryInAppData`** (default off) stores the history
INI and the saved playlist (`default.mpcpl`) in `%APPDATA%\MPC-HC` instead of
the player folder — e.g. a shared portable install where each user should keep
private history. The same relocation happens automatically when the history
file cannot be created in the player folder (read-only install running off a
settings INI). An existing history file is carried over when the location
changes, so toggling the option doesn't lose history.

## Downgrade protection for DVB channels

Saved DVB channels are serialized with a leading format-version token that has
changed several times; an older build **throws** on a newer token, drops the
channel, and — because channels are rewritten on every settings save —
destroys the newer list just by running. Since old builds cannot be taught to
leave the data alone, the new build stores the DVB configuration in a
replacement section they never touch: **`DVBConfiguration2`** (same pattern as
`Commands2` / `FileFormats2`). The legacy `DVBConfiguration` section is left
frozen, so a downgrade finds its own last-known-good settings. Presence is
detected by probing `BDASymbolRate` in the new section with a default of `-1`;
`-1` means first run after upgrade, so everything is read once from the legacy
section and migrated on the next save.

This is deliberately the *only* value that gets this treatment. An empirical
sweep of the settings written by ~45 archived releases confirmed everything
else evolves additively (new keys old builds ignore), and the toolbar's
`ButtonSequence` already carries its own in-band versioning
(`ButtonLayoutRevision`) and is only rewritten on explicit user customization.

## Docs

Design notes in `docs/settings-versioning.md` and
`docs/settings-history-store.md`.

## Testing

- Built x64 Release; runtime-tested in portable mode: legacy DVB settings
  migrate to `DVBConfiguration2` byte-identically with the legacy section
  frozen; MediaHistory splits into `<exe>.history.ini` with no residue; second
  run is idempotent; INI binary values verified byte-compatible with the legacy
  A-P encoding (decoded `CycleDelta`/`TargetSyncOffset`/`ControlLimit` match).
- Verified registry-mode key layout keeps `DVBConfiguration` a plain leaf key,
  so old builds' non-recursive section clear (`RegDeleteKey`) keeps working.
- Runtime-tested `HistoryInAppData`: with the option set, the history splits
  directly into `%APPDATA%\MPC-HC\<exe>.history.ini`; toggling it off moves the
  file back next to the executable with content intact.

Closes #2347.
