### PR TITLE
Add filter to exclude files and URLs from history

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -71,6 +71,8 @@ CAppSettings::CAppSettings()
     , fTitleBarTextTitle(false)
     , fKeepHistory(true)
     , iRecentFilesNumber(100)
+    , sHistoryExcludeFilter()
+    , sHistoryExcludeFilterPrivate()
     , MRU(L"MediaHistory", iRecentFilesNumber)
     , MRUDub(0, _T("Recent Dub List"), _T("Dub%d"), 20)
     , fRememberDVDPos(false)
@@ -1010,6 +1012,8 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_ASPECTRATIO_Y, sizeAspectRatio.cy);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_KEEPHISTORY, fKeepHistory);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_RECENT_FILES_NUMBER, iRecentFilesNumber);
+    pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER, sHistoryExcludeFilter);
+    pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER_PRIVATE, sHistoryExcludeFilterPrivate);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_DSVIDEORENDERERTYPE, iDSVideoRendererType);
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_SHUFFLEPLAYLISTITEMS, bShufflePlaylistItems);
@@ -1846,6 +1850,8 @@ void CAppSettings::LoadSettings()
     fileAssoc.SetNoRecentDocs(!fKeepHistory);
     iRecentFilesNumber = std::max(0, (int)pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_RECENT_FILES_NUMBER, 100));
     MRU.SetSize(iRecentFilesNumber);
+    sHistoryExcludeFilter = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER, _T(""));
+    sHistoryExcludeFilterPrivate = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER_PRIVATE, _T(""));
 
     if (pApp->GetProfileBinary(IDS_R_SETTINGS, IDS_RS_LASTWINDOWRECT, &ptr, &len)) {
         if (len == sizeof(CRect)) {
@@ -2989,7 +2995,8 @@ void CAppSettings::CRecentFileAndURLList::Add(LPCTSTR lpszPathName)
     ASSERT(lpszPathName != nullptr);
     ASSERT(AfxIsValidString(lpszPathName));
 
-    if (m_nSize <= 0 || CString(lpszPathName).MakeLower().Find(_T("@device:")) >= 0) {
+    if (m_nSize <= 0 || CString(lpszPathName).MakeLower().Find(_T("@device:")) >= 0
+            || AfxGetAppSettings().IsExcludedFromHistory(lpszPathName)) {
         return;
     }
 
@@ -3109,6 +3116,34 @@ CStringW getRFEHash(ULONGLONG llDVDGuid) {
     CStringW hash;
     hash.Format(L"DVD%llu", llDVDGuid);
     return hash;
+}
+
+// Does lowerPath contain any of the semicolon-separated substrings of filter?
+static bool MatchesHistoryExcludeFilter(const CStringW& lowerPath, const CStringW& filter) {
+    int pos = 0;
+    while (pos >= 0) {
+        CStringW token = filter.Tokenize(L";", pos);
+        token.Trim();
+        if (token.IsEmpty()) {
+            continue;
+        }
+        token.MakeLower();
+        if (lowerPath.Find(token) >= 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Matching is case-insensitive: correct for local paths, and the friendlier choice for URLs.
+bool CAppSettings::IsExcludedFromHistory(LPCWSTR path) const {
+    if (sHistoryExcludeFilter.IsEmpty() && sHistoryExcludeFilterPrivate.IsEmpty()) {
+        return false;
+    }
+    CStringW lowerPath(path);
+    lowerPath.MakeLower();
+    return MatchesHistoryExcludeFilter(lowerPath, sHistoryExcludeFilter)
+           || MatchesHistoryExcludeFilter(lowerPath, sHistoryExcludeFilterPrivate);
 }
 
 CStringW getRFEHash(RecentFileEntry &r) {
@@ -3290,6 +3325,19 @@ void CAppSettings::CRecentFileListWithMoreInfo::Add(RecentFileEntry r, bool curr
     }
     if (CString(r.fns.GetHead()).MakeLower().Find(_T("@device:")) >= 0) {
         return;
+    }
+
+    const auto& s = AfxGetAppSettings();
+    POSITION fnPos = r.fns.GetHeadPosition();
+    while (fnPos) {
+        if (s.IsExcludedFromHistory(r.fns.GetNext(fnPos))) {
+            if (current_open) {
+                // Nothing is current anymore, so playback of this file updates no entry.
+                current_rfe_hash.Empty();
+                persistedFilePosition = 0;
+            }
+            return;
+        }
     }
 
     if (r.hash.IsEmpty()) {

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -3718,15 +3718,24 @@ void CAppSettings::CRecentFileListWithMoreInfo::WriteMediaHistoryEntry(RecentFil
         pApp->WriteProfileStringW(subSection, L"SubtitleTrackIndex", nullptr);
     }
 
-    if (updateLastOpened || isNewEntry || r.lastOpened.IsEmpty()) {
-        auto now = std::chrono::system_clock::now();
+    auto now = std::chrono::system_clock::now();
+
+    // Only stamp a new time when the entry is actually being opened, or when we
+    // have no time for it at all. An entry missing from the store is NOT reason
+    // enough: rewriting the whole history into a different store (switching
+    // between registry and ini) makes every entry look new, and restamping them
+    // all with the current time would collapse them onto near-identical
+    // timestamps and scramble the recent files order.
+    if (updateLastOpened || r.lastOpened.IsEmpty()) {
         auto nowISO = date::format<wchar_t>(L"%FT%TZ", date::floor<std::chrono::milliseconds>(now));
         r.lastOpened = CStringW(nowISO.c_str());
+    }
+    if (updateLastOpened || isNewEntry || pApp->GetProfileStringW(subSection, L"LastOpened", L"") != r.lastOpened) {
         pApp->WriteProfileStringW(subSection, L"LastOpened", r.lastOpened);
-        if (isNewEntry) {
-            rfe_last_added = (int)std::chrono::time_point_cast<std::chrono::seconds>(now).time_since_epoch().count();
-            pApp->WriteProfileInt(m_section, L"LastAdded", rfe_last_added);
-        }
+    }
+    if (isNewEntry) {
+        rfe_last_added = (int)std::chrono::time_point_cast<std::chrono::seconds>(now).time_since_epoch().count();
+        pApp->WriteProfileInt(m_section, L"LastAdded", rfe_last_added);
     }
     listModifySequence++;
 }

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -605,6 +605,12 @@ public:
     bool            fTitleBarTextTitle;
     bool            fKeepHistory;
     int             iRecentFilesNumber;
+    // Semicolon-separated substrings: a file/URL containing any of them is kept out of the
+    // history. The two lists are equivalent, but the private one is deliberately not exposed
+    // in the options UI, so it can hold terms the user does not want on screen.
+    CString         sHistoryExcludeFilter;
+    CString         sHistoryExcludeFilterPrivate;
+    bool            IsExcludedFromHistory(LPCWSTR path) const;
     CRecentFileListWithMoreInfo MRU;
     CRecentFileAndURLList MRUDub;
     bool            fRememberDVDPos;

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -14358,7 +14358,9 @@ void CMainFrame::OpenFile(OpenFileData* pOFD)
                             r.fns.RemoveAll();
                             r.fns.AddHeadList(&pli.m_fns);
                         }
-                        SHAddToRecentDocs(SHARD_PATH, fn);
+                        if (!s.IsExcludedFromHistory(fn)) {
+                            SHAddToRecentDocs(SHARD_PATH, fn);
+                        }
                     }
                     if (pli.m_cue) {
                         r.cue = pli.m_cue_filename;
@@ -14868,7 +14870,9 @@ void CMainFrame::OpenDVD(OpenDVDData* pODD)
             auto* pMRU = &s.MRU;
             pMRU->Add(pODD->title, llDVDGuid);
         }
-        SHAddToRecentDocs(SHARD_PATH, pODD->title);
+        if (!s.IsExcludedFromHistory(pODD->title)) {
+            SHAddToRecentDocs(SHARD_PATH, pODD->title);
+        }
     }
 
     // TODO: resetdvd

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -194,7 +194,7 @@ void CPPageAdvanced::InitSettings()
         StrRes(IDS_PPAGEADVANCED_STARTUP_PRESET));
     addBoolItem(TIME_ON_SEEKBAR_LEFT, IDS_RS_TIME_ON_SEEKBAR_LEFT, false, s.bTimeOnSeekBarLeft, StrRes(IDS_PPAGEADVANCED_TIME_ON_SEEKBAR_LEFT));
     addBoolItem(HISTORY_IN_APPDATA, IDS_RS_HISTORY_IN_APPDATA, false, s.bHistoryInAppData, L"Store the history file and the saved playlist in %APPDATA%\\MPC-HC instead of the player folder, when settings are stored in an INI file. This also happens automatically when the player folder is not writable. Requires restart.");
-    addCStringItem(HISTORY_EXCLUDE_FILTER, IDS_RS_HISTORY_EXCLUDE_FILTER, _T(""), s.sHistoryExcludeFilter, L"Semicolon separated list of substrings. Files and URLs whose full path contains any of them are not added to the recent files list, the resume position history, or the Windows recent documents list.\nExample: private;C:\\Videos\\Temp;youtube.com\nA second list, which is not shown here, can be set in the settings file (registry value or INI entry) \"HistoryExcludeFilterPrivate\". Both lists are applied.");
+    addCStringItem(HISTORY_EXCLUDE_FILTER, IDS_RS_HISTORY_EXCLUDE_FILTER, _T(""), s.sHistoryExcludeFilter, L"Semicolon separated list of substrings. Files and URLs whose full path contains any of them are not added to the recent files list, the resume position history, or the Windows recent documents list.\nExample: private;C:\\Videos\\Temp;youtube.com");
 }
 
 BOOL CPPageAdvanced::OnApply()

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -194,6 +194,7 @@ void CPPageAdvanced::InitSettings()
         StrRes(IDS_PPAGEADVANCED_STARTUP_PRESET));
     addBoolItem(TIME_ON_SEEKBAR_LEFT, IDS_RS_TIME_ON_SEEKBAR_LEFT, false, s.bTimeOnSeekBarLeft, StrRes(IDS_PPAGEADVANCED_TIME_ON_SEEKBAR_LEFT));
     addBoolItem(HISTORY_IN_APPDATA, IDS_RS_HISTORY_IN_APPDATA, false, s.bHistoryInAppData, L"Store the history file and the saved playlist in %APPDATA%\\MPC-HC instead of the player folder, when settings are stored in an INI file. This also happens automatically when the player folder is not writable. Requires restart.");
+    addCStringItem(HISTORY_EXCLUDE_FILTER, IDS_RS_HISTORY_EXCLUDE_FILTER, _T(""), s.sHistoryExcludeFilter, L"Semicolon separated list of substrings. Files and URLs whose full path contains any of them are not added to the recent files list, the resume position history, or the Windows recent documents list.\nExample: private;C:\\Videos\\Temp;youtube.com\nA second list, which is not shown here, can be set in the settings file (registry value or INI entry) \"HistoryExcludeFilterPrivate\". Both lists are applied.");
 }
 
 BOOL CPPageAdvanced::OnApply()

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -237,6 +237,7 @@ private:
         STARTUP_PRESET,
         TIME_ON_SEEKBAR_LEFT,
         HISTORY_IN_APPDATA,
+        HISTORY_EXCLUDE_FILTER,
     };
 
     enum {

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -138,6 +138,8 @@
 #define IDS_RS_CUSTOM_PRESET_CONTROLSTATE   _T("CustomPresetControlState")
 #define IDS_RS_CUSTOM_PRESET_CAPTION        _T("CustomPresetCaption")
 #define IDS_RS_STARTUP_PRESET               _T("StartupPreset")
+#define IDS_RS_HISTORY_EXCLUDE_FILTER       _T("HistoryExcludeFilter")
+#define IDS_RS_HISTORY_EXCLUDE_FILTER_PRIVATE _T("HistoryExcludeFilterPrivate")
 
 // Audio
 #define IDS_RS_VOLUME                       _T("Volume")


### PR DESCRIPTION
Closes #3985.

Adds two semicolon-separated substring lists; a file or URL whose full path contains any token is kept out of the history:

- **`HistoryExcludeFilter`** — editable in Options → Advanced.
- **`HistoryExcludeFilterPrivate`** — deliberately not shown in the UI (and not mentioned in the tooltip either), settable only via the registry value / INI entry, per the issue's note about expert users who don't want the terms on screen.

Both lists are applied. Matching is case-insensitive, and blank tokens are ignored so a stray `;` doesn't exclude everything.

### Where it applies

`CAppSettings::IsExcludedFromHistory()` is checked in:

- `CRecentFileListWithMoreInfo::Add(RecentFileEntry, bool)` — the single point every history path funnels through (regular files, DVDs, yt-dlp playlists), so nothing is written to `MediaHistory` at all. Every filename in the entry is tested, not just the first.
- When the excluded file is the one being opened, `current_rfe_hash` is cleared, so resume position, track selection and A-B marks aren't written onto the previously played file's entry.
- `CRecentFileAndURLList::Add` — the "Recent Dub List".
- Both `SHAddToRecentDocs` calls, otherwise the path would still reach the Windows recent documents list / jump list.

Only *adding* is filtered: entries already in the history stay until they age out.

### Testing

Ran the built player against two media files in a portable INI install:

- filter `secret` → `secretstuff.mpg` absent from `MediaHistory`, `keepme.mpg` present;
- public list `  ; ;` plus private list `nomatch; KEEPME.MPG ` → exactly the inverse, confirming the private list works on its own, matching is case-insensitive, tokens are trimmed, and empty tokens match nothing;
- both values round-trip through save/load.


---

## Also: preserve `LastOpened` when history moves between stores

Fixes the `LastOpened` corruption reported in #3979 (recent files out of order after
switching settings storage).

`WriteMediaHistoryEntry` treated "this entry is not in the store yet" as reason to
stamp `LastOpened` with the current time:

```cpp
bool isNewEntry = storedFilename.IsEmpty();
...
if (updateLastOpened || isNewEntry || r.lastOpened.IsEmpty()) { /* stamp now */ }
```

When the whole history is rewritten into a *different* store, every entry is missing
from the destination, so all of them get restamped within the same millisecond.
`LoadMediaHistory` orders the list by `LastOpened`, and the ties then resolve by hash
order, so the list comes back shuffled.

Now a new time is only generated when the entry is really being opened
(`updateLastOpened`) or when there is no time for it at all; an entry that already
carries a time keeps it, and the value is written when it is new or has changed.
`LastAdded` handling is unchanged.

Not a regression from the settings PRs — the restamp dates back to f47515f8e (2022);
moving stores is just the first thing that rewrites a full history into an empty
destination.

### Testing

Seeded a portable history with three entries with distinct timestamps, then switched
storage INI → Registry:

- before: all three became `2026-08-01T23:52:27.547Z` (identical to the millisecond)
- after: `2026-03-03`, `2026-02-02`, `2026-01-01` timestamps preserved unchanged
