### PR TITLE
Fix spurious playlist horizontal scrollbar when the playlist is restored at startup (#3972)

### DIFF
--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1882,7 +1882,15 @@ void CPlayerPlaylistBar::ResizeListColumn()
         m_list.SetColumnWidth(COL_NAME, 0);
         m_list.MoveWindow(listR, FALSE);
         m_list.GetClientRect(r);
-        m_list.SetColumnWidth(COL_NAME, std::max(0, r.Width() - m_nTimeColWidth));
+        int width = r.Width();
+        // The list does not update its scrollbars while redraw is disabled, so when items were
+        // added in that state (playlist restored at startup) the client rect still reports the
+        // full width. Reserve room for the vertical scrollbar that is about to appear, else the
+        // name column ends up too wide and a spurious horizontal scrollbar is shown.
+        if (width == listR.Width() && m_list.GetItemCount() > m_list.GetCountPerPage()) {
+            width -= m_pMainFrame->m_dpi.GetSystemMetricsDPI(SM_CXVSCROLL);
+        }
+        m_list.SetColumnWidth(COL_NAME, std::max(0, width - m_nTimeColWidth));
         m_list.SetRedraw(TRUE);
 
         Invalidate();


### PR DESCRIPTION
Fixes #3972.

`ResizeListColumn()` sizes the Name column from the list's client rect, but a list view does not recompute its scrollbars while redraw is disabled — and `LoadPlaylist()` wraps the whole startup restore (including `SetItemCountEx`) in `m_list.SetRedraw(FALSE)`. So at startup the client rect still reports the full width as if there were no vertical scrollbar, the Name column is sized to that, and once redraw is re-enabled the vertical scrollbar appears and the columns overflow by exactly `SM_CXVSCROLL` — the spurious horizontal scrollbar. Any later resize calls `ResizeListColumn()` with redraw on, which is why manually resizing the window makes it go away.

Instead of trusting the stale measurement, predict the scrollbar: if the client width still equals the full frame width (nothing deducted yet) and `GetItemCount() > GetCountPerPage()`, reserve one DPI-scaled `SM_CXVSCROLL` before setting the column width. The first condition prevents double-subtraction when the scrollbar is already correctly accounted for. Fixing it in `ResizeListColumn()` rather than in `LoadPlaylist()` covers every caller that resizes while redraw is off.

Verified with two portable instances (develop vs. this change) given an identical seeded config and a 60-item `default.mpcpl`, captured on launch with no resize: before shows the horizontal scrollbar, after does not.