### PR TITLE
Fix crash on exit when the player is closed during the first-run update-check prompt

### DIFF
--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -2282,6 +2282,14 @@ BOOL CMPlayerCApp::InitInstance()
         UpdateChecker::CheckForUpdate(true);
     }
 
+    if (!m_pMainWnd) {
+        // The first-run "enable automatic update checks?" prompt above is modal, so it pumps
+        // messages. If the user closed the player while it was up, the main frame is already
+        // destroyed and MFC has cleared m_pMainWnd. Abort startup instead of dereferencing it;
+        // AfxWinMain skips Run() and calls ExitInstance(), so the settings still get saved.
+        return FALSE;
+    }
+
     SendCommandLine(m_pMainWnd->m_hWnd);
     RegisterHotkeys();
 


### PR DESCRIPTION
Closing the player while the first-run "enable automatic update checks?" prompt is
open kills the process with `0xC0000005`.

`UpdateChecker::IsAutoUpdateEnabled()` shows that prompt from inside
`CMPlayerCApp::InitInstance()`, at a point where the main frame already exists and
is visible. It only appears when `UpdaterAutoCheck` has never been set, i.e. on a
first run. Being modal, it runs its own message pump, so a close that arrives
while it is up (clicking X, File > Exit, `WM_CLOSE`) is processed right there: the
frame is destroyed and MFC clears `m_pMainWnd`. `InitInstance` then resumes and
unconditionally dereferences it:

```cpp
    SendCommandLine(m_pMainWnd->m_hWnd);
```

```
ExceptionCode: c0000005 (Access violation), read of 0x40
ExceptionAddress: mpc_hc64!CMPlayerCApp::InitInstance+0x1820  [mplayerc.cpp @ 2285]

    mov  rdx, qword ptr [r14+40h]   ; rdx = this->m_pMainWnd  (NULL)
    mov  rdx, qword ptr [rdx+40h]   ; <-- AV
    call mpc_hc64!CMPlayerCApp::SendCommandLine
```

Because `InitInstance` never returns, `CWinThread::Run()` never starts and
`ExitInstance()` never runs, so `SaveSettings()` / `CProfile::Flush()` are skipped
too. In registry mode that is invisible, but in portable/INI mode the profile is
only written at exit, so the whole session's settings are silently discarded.

The fix bails out of startup if the main window went away while the prompt was up.
`AfxWinMain` handles a `FALSE` return by skipping `Run()` and calling
`ExitInstance()`, so settings are still saved, and its `m_pMainWnd != NULL` cleanup
branch is not taken.

Verified with a portable build closed 4 s after the window appears:

| profile | before | after |
|---|---|---|
| fresh (prompt shown) | exit `0xC0000005`, 40-byte ini | exit `0`, 21,168-byte ini |
| `UpdaterAutoCheck=0` (no prompt) | exit `0`, 21,113-byte ini | exit `0`, 21,171-byte ini |
