### PR TITLE
Fix file dialogs truncating selected paths at MAX_PATH

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -4927,11 +4927,7 @@ void CMainFrame::OnFileOpenQuick()
     }
 
     CAtlList<CString> fns;
-
-    POSITION pos = fd.GetStartPosition();
-    while (pos) {
-        fns.AddTail(fd.GetNextPathName(pos));
-    }
+    FileDialogUtils::GetSelectedPaths(fd, fns);
 
     bool fMultipleFiles = false;
 
@@ -6907,16 +6903,19 @@ void CMainFrame::OnFileSubtitlesLoad()
     CFileDialog fd(TRUE, nullptr, nullptr, dwFlags, filters, GetModalParent());
 
     OPENFILENAME& ofn = fd.GetOFN();
-    // Provide a buffer big enough to hold 16 paths (which should be more than enough)
+    // Provide a buffer big enough to hold 16 paths (which should be more than enough).
+    // Only the old style dialog falls back to it, GetSelectedPaths() normally reads the
+    // selection straight from the shell interface.
     const int nBufferSize = 16 * (MAX_PATH + 1) + 1;
     CString filenames;
     ofn.lpstrFile = filenames.GetBuffer(nBufferSize);
     ofn.nMaxFile = nBufferSize;
     // Set the current file directory as default folder
     CString curfile = m_wndPlaylistBar.GetCurFileName();
+    CPathW defaultDir; // must outlive DoModal(), ofn.lpstrInitialDir points into it
     if (!PathUtils::IsURL(curfile)) {
         ExtendMaxPathLengthIfNeeded(curfile, true);
-        CPathW defaultDir(curfile);
+        defaultDir = curfile.GetString();
         defaultDir.RemoveFileSpec();
         if (!defaultDir.m_strPath.IsEmpty() && defaultDir.IsDirectory()) {
             ofn.lpstrInitialDir = defaultDir.m_strPath;
@@ -6925,9 +6924,11 @@ void CMainFrame::OnFileSubtitlesLoad()
 
     if (fd.DoModal() == IDOK) {
         bool bFirstFile = true;
-        POSITION pos = fd.GetStartPosition();
+        CAtlList<CString> subfiles;
+        FileDialogUtils::GetSelectedPaths(fd, subfiles);
+        POSITION pos = subfiles.GetHeadPosition();
         while (pos) {
-            CString subfile = fd.GetNextPathName(pos);
+            const CString& subfile = subfiles.GetNext(pos);
             if (m_pDVS) {
                 if (SUCCEEDED(m_pDVS->put_FileName((LPWSTR)(LPCWSTR)subfile))) {
                     m_pDVS->put_SelectedLanguage(0);

--- a/src/mpc-hc/OpenDlg.cpp
+++ b/src/mpc-hc/OpenDlg.cpp
@@ -145,11 +145,7 @@ void COpenDlg::OnBrowseFile()
     }
 
     m_fns.RemoveAll();
-
-    POSITION pos = fd.GetStartPosition();
-    while (pos) {
-        m_fns.AddTail(fd.GetNextPathName(pos));
-    }
+    FileDialogUtils::GetSelectedPaths(fd, m_fns);
 
     if (!m_fns.IsEmpty()) {
         if (s.fKeepHistory) {

--- a/src/mpc-hc/OpenFileDlg.cpp
+++ b/src/mpc-hc/OpenFileDlg.cpp
@@ -26,6 +26,93 @@
 
 #define __DUMMY__ _T("*.*")
 
+namespace FileDialogUtils
+{
+    static void AppendPath(IShellItem* pItem, CAtlList<CString>& paths)
+    {
+        CComHeapPtr<WCHAR> path;
+        if (SUCCEEDED(pItem->GetDisplayName(SIGDN_FILESYSPATH, &path))) {
+            paths.AddTail(CString(path));
+        }
+    }
+
+    // Fallback for the old style dialog. The buffer holds a sequence of null terminated
+    // strings: either a single full path, or the folder followed by one bare file name
+    // per selected file. Note that the MSDN example for CFileDialog gets the first case
+    // wrong, it reports the path as the folder and then finds no files at all.
+    static void ParseOFNBuffer(const OPENFILENAME& ofn, CAtlList<CString>& paths)
+    {
+        const TCHAR* p = ofn.lpstrFile;
+        if (!p) {
+            return;
+        }
+
+        size_t remaining = ofn.nMaxFile;
+        size_t len = _tcsnlen(p, remaining);
+        if (len == 0 || len >= remaining) {
+            return;
+        }
+
+        CString folder(p, (int)len);
+        p += len + 1;
+        remaining -= len + 1;
+
+        len = _tcsnlen(p, remaining);
+        if (len == 0) {
+            // only one string, so it is a full path rather than a folder
+            paths.AddTail(folder);
+            return;
+        }
+
+        if (folder[folder.GetLength() - 1] != _T('\\')) {
+            folder += _T('\\');
+        }
+        while (len > 0 && len < remaining) {
+            paths.AddTail(folder + CString(p, (int)len));
+            p += len + 1;
+            remaining -= len + 1;
+            len = _tcsnlen(p, remaining);
+        }
+    }
+
+    bool GetSelectedPaths(CFileDialog& fd, CAtlList<CString>& paths)
+    {
+        // Read the result from the shell interface the dialog is built on. Unlike the
+        // OPENFILENAME buffer and CFileDialog::GetNextPathName(), IShellItem has no
+        // path length limit of its own.
+        CComPtr<IFileOpenDialog> pOpenDlg;
+        pOpenDlg.Attach(fd.GetIFileOpenDialog());
+        if (pOpenDlg) {
+            CComPtr<IShellItemArray> pItems;
+            if (SUCCEEDED(pOpenDlg->GetResults(&pItems)) && pItems) {
+                DWORD count = 0;
+                if (SUCCEEDED(pItems->GetCount(&count))) {
+                    for (DWORD i = 0; i < count; i++) {
+                        CComPtr<IShellItem> pItem;
+                        if (SUCCEEDED(pItems->GetItemAt(i, &pItem))) {
+                            AppendPath(pItem, paths);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (paths.IsEmpty()) {
+            // old style dialog, or a selection with no file system path (COpenFileDlg
+            // substitutes "*.*" when a directory was picked)
+            ParseOFNBuffer(fd.GetOFN(), paths);
+        }
+
+        return !paths.IsEmpty();
+    }
+
+    CString GetSelectedPath(CFileDialog& fd)
+    {
+        CAtlList<CString> paths;
+        return GetSelectedPaths(fd, paths) ? paths.GetHead() : CString();
+    }
+}
+
 bool COpenFileDlg::m_fAllowDirSelection = false;
 WNDPROC COpenFileDlg::m_wndProc = nullptr;
 
@@ -153,85 +240,4 @@ BOOL COpenFileDlg::OnIncludeItem(OFNOTIFYEX* pOFNEx, LRESULT* pResult)
     *pResult = mask.Find(ext) >= 0 || mask.Find(_T("*.*")) >= 0;
 
     return TRUE;
-}
-
-// override CFileDialog::GetNextPathName() and increase max path length
-CString COpenFileDlg::GetNextPathName(POSITION& pos) const
-{
-    BOOL bExplorer = m_ofn.Flags & OFN_EXPLORER;
-    TCHAR chDelimiter;
-    if (bExplorer)
-        chDelimiter = '\0';
-    else
-        chDelimiter = ' ';
-
-    LPTSTR lpsz = (LPTSTR)pos;
-    if (lpsz == m_ofn.lpstrFile) // first time
-    {
-        if ((m_ofn.Flags & OFN_ALLOWMULTISELECT) == 0)
-        {
-            pos = NULL;
-            return m_ofn.lpstrFile;
-        }
-
-        // find char pos after first Delimiter
-        while (*lpsz != chDelimiter && *lpsz != '\0')
-            lpsz = _tcsinc(lpsz);
-        lpsz = _tcsinc(lpsz);
-
-        // if single selection then return only selection
-        if (*lpsz == 0)
-        {
-            pos = NULL;
-            return m_ofn.lpstrFile;
-        }
-    }
-
-    CString strBasePath = m_ofn.lpstrFile;
-    if (!bExplorer)
-    {
-        LPTSTR lpszPath = m_ofn.lpstrFile;
-        while (*lpszPath != chDelimiter)
-            lpszPath = _tcsinc(lpszPath);
-        strBasePath = strBasePath.Left(int(lpszPath - m_ofn.lpstrFile));
-    }
-
-    LPTSTR lpszFileName = lpsz;
-    CString strFileName = lpsz;
-
-    // find char pos at next Delimiter
-    while (*lpsz != chDelimiter && *lpsz != '\0')
-        lpsz = _tcsinc(lpsz);
-
-    if (!bExplorer && *lpsz == '\0')
-        pos = NULL;
-    else
-    {
-        if (!bExplorer)
-            strFileName = strFileName.Left(int(lpsz - lpszFileName));
-
-        lpsz = _tcsinc(lpsz);
-        if (*lpsz == '\0') // if double terminated then done
-            pos = NULL;
-        else
-            pos = (POSITION)lpsz;
-    }
-
-    TCHAR strDrive[_MAX_DRIVE], strDir[4 * _MAX_DIR], strName[4 * _MAX_FNAME], strExt[_MAX_EXT];
-    Checked::tsplitpath_s(strFileName, strDrive, _MAX_DRIVE, strDir, 4 * _MAX_DIR, strName, 4 * _MAX_FNAME, strExt, _MAX_EXT);
-    TCHAR strPath[4 * _MAX_PATH];
-    if (*strDrive || *strDir)
-    {
-        Checked::tcscpy_s(strPath, _countof(strPath), strFileName);
-    } else
-    {
-        if ((strBasePath.GetLength() != 3) || (strBasePath[1] != ':') || (strBasePath[2] != '\\'))
-        {
-            strBasePath += _T("\\");
-        }
-        Checked::tsplitpath_s(strBasePath, strDrive, _MAX_DRIVE, strDir, 4 * _MAX_DIR, NULL, 0, NULL, 0);
-        Checked::tmakepath_s(strPath, 4 * _MAX_PATH, strDrive, strDir, strName, strExt);
-    }
-
-    return strPath;
 }

--- a/src/mpc-hc/OpenFileDlg.h
+++ b/src/mpc-hc/OpenFileDlg.h
@@ -25,6 +25,18 @@
 #include <atlpath.h>
 
 
+namespace FileDialogUtils
+{
+    // Retrieves the path(s) the user selected, to be called after DoModal() returned IDOK.
+    // Use this instead of CFileDialog::GetStartPosition()/GetNextPathName(), which cannot
+    // return a path longer than _MAX_PATH. Returns false if nothing could be retrieved.
+    bool GetSelectedPaths(CFileDialog& fd, CAtlList<CString>& paths);
+
+    // Single selection variant, returns an empty string on failure.
+    CString GetSelectedPath(CFileDialog& fd);
+}
+
+
 // COpenFileDlg
 
 class COpenFileDlg : public CFileDialog
@@ -58,5 +70,4 @@ protected:
 
 public:
     afx_msg void OnDestroy();
-    CString GetNextPathName(POSITION& pos) const;
 };

--- a/src/mpc-hc/PPageLogo.cpp
+++ b/src/mpc-hc/PPageLogo.cpp
@@ -26,6 +26,7 @@
 #include "CMPCTheme.h"
 #include "CMPCThemeUtil.h"
 #include "ColorProfileUtil.h"
+#include "OpenFileDlg.h"
 
 // CPPageLogo dialog
 
@@ -214,7 +215,7 @@ void CPPageLogo::OnBnClickedButton2()
                     this, 0);
 
     if (dlg.DoModal() == IDOK) {
-        m_logofn = dlg.GetPathName();
+        m_logofn = FileDialogUtils::GetSelectedPath(dlg);
         UpdateData(FALSE);
         OnBnClickedExternalRadio();
     }

--- a/src/mpc-hc/PPageShaders.cpp
+++ b/src/mpc-hc/PPageShaders.cpp
@@ -21,6 +21,7 @@
 #include "stdafx.h"
 #include "PPageShaders.h"
 #include "MainFrm.h"
+#include "OpenFileDlg.h"
 #include "PathUtils.h"
 #include "mplayerc.h"
 #undef SubclassWindow
@@ -467,6 +468,8 @@ void CPPageShaders::OnAddShaderFile()
     CFileDialog dlg(TRUE, nullptr, nullptr, dlgFlags, dlgFilter, this);
     // default buffer size is 260 chars
     // since we allow multi-select, we want it larger
+    // (only the old style dialog falls back to this buffer, GetSelectedPaths() normally
+    // reads the selection straight from the shell interface)
     CString buff;
     const DWORD bufflen = 4096;
     dlg.GetOFN().lpstrFile = buff.GetBuffer(bufflen);
@@ -474,9 +477,11 @@ void CPPageShaders::OnAddShaderFile()
 
     if (dlg.DoModal() == IDOK) {
         auto list = m_Shaders.GetList();
-        POSITION dlgPos = dlg.GetStartPosition();
+        CAtlList<CString> paths;
+        FileDialogUtils::GetSelectedPaths(dlg, paths);
+        POSITION dlgPos = paths.GetHeadPosition();
         while (dlgPos) {
-            Shader shader(dlg.GetNextPathName(dlgPos));
+            Shader shader(paths.GetNext(dlgPos));
             if (std::find(list.begin(), list.end(), shader) == std::end(list)) {
                 m_Shaders.AddShader(shader);
             }

--- a/src/mpc-hc/RegFilterChooserDlg.cpp
+++ b/src/mpc-hc/RegFilterChooserDlg.cpp
@@ -25,6 +25,7 @@
 #include "mplayerc.h"
 #include "DSUtil.h"
 #include "FakeFilterMapper2.h"
+#include "OpenFileDlg.h"
 #include <initguid.h>
 #include <dmo.h>
 #include "PPageExternalFilters.h"
@@ -168,7 +169,7 @@ void CRegFilterChooserDlg::OnBnClickedButton1()
 
     if (dlg.DoModal() == IDOK) {
         CFilterMapper2 fm2(false);
-        fm2.Register(dlg.GetPathName());
+        fm2.Register(FileDialogUtils::GetSelectedPath(dlg));
         m_filters.AddTail(&fm2.m_filters);
         fm2.m_filters.RemoveAll();
 


### PR DESCRIPTION
Fixes #3969.

`CFileDialog` cannot return a path longer than `_MAX_PATH`, in two separate places: its
default `m_szFileName[_MAX_PATH]` buffer, and the fixed stack buffers in
`GetNextPathName()` (`_MAX_DIR` / `_MAX_FNAME` / `strPath[_MAX_PATH]`), which do not
truncate silently but throw via `AfxCrtErrorCheck`. Both are still present in the newest
MFC, so this is not something a toolset update will fix.

Adds `FileDialogUtils::GetSelectedPaths()` / `GetSelectedPath()`, which read the selection
from the dialog's own `IFileOpenDialog` via `IShellItemArray` and
`GetDisplayName(SIGDN_FILESYSPATH)`, so no fixed-size buffer is involved at all. They take
a `CFileDialog&`, so plain `CFileDialog` call sites can use them without switching class.

`GetIFileOpenDialog()` is used rather than `CFileDialog::GetResults()` because the latter is
`ENSURE`-guarded and throws in release builds if the `QueryInterface` fails, for example on
a save dialog.

For the old style dialog, which is only reached if the `IFileDialog` cannot be created,
there is a fallback that parses the `OPENFILENAME` buffer directly. It also covers
`COpenFileDlg`'s `"*.*"` directory-selection entry, which has no shell item to enumerate.

Converted call sites:

- `CMainFrame::OnFileSubtitlesLoad()` and `CPPageShaders::OnAddShaderFile()` — multi-select,
  so they were the ones actually reaching `GetNextPathName()`'s stack buffers
- `CMainFrame::OnFileOpenQuick()` and `COpenDlg::OnBrowseFile()` — were using
  `COpenFileDlg::GetNextPathName()`, capped at `4 * _MAX_PATH`
- `CPPageLogo` and `CRegFilterChooserDlg` — single-select, but `GetPathName()` was returning
  a path truncated to 260 characters

With no callers left, `COpenFileDlg::GetNextPathName()` is removed. `COpenFileDlg` itself
stays for the filter mask and directory selection it uniquely provides.

Also fixes a dangling pointer in `OnFileSubtitlesLoad()`: `ofn.lpstrInitialDir` pointed at a
`CPathW` that went out of scope before `DoModal()` was called.
