### PR TITLE
Sort files by path when opening a multi-file selection from Explorer

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -837,6 +837,7 @@ CMainFrame::CMainFrame()
     , m_iReloadSubIdx(-1)
     , m_bRememberFilePos(false)
     , m_dwLastRun(0)
+    , m_nLastAppendSelectionIndex(0)
     , m_bBuffering(false)
     , m_fLiveWM(false)
     , m_rtDurationOverride(-1)
@@ -5227,12 +5228,20 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
             OpenMedia(p);
         } else {
             ULONGLONG tcnow = GetTickCount64();
-            if (m_dwLastRun && ((tcnow - m_dwLastRun) < s.iRedirectOpenToAppendThreshold)) {
+            // Opening a multi-file selection in Explorer spawns one process per file. Those arrive here in
+            // arbitrary order, so the entries added by the second and later ones are sorted back into place.
+            bool bSameSelection = m_dwLastRun && ((tcnow - m_dwLastRun) < s.iRedirectOpenToAppendThreshold);
+            if (bSameSelection) {
                 s.nCLSwitches |= CLSW_ADD;
             }
             m_dwLastRun = tcnow;
+            bool bRandomize = !!(s.nCLSwitches & CLSW_RANDOMIZE);
 
-            if ((s.nCLSwitches & CLSW_ADD) && !IsPlaylistEmpty()) {             
+            if ((s.nCLSwitches & CLSW_ADD) && !IsPlaylistEmpty()) {
+                if (!bSameSelection) { // a new selection starts at the current end of the playlist
+                    m_nLastAppendSelectionIndex = (int)m_wndPlaylistBar.GetCount();
+                }
+
                 POSITION pos2 = sl.GetHeadPosition();
                 while (pos2) {
                     CString fn = sl.GetNext(pos2);
@@ -5256,8 +5265,15 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
                     }
                     PostMessage(WM_MPC_OPENCURPLAYLIST, 0, 0);
                 }
+
+                // Done last so that it does not interfere with the item selected above. Sorting only moves
+                // list nodes around, so the playlist position stays on the same item.
+                if (bSameSelection && !bRandomize) {
+                    m_wndPlaylistBar.SortByPathFrom(m_nLastAppendSelectionIndex);
+                }
             } else {
                 fSetForegroundWindow = true;
+                m_nLastAppendSelectionIndex = 0; // the playlist gets replaced below
 
                 if (GetMediaState() == State_Running) {
                     MediaControlPause(true);

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -457,6 +457,7 @@ private:
     bool m_bRememberFilePos;
 
     ULONGLONG m_dwLastRun;
+    int m_nLastAppendSelectionIndex; // playlist index where the current batch of redirected opens started
 
     bool m_bBuffering;
 

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1560,6 +1560,19 @@ void CPlayerPlaylistBar::SetCurTime(REFERENCE_TIME rt)
     }
 }
 
+// Sorts the items from startIndex until the end of the list on path, leaving the preceding items untouched.
+void CPlayerPlaylistBar::SortByPathFrom(int startIndex)
+{
+    if (startIndex < 0 || (INT_PTR)startIndex + 1 >= m_pl.GetCount()) {
+        return;
+    }
+    POSITION selPos = FindPos(m_list.GetSelectionMark());
+    m_pl.SortByPath(startIndex);
+    SetupList();
+    SyncSelectionToPos(selPos ? selPos : m_pl.GetPos());
+    SavePlaylist();
+}
+
 void CPlayerPlaylistBar::Randomize()
 {
     POSITION selPos = FindPos(m_list.GetSelectionMark());

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -173,6 +173,7 @@ public:
     void SetCurLabel(CString label);
     void SetCurTime(REFERENCE_TIME rt);
     void Randomize();
+    void SortByPathFrom(int startIndex);
     void UpdateLabel(CString in);
 
     void Refresh();

--- a/src/mpc-hc/Playlist.cpp
+++ b/src/mpc-hc/Playlist.cpp
@@ -331,11 +331,23 @@ void CPlaylist::SortByName()
     }
 }
 
-void CPlaylist::SortByPath()
+// Sorts the items from startIndex until the end of the list, leaving the preceding items untouched.
+void CPlaylist::SortByPath(int startIndex)
 {
-    CAtlArray<plsort2_t> a;
-    a.SetCount(GetCount());
+    if (startIndex < 0) {
+        startIndex = 0;
+    }
+    if ((size_t)startIndex + 1 >= GetCount()) { // nothing to sort
+        return;
+    }
+
     POSITION pos = GetHeadPosition();
+    for (int i = 0; i < startIndex; i++) {
+        GetNext(pos);
+    }
+
+    CAtlArray<plsort2_t> a;
+    a.SetCount(GetCount() - startIndex);
     for (int i = 0; pos; i++, GetNext(pos)) {
         a[i].str = GetAt(pos).m_fns.GetHead(), a[i].pos = pos;
     }

--- a/src/mpc-hc/Playlist.h
+++ b/src/mpc-hc/Playlist.h
@@ -107,7 +107,8 @@ public:
     bool RemoveAll();
     bool RemoveAt(POSITION pos);
 
-    void SortById(), SortByName(), SortByPath(), Randomize();
+    void SortById(), SortByName(), Randomize();
+    void SortByPath(int startIndex = 0);
 
     POSITION GetPos() const;
     void SetPos(POSITION pos);


### PR DESCRIPTION
Implements #3991.

Opening a multi-file selection in Explorer spawns one process per file. Those get redirected to the running instance and appended, but they arrive in arbitrary order, so the playlist ends up shuffled.

Alongside the existing timestamp, a playlist index is now stored when a new selection starts. Every append that arrives within `iRedirectOpenToAppendThreshold` of the previous one sorts the playlist on path from that index to the end, leaving anything before it untouched. An append that arrives after the threshold starts a new batch and resets the index.

- `CPlaylist::SortByPath()` takes an optional start index and sorts only the tail range. Existing call sites are unchanged.
- `CPlayerPlaylistBar::SortByPathFrom()` wraps it following the existing sort-menu pattern.
- `CMainFrame::OnCopyData()` tracks the index: on a new selection it is set to the current playlist count, or 0 on the open path since that replaces the list.

Two details:

- The sort runs after the `CLSW_OPEN | CLSW_PLAY` block rather than before it. Sorting only relinks list nodes, so positions stay valid and the newly added file is still the one that plays; sorting first would have made `/add /play` start the alphabetically last file instead.
- It is skipped when `/randomize` was passed, which would otherwise be undone.

Tested with a release x64 build:

| scenario | arrival order | resulting playlist |
| --- | --- | --- |
| Explorer-style open | c, then a, e, b, d | `a, b, d, e` |
| `/add` batch onto an existing list | zz, then yy, e, a | `zz, a, e, yy` (zz preserved, batch sorted from index 1) |
| `/add` with a gap past the threshold | zz, yy, then e, a | `zz, yy, a, e` (gap starts a new batch) |