### PR TITLE
Migrate internal filter settings when changing settings storage location

### DIFF
--- a/src/mpc-hc/Profile.cpp
+++ b/src/mpc-hc/Profile.cpp
@@ -1107,6 +1107,79 @@ void CProfile::MoveSectionTree(const wchar_t* root, CProfile& dst)
     }
 }
 
+void CProfile::ReadSectionTree(const wchar_t* root, ProfileMap& tree)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    if (!m_bRegistryMode) {
+        InitIni();
+        const CStringW rootStr(root);
+        const CStringW prefix(rootStr + L"\\");
+
+        // Iterate the whole map instead of enumerating subsections level by
+        // level: an intermediate section without direct values (e.g.
+        // "root\a" when only "root\a\b" holds values) has no map entry, so
+        // it would hide the deeper sections from EnumSectionNames().
+        for (const auto& section : m_ProfileMap) {
+            if (section.first.CompareNoCase(rootStr) == 0 || StartsWithNoCase(section.first, prefix)) {
+                tree[section.first] = section.second;
+            }
+        }
+        return;
+    }
+
+    std::vector<CStringW> pending;
+    pending.emplace_back(root);
+
+    while (!pending.empty()) {
+        const CStringW section = pending.back();
+        pending.pop_back();
+
+        std::vector<CStringW> valuenames;
+        EnumValueNames(section, valuenames);
+        for (const auto& name : valuenames) {
+            // REG_SZ values are copied as-is, REG_DWORD values are stored as
+            // their decimal representation; other types are not used by the
+            // sections this is meant for.
+            CStringW str;
+            int number = 0;
+            if (ReadString(section, name, str)) {
+                tree[section][name] = str;
+            } else if (ReadInt(section, name, number)) {
+                str.Format(L"%d", number);
+                tree[section][name] = str;
+            }
+        }
+
+        std::vector<CStringW> subsections;
+        EnumSectionNames(section, subsections);
+        for (const auto& sub : subsections) {
+            pending.emplace_back(section + L"\\" + sub);
+        }
+    }
+}
+
+void CProfile::WriteSectionTree(const ProfileMap& tree)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Mutex);
+
+    for (const auto& section : tree) {
+        for (const auto& kv : section.second) {
+            // Entirely numeric values become REG_DWORD, matching how the
+            // readers (GetProfileInt) expect to find them in the registry;
+            // everything else stays a string.
+            const wchar_t* str = kv.second;
+            wchar_t* end = nullptr;
+            const long number = wcstol(str, &end, 10);
+            if (m_bRegistryMode && end > str && *end == L'\0') {
+                WriteInt(section.first, kv.first, (int)number);
+            } else {
+                WriteString(section.first, kv.first, kv.second);
+            }
+        }
+    }
+}
+
 bool CProfile::HasEntry(const wchar_t* section, const wchar_t* entry)
 {
     std::lock_guard<std::recursive_mutex> lock(m_Mutex);

--- a/src/mpc-hc/Profile.h
+++ b/src/mpc-hc/Profile.h
@@ -131,6 +131,13 @@ public:
     // Used once to split MediaHistory out into its own store. INI mode.
     void MoveSectionTree(const wchar_t* root, CProfile& dst);
 
+    // Snapshot all values under "root" and "root\..." as raw strings, and write
+    // such a snapshot back into the current store. Used to carry sections that
+    // exist only in the profile store (e.g. the internal filter settings)
+    // across a settings location switch.
+    void ReadSectionTree(const wchar_t* root, ProfileMap& tree);
+    void WriteSectionTree(const ProfileMap& tree);
+
     SettingsLocation GetSettingsLocation() const;
 
     // Registry path ("Software\\MPC-HC\\...") of the store when in registry

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -1103,6 +1103,11 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
     m_s->GetFav(FAV_DVD, DVDsFav);
     m_s->GetFav(FAV_DEVICE, devicesFav);
 
+    // The internal filter settings (LAV Splitter/Video/Audio, audio renderer)
+    // exist only in the profile store, so snapshot them for the new location
+    ProfileMap internalFilterSettings;
+    m_Profile.ReadSectionTree(IDS_R_INTERNAL_FILTERS, internalFilterSettings);
+
     if (useIni) {
         // Offer to leave the old registry settings in place as a backup copy
         // (useful when running multiple copies of the player). A present INI
@@ -1125,6 +1130,9 @@ bool CMPlayerCApp::ChangeSettingsLocation(bool useIni)
     if (!success) {
         return false;
     }
+
+    // Restore the internal filter settings into the new store
+    m_Profile.WriteSectionTree(internalFilterSettings);
 
     // Point the MediaHistory store at the new location before SaveSettings()
     // below re-writes the full in-memory history there in the correct format.


### PR DESCRIPTION
Fixes #3998

The internal filter settings (LAV Splitter/Video/Audio and the SaneAR audio renderer) are read and written on demand under the `Internal Filters` profile section, so they are not part of what `CAppSettings::SaveSettings()` rewrites after a settings location switch. `ChangeSettingsLocation()` only carried over the in-memory settings, favorites, and external filters, leaving the internal filter settings behind in the old store. This was also the case before the CProfile conversion.

The fix snapshots the whole `Internal Filters` section tree (raw values) before switching stores and writes it back into the new store afterwards:

- `CProfile::ReadSectionTree()` captures all values under a root section and its subsections. In INI mode it copies the raw strings directly from the profile map (walking by prefix, so subsections like `LAVVideo\HWAccel` are found even when the intermediate section has no direct values, which happens when only the hardware decoder was configured on the Internal Filters page). In registry mode it enumerates subkeys recursively, copying REG_SZ values as-is and REG_DWORD values as their decimal representation.
- `CProfile::WriteSectionTree()` writes a snapshot back. When the target is the registry, entirely numeric values are written as REG_DWORD and everything else as REG_SZ, matching how `GetProfileInt`/`GetProfileString` later read them.

These sections only contain int and string values, so no other registry types need handling.