### PR TITLE
Apply ASS style headers from linked MKV segments (ordered chapters)

### DIFF
--- a/src/Subtitles/SubtitleInputPin.cpp
+++ b/src/Subtitles/SubtitleInputPin.cpp
@@ -88,6 +88,7 @@ HRESULT CSubtitleInputPin::CheckMediaType(const CMediaType* pmt)
 HRESULT CSubtitleInputPin::CompleteConnect(IPin* pReceivePin)
 {
     InvalidateSamples();
+    m_lastHeader.clear();
 
     if (m_mt.majortype == MEDIATYPE_Text) {
         if (!(m_pSubStream = DEBUG_NEW CRenderedTextSubtitle(m_pSubLock))) {
@@ -154,6 +155,10 @@ HRESULT CSubtitleInputPin::CompleteConnect(IPin* pReceivePin)
             }
             pRTS->m_storageRes = pRTS->m_playRes = CSize(384, 288);
             pRTS->CreateDefaultStyle(DEFAULT_CHARSET);
+
+            if (subtype_ass && dwOffset > 0 && m_mt.cbFormat > dwOffset) {
+                m_lastHeader.assign(m_mt.pbFormat + dwOffset, m_mt.pbFormat + m_mt.cbFormat);
+            }
 
             if (dwOffset > 0 && m_mt.cbFormat - dwOffset > 0) {
                 CMediaType mt = m_mt;
@@ -268,6 +273,33 @@ STDMETHODIMP CSubtitleInputPin::Receive(IMediaSample* pSample)
     }
 
     CAutoLock cAutoLock(&m_csReceive);
+
+    if (m_mt.majortype == MEDIATYPE_Subtitle
+            && (m_mt.subtype == MEDIASUBTYPE_SSA || m_mt.subtype == MEDIASUBTYPE_ASS || m_mt.subtype == MEDIASUBTYPE_ASS2)) {
+        // The splitter can send an updated subtitle header as a dynamic media type change,
+        // e.g. when MKV ordered chapters transition into a linked segment whose track has
+        // different styles. Queue it so it is applied in decode order, ahead of the samples
+        // that reference the new styles.
+        AM_MEDIA_TYPE* pmt = nullptr;
+        if (pSample->GetMediaType(&pmt) == S_OK && pmt) {
+            if (pmt->majortype == MEDIATYPE_Subtitle && pmt->formattype == FORMAT_SubtitleInfo
+                    && pmt->cbFormat > sizeof(SUBTITLEINFO)) {
+                const SUBTITLEINFO* psi = (const SUBTITLEINFO*)pmt->pbFormat;
+                if (psi->dwOffset >= sizeof(SUBTITLEINFO) && psi->dwOffset < pmt->cbFormat) {
+                    const BYTE* pHeader = pmt->pbFormat + psi->dwOffset;
+                    size_t headerLen = pmt->cbFormat - psi->dwOffset;
+                    if (m_lastHeader.size() != headerLen || memcmp(m_lastHeader.data(), pHeader, headerLen) != 0) {
+                        m_lastHeader.assign(pHeader, pHeader + headerLen);
+                        std::unique_lock<std::mutex> lock(m_mutexQueue);
+                        m_sampleQueue.emplace_back(DEBUG_NEW SubtitleSample(pHeader, headerLen));
+                        lock.unlock();
+                        m_condQueueReady.notify_one();
+                    }
+                }
+            }
+            DeleteMediaType(pmt);
+        }
+    }
 
     REFERENCE_TIME tStart, tStop;
     hr = pSample->GetTime(&tStart, &tStop);
@@ -388,6 +420,11 @@ REFERENCE_TIME CSubtitleInputPin::DecodeSample(const std::unique_ptr<SubtitleSam
     bool bInvalidate = false;
 
     if (pSample->data.size() <= 0) {
+        return -1;
+    }
+
+    if (pSample->bHeaderChange) {
+        ApplyHeaderChange(pSample->data.data(), pSample->data.size());
         return -1;
     }
 
@@ -528,6 +565,50 @@ REFERENCE_TIME CSubtitleInputPin::DecodeSample(const std::unique_ptr<SubtitleSam
     }
 
     return bInvalidate ? pSample->rtStart : -1;
+}
+
+void CSubtitleInputPin::ApplyHeaderChange(const BYTE* pData, size_t len)
+{
+    // Runs on the decoding thread with m_pSubLock held (see DecodeSamples). The samples
+    // that follow reference the style definitions of this header by name.
+    CRenderedTextSubtitle* pRTS = (CRenderedTextSubtitle*)(ISubStream*)m_pSubStream;
+    if (!pRTS) {
+        return;
+    }
+
+#if USE_LIBASS
+    if (pRTS->m_LibassContext.IsLibassActive()) {
+        // libass resolves the style of new events against the most recently added
+        // style with a matching name, so earlier events keep their definitions
+        ass_process_codec_private(pRTS->m_LibassContext.m_track.get(), (char*)pData, (int)len);
+        return;
+    }
+#endif
+
+    std::vector<BYTE> buf;
+    buf.reserve(len + 3);
+    if (len < 3 || pData[0] != 0xef || pData[1] != 0xbb || pData[2] != 0xbf) {
+        static const BYTE bom[] = { 0xef, 0xbb, 0xbf };
+        buf.insert(buf.end(), bom, bom + 3);
+    }
+    buf.insert(buf.end(), pData, pData + len);
+
+    CSimpleTextSubtitle sts;
+    if (!sts.Open(buf.data(), (int)buf.size(), DEFAULT_CHARSET, pRTS->m_name)) {
+        return;
+    }
+
+    POSITION pos = sts.m_styles.GetStartPosition();
+    while (pos) {
+        CString name;
+        STSStyle* style = nullptr;
+        sts.m_styles.GetNextAssoc(pos, name, style);
+        if (style && !(sts.m_bUsingPlayerDefaultStyle && name == _T("Default"))) {
+            // on a name collision, AddStyle renames the existing style and remaps the
+            // events already referencing it, so they keep their original definitions
+            pRTS->AddStyle(name, DEBUG_NEW STSStyle(*style));
+        }
+    }
 }
 
 void CSubtitleInputPin::InvalidateSamples()

--- a/src/Subtitles/SubtitleInputPin.h
+++ b/src/Subtitles/SubtitleInputPin.h
@@ -45,14 +45,23 @@ class CSubtitleInputPin : public CBaseInputPin
     struct SubtitleSample {
         REFERENCE_TIME rtStart, rtStop;
         std::vector<BYTE> data;
+        bool bHeaderChange; // data holds a new subtitle header from a dynamic media type change
 
         SubtitleSample(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, BYTE* pData, size_t len)
             : rtStart(rtStart)
             , rtStop(rtStop)
-            , data(pData, pData + len) {}
+            , data(pData, pData + len)
+            , bHeaderChange(false) {}
+
+        SubtitleSample(const BYTE* pData, size_t len)
+            : rtStart(0)
+            , rtStop(0)
+            , data(pData, pData + len)
+            , bHeaderChange(true) {}
     };
 
     std::list<std::unique_ptr<SubtitleSample>> m_sampleQueue;
+    std::vector<BYTE> m_lastHeader;
 
     bool m_bExitDecodingThread, m_bStopDecoding;
     std::thread m_decodeThread;
@@ -61,6 +70,7 @@ class CSubtitleInputPin : public CBaseInputPin
 
     void DecodeSamples();
     REFERENCE_TIME DecodeSample(const std::unique_ptr<SubtitleSample>& pSample);
+    void ApplyHeaderChange(const BYTE* pData, size_t len);
     void InvalidateSamples();
 
 protected:


### PR DESCRIPTION
When playing an MKV that uses ordered chapters / segment linking, dialogue lines coming from a linked segment were rendered with the main file's ASS style definitions. If the linked segment's track defines different styles (colors, fonts), subtitles during those chapters rendered incorrectly. Sample in mpv-player/mpv#6503 (`main.mkv` + `included.mkv`): during the linked chapter, text renders red Times New Roman instead of white Indie Flower. This is the remaining unfixed part of #549.

Since LAV Filters 0.75 (Nevcairiel/LAVFilters#356), LAV Splitter forwards the linked segment's subtitle CodecPrivate as a dynamic media type change attached to the first sample after each segment boundary. MPC-HC's subtitle input pin ignored it, so the renderer only ever saw the styles from pin connection time. (Embedded fonts are unaffected: LAV already exports/installs attachments from all linked segments.)

Changes in `CSubtitleInputPin`:
- `Receive` now checks `IMediaSample::GetMediaType` on SSA/ASS/ASS2 pins. If the attached format differs from the last seen header, the new header is queued through the sample queue, so it is applied on the decoding thread in order, ahead of the samples that reference the new styles.
- The new header's styles are parsed and merged into the live `CRenderedTextSubtitle` via `AddStyle`, whose existing collision handling renames the previous same-named style and remaps the events already using it. Events from before the boundary keep their original definitions; events after it resolve to the new ones (both segments typically name their style "Default").
- When libass is active, the header is fed to the track with `ass_process_codec_private`; libass resolves new events against the most recently added style with a matching name, giving the same semantics.

Files without dynamic media type changes never enter the new code path.

Tested with the mpv #6503 sample pair (internal subtitle renderer): correct styles in all three chapters during linear playback and when seeking directly into the linked chapter.

Note: with libass enabled, events from the linked segment currently don't render at all — a pre-existing `LibassContext` ingest issue that is unchanged by this PR (verified against an unpatched build).

### Screenshots

Playback of the mpv sample (`main.mkv`) during the linked chapter, internal subtitle renderer:

![before/after](https://raw.githubusercontent.com/adipose/mpc-hc/pr4011-assets/pr4011_before_after.png)
