### PR TITLE
EVR-CP: fix first seconds of still images rendered black

### DIFF
--- a/src/filters/renderer/VideoRenderers/EVRAllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/EVRAllocatorPresenter.cpp
@@ -2444,7 +2444,11 @@ void CEVRAllocatorPresenter::RenderThread()
                                 SubPicSetTime();
                                 Paint(pMFSample);
                             }
-                            NextSleepTime = int(SampleDuration / 10000 - 2);
+                            // Sleep no longer than 10ms, so that a state change is picked up promptly.
+                            // Still image sources deliver samples with durations of several seconds;
+                            // sleeping that long here leaves the screen black after playback starts,
+                            // because nothing wakes this thread when the clock is started.
+                            NextSleepTime = (SampleDuration >= 120000) ? 10 : (SampleDuration < 40000) ? 1 : int(SampleDuration / 10000 - 2);
                         }
 
                         if (bStepForward) {


### PR DESCRIPTION
Fixes #2301

With still image sources (MPC Image Source, "Generate Still Video") under EVR-CP, the first seconds of each image are rendered black; the frame appears late, or in some cases only when an unrelated window repaint happens (e.g. pausing).

### Cause

Image sources deliver samples with very long durations (MPC Image Source: 2 seconds per frame; qedit Generate Still Video: one sample spanning the whole clip). During preroll, the render thread picks up the first sample while the presenter is still in `Paused` state, does not present it (no seek happened, so `bForcePaint` is false), requeues it, and then sleeps for the full sample duration:

```cpp
NextSleepTime = int(SampleDuration / 10000 - 2);
```

Nothing wakes the render thread when the presentation clock starts (`OnClockStart` only sets `m_nRenderState`; the thread's only wake events are quit and flush), so playback runs seconds of black until the oversleep expires. With normal video the sleep is one frame duration (20-40 ms), which is why this was never noticeable.

Timeline captured with an instrumented build (MPC Image Source + EVR-CP, timestamps in seconds):

```
457.4312  Get from Mixer: sample t=0                     <- first frame ready (preroll)
457.4324  Paused state, not presented -> sleep 1998 ms
457.4499  OnClockStart                                   <- playback starts, thread asleep
459.4312  first Paint, clock is already at 1.97s         <- black until here
```

### Fix

Clamp the sleep in the paused branch to 10 ms so state changes are picked up promptly. The `bForcePaint` gate (added in 5b803b86b) already prevents redundant repaints while paused; the long sleep only saved a few idle loop iterations, and every other state already runs the loop at ~1 ms polls.

### Screenshots

Before — playback running, screen stays black for ~2s, image appears late:

![before](https://raw.githubusercontent.com/adipose/mpc-hc/pr4023-assets/before.png)

After — image is shown as soon as playback starts:

![after](https://raw.githubusercontent.com/adipose/mpc-hc/pr4023-assets/after.png)

Note: there is a second, unrelated defect visible with single-sample sources (qedit): the source signals end-of-stream while its only frame is still inside the mixer, so `checkPendingMediaFinished()` sees an empty scheduled queue and sends `EC_COMPLETE` before anything was presented. Not addressed here.
