### PR TITLE
Add advanced option to automatically remove old entries from media history

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -71,6 +71,7 @@ CAppSettings::CAppSettings()
     , fTitleBarTextTitle(false)
     , fKeepHistory(true)
     , iRecentFilesNumber(100)
+    , iHistoryMaxAgeDays(365)
     , sHistoryExcludeFilter()
     , sHistoryExcludeFilterPrivate()
     , MRU(L"MediaHistory", iRecentFilesNumber)
@@ -1013,6 +1014,7 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_ASPECTRATIO_Y, sizeAspectRatio.cy);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_KEEPHISTORY, fKeepHistory);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_RECENT_FILES_NUMBER, iRecentFilesNumber);
+    pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_HISTORY_MAX_AGE_DAYS, iHistoryMaxAgeDays);
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER, sHistoryExcludeFilter);
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER_PRIVATE, sHistoryExcludeFilterPrivate);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_DSVIDEORENDERERTYPE, iDSVideoRendererType);
@@ -1851,6 +1853,7 @@ void CAppSettings::LoadSettings()
     fKeepHistory = !!pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_KEEPHISTORY, TRUE);
     fileAssoc.SetNoRecentDocs(!fKeepHistory);
     iRecentFilesNumber = std::max(0, (int)pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_RECENT_FILES_NUMBER, 100));
+    iHistoryMaxAgeDays = std::max(0, (int)pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_HISTORY_MAX_AGE_DAYS, 365));
     MRU.SetSize(iRecentFilesNumber);
     sHistoryExcludeFilter = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER, _T(""));
     sHistoryExcludeFilterPrivate = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_HISTORY_EXCLUDE_FILTER_PRIVATE, _T(""));
@@ -3590,12 +3593,21 @@ void CAppSettings::CRecentFileListWithMoreInfo::ReadMediaHistory() {
 
     auto timeToHash = CAppSettings::LoadHistoryHashes(m_section, L"LastOpened");
 
+    // lastOpened timestamps are ISO 8601, so they can be compared as strings
+    CStringW cutoff;
+    int maxAgeDays = AfxGetAppSettings().iHistoryMaxAgeDays;
+    if (maxsize > 0 && maxAgeDays > 0) {
+        auto cutoffTime = std::chrono::system_clock::now() - std::chrono::hours(24) * maxAgeDays;
+        auto cutoffISO = date::format<wchar_t>(L"%FT%TZ", date::floor<std::chrono::milliseconds>(cutoffTime));
+        cutoff = cutoffISO.c_str();
+    }
+
     rfe_array.RemoveAll();
     int entries = 0;
     for (auto iter = timeToHash.rbegin(); iter != timeToHash.rend(); ++iter) {
         bool purge_rfe = true;
         CStringW hash = iter->second;
-        if (entries < maxsize) {
+        if (entries < maxsize && (cutoff.IsEmpty() || iter->first >= cutoff)) {
             RecentFileEntry r;
             r.lastOpened = iter->first;
             if (LoadMediaHistoryEntry(hash, r)) {

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -1425,7 +1425,7 @@ void CAppSettings::SaveSettings(bool write_full_history /* = false */)
 
 void CAppSettings::PurgeMediaHistory(size_t maxsize) {
     CStringW section = L"MediaHistory";
-    auto timeToHash = LoadHistoryHashes(section, L"LastUpdated");
+    auto timeToHash = LoadHistoryHashes(section, L"LastOpened");
     size_t entries = timeToHash.size();
     if (entries > maxsize) {
         for (auto iter = timeToHash.rbegin(); iter != timeToHash.rend(); ++iter) {

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -605,6 +605,7 @@ public:
     bool            fTitleBarTextTitle;
     bool            fKeepHistory;
     int             iRecentFilesNumber;
+    int             iHistoryMaxAgeDays;
     // Semicolon-separated substrings: a file/URL containing any of them is kept out of the
     // history. The two lists are equivalent, but the private one is deliberately not exposed
     // in the options UI, so it can hold terms the user does not want on screen.

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -177,6 +177,7 @@ void CPPageAdvanced::InitSettings()
 
     addHeaderItem(ResStr(IDS_PPAGEADVANCED_GRP_HISTORY));
     addIntItem(RECENT_FILES_NB, IDS_RS_RECENT_FILES_NUMBER, 100, s.iRecentFilesNumber, std::make_pair(0, 1000), StrRes(IDS_PPAGEADVANCED_RECENT_FILES_NUMBER));
+    addIntItem(HISTORY_MAX_AGE_DAYS, IDS_RS_HISTORY_MAX_AGE_DAYS, 365, s.iHistoryMaxAgeDays, std::make_pair(0, 10000), L"Automatically remove entries older than this number of days from the recent files history. Set to 0 to disable age-based cleanup.");
     addIntItem(FILE_POS_LONGER, IDS_RS_FILEPOSLONGER, 5, s.iRememberPosForLongerThan, std::make_pair(0, INT_MAX), StrRes(IDS_PPAGEADVANCED_FILE_POS_LONGER));
     addBoolItem(FILE_POS_AUDIO, IDS_RS_FILEPOSAUDIO, true, s.bRememberPosForAudioFiles, StrRes(IDS_PPAGEADVANCED_FILE_POS_AUDIO));
     addBoolItem(FILE_POS_PLAYLIST, IDS_RS_FILEPOS_PLAYLIST, true, s.bRememberExternalPlaylistPos, StrRes(IDS_PPAGEADVANCED_FILEPOS_PLAYLIST));
@@ -221,6 +222,7 @@ void CPPageAdvanced::InitSettings()
 BOOL CPPageAdvanced::OnApply()
 {
     auto& s = AfxGetAppSettings();
+    int oldHistoryMaxAgeDays = s.iHistoryMaxAgeDays;
 
     for (int i = 0; i < m_list.GetItemCount(); i++) {
         if (IsHeaderRow(i)) {
@@ -231,6 +233,10 @@ BOOL CPPageAdvanced::OnApply()
     }
 
     s.MRU.SetSize(s.iRecentFilesNumber);
+    if (s.iHistoryMaxAgeDays != oldHistoryMaxAgeDays && s.iHistoryMaxAgeDays > 0) {
+        s.MRU.rfe_last_added = 0; // force reload so the new age limit is applied immediately
+        s.MRU.ReadMediaHistory();
+    }
 
 #if !defined(_DEBUG) && USE_DRDUMP_CRASH_REPORTER
     if (!s.bEnableCrashReporter && CrashReporter::IsEnabled()) {

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -244,6 +244,7 @@ private:
         TIME_ON_SEEKBAR_LEFT,
         HISTORY_IN_APPDATA,
         HISTORY_EXCLUDE_FILTER,
+        HISTORY_MAX_AGE_DAYS,
     };
 
     static constexpr DWORD_PTR HEADER_ITEM_DATA = (DWORD_PTR)-1;

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -232,6 +232,7 @@
 #define IDS_RS_SRCFILTERS                   _T("SrcFilters")
 #define IDS_RS_KEEPHISTORY                  _T("KeepHistory")
 #define IDS_RS_RECENT_FILES_NUMBER          _T("RecentFilesNumber")
+#define IDS_RS_HISTORY_MAX_AGE_DAYS         _T("HistoryMaxAgeDays")
 #define IDS_RS_LOGOID                       _T("LogoID2")
 #define IDS_RS_LOGOEXT                      _T("LogoExt")
 #define IDS_RS_LOGOCOLORPROFILE             _T("LogoColorProfile")


### PR DESCRIPTION
Implements #4026.

Adds an advanced option `HistoryMaxAgeDays` (History group). Entries older than this number of days are automatically removed from the media history when it is loaded. Default is 365 days; 0 disables age-based cleanup. The limit is also applied immediately when the value is changed in the options dialog.

Since `LastOpened` timestamps are ISO 8601 strings, the age check is a lexicographic comparison against a cutoff, same as the History dialog's manual "Remove older than" commands.

Also fixes `PurgeMediaHistory()` sorting on `LastUpdated`, a field that MediaHistory entries never write (only PlaylistHistory does), which made the count-based purge remove entries in arbitrary order instead of oldest-first. It now sorts on `LastOpened`.