### PR TITLE
Hide D3D9 render device selection when there is only one adapter

### DIFF
--- a/src/mpc-hc/CMPCThemeGroupBox.cpp
+++ b/src/mpc-hc/CMPCThemeGroupBox.cpp
@@ -75,7 +75,8 @@ void CMPCThemeGroupBox::OnPaint()
 }
 
 void CMPCThemeGroupBox::OnEnable(BOOL bEnable) {
-    if (AppNeedsThemedControls()) {
+    //SetRedraw(TRUE) sets WS_VISIBLE, so the redraw dance must be skipped for hidden controls
+    if (AppNeedsThemedControls() && (GetStyle() & WS_VISIBLE)) {
         SetRedraw(FALSE);
         __super::OnEnable(bEnable);
         SetRedraw(TRUE);

--- a/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
+++ b/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
@@ -241,7 +241,8 @@ void CMPCThemeRadioOrCheck::OnLButtonDown(UINT nFlags, CPoint point)
 
 void CMPCThemeRadioOrCheck::OnEnable(BOOL bEnable)
 {
-    if (AppNeedsThemedControls()) {
+    //SetRedraw(TRUE) sets WS_VISIBLE, so the redraw dance must be skipped for hidden controls
+    if (AppNeedsThemedControls() && (GetStyle() & WS_VISIBLE)) {
         SetRedraw(FALSE);
         __super::OnEnable(bEnable);
         SetRedraw(TRUE);

--- a/src/mpc-hc/CMPCThemeStatic.cpp
+++ b/src/mpc-hc/CMPCThemeStatic.cpp
@@ -143,7 +143,8 @@ void CMPCThemeStatic::OnNcPaint()
 
 void CMPCThemeStatic::OnEnable(BOOL bEnable)
 {
-    if (AppNeedsThemedControls() || isFileDialogChild) {
+    //SetRedraw(TRUE) sets WS_VISIBLE, so the redraw dance must be skipped for hidden controls
+    if ((AppNeedsThemedControls() || isFileDialogChild) && (GetStyle() & WS_VISIBLE)) {
         SetRedraw(FALSE);
         __super::OnEnable(bEnable);
         SetRedraw(TRUE);

--- a/src/mpc-hc/CMPCThemeStaticLink.cpp
+++ b/src/mpc-hc/CMPCThemeStaticLink.cpp
@@ -87,7 +87,8 @@ HBRUSH CMPCThemeStaticLink::CtlColor(CDC* pDC, UINT nCtlColor)   //avoid overrid
 
 void CMPCThemeStaticLink::OnEnable(BOOL bEnable)
 {
-    if (AppNeedsThemedControls()) {
+    //SetRedraw(TRUE) sets WS_VISIBLE, so the redraw dance must be skipped for hidden controls
+    if (AppNeedsThemedControls() && (GetStyle() & WS_VISIBLE)) {
         SetRedraw(FALSE);
         __super::OnEnable(bEnable);
         SetRedraw(TRUE);

--- a/src/mpc-hc/PPageVideoRenderer.cpp
+++ b/src/mpc-hc/PPageVideoRenderer.cpp
@@ -193,7 +193,10 @@ BOOL CPPageVideoRenderer::OnInitDialog()
     GetDlgItem(IDC_EVR_BUFFERS)->EnableWindow(m_iRendererType != VIDRNDT_DS_VMR9RENDERLESS);
 
     // The D3D9 render device selection is only meaningful with more than one adapter
-    bool canSelectD3D9Device = m_iD3D9RenderDeviceCtrl.GetCount() > 1 && m_iRendererType != VIDRNDT_DS_SYNC;
+    bool multipleD3D9Devices = m_iD3D9RenderDeviceCtrl.GetCount() > 1;
+    bool canSelectD3D9Device = multipleD3D9Devices && m_iRendererType != VIDRNDT_DS_SYNC;
+    GetDlgItem(IDC_D3D9DEVICE)->ShowWindow(multipleD3D9Devices ? SW_SHOW : SW_HIDE);
+    GetDlgItem(IDC_D3D9DEVICE_COMBO)->ShowWindow(multipleD3D9Devices ? SW_SHOW : SW_HIDE);
     GetDlgItem(IDC_D3D9DEVICE)->EnableWindow(canSelectD3D9Device);
     GetDlgItem(IDC_D3D9DEVICE_COMBO)->EnableWindow(canSelectD3D9Device && m_fD3D9RenderDevice);
 


### PR DESCRIPTION
Follow-up to feedback on #4027 (https://github.com/clsid2/mpc-hc/pull/4027#issuecomment-5230869785): on systems with a single graphics adapter, the "Select D3D9 Render Device" checkbox and its combobox showed as a disabled row with an empty selection, which looks broken. Since the selection can never be used on such systems (nothing in the player can make it applicable), the row is now hidden entirely. With multiple adapters it behaves as before: visible, and grayed only while the Sync renderer is selected.

Implementing this exposed a latent bug in the themed controls: `CMPCThemeRadioOrCheck`, `CMPCThemeGroupBox`, `CMPCThemeStatic`, and `CMPCThemeStaticLink` wrap `OnEnable` in a `SetRedraw(FALSE)`/`SetRedraw(TRUE)` pair, and `WM_SETREDRAW` works by toggling `WS_VISIBLE` — so enabling/disabling a hidden themed control made it visible again (dark theme only, where the owner-drawn path is active). Fixed by skipping the redraw dance when the control is hidden; a hidden control needs no repaint.

### Screenshots

Single-adapter system, all themes:

![hidden d3d9 row](https://raw.githubusercontent.com/adipose/mpc-hc/patch637-assets/vidrend-hidden-composite.png)
