### PR TITLE
Detect similar title/filename in recent files list when title has characters that are illegal in filenames

### DIFF
--- a/src/DSUtil/text.cpp
+++ b/src/DSUtil/text.cpp
@@ -352,8 +352,32 @@ int LastIndexOfCString(const CString& text, const CString& pattern) {
     }
 }
 
+// Remove characters that are illegal in file names, together with the
+// substitutes download tools commonly use when sanitizing them (youtube-dl
+// replaces '/' with '_', deletes '?', expands ':' to " -", turns '"' into
+// '\''). Removing both the originals and the substitutes from both strings
+// lets a title still match its sanitized file name.
+static CString StripIgnoredForNameSimilarity(const CString& str) {
+    CString ret;
+    LPTSTR buf = ret.GetBuffer(str.GetLength());
+    int len = 0;
+    for (int i = 0; i < str.GetLength(); i++) {
+        TCHAR c = str[i];
+        if (c > _T(' ') && !_tcschr(_T("/\\:*?\"<>|_-.'"), c)) {
+            buf[len++] = c;
+        }
+    }
+    ret.ReleaseBufferSetLength(len);
+    return ret;
+}
+
 bool IsNameSimilar(const CString& title, const CString& fileName) {
     if (fileName.Find(title.Left(25)) > -1) return true;
+
+    CString strippedTitle = StripIgnoredForNameSimilarity(title);
+    if (strippedTitle.GetLength() >= 10) {
+        return StripIgnoredForNameSimilarity(fileName).Find(strippedTitle.Left(25)) > -1;
+    }
     return false;
 }
 

--- a/src/DSUtil/text.cpp
+++ b/src/DSUtil/text.cpp
@@ -374,6 +374,16 @@ static CString StripIgnoredForNameSimilarity(const CString& str) {
 bool IsNameSimilar(const CString& title, const CString& fileName) {
     if (fileName.Find(title.Left(25)) > -1) return true;
 
+    // Titles of the form "ReleaseGroup | FileNameWithoutExt" contain the file
+    // name instead of the other way around. Treat those as similar when the
+    // title is not much longer than the file name itself.
+    int dot = fileName.ReverseFind(_T('.'));
+    CString baseName = dot > 0 ? fileName.Left(dot) : fileName;
+    if (baseName.GetLength() >= 10 && title.Find(baseName) > -1
+            && title.GetLength() <= baseName.GetLength() + 25) {
+        return true;
+    }
+
     CString strippedTitle = StripIgnoredForNameSimilarity(title);
     if (strippedTitle.GetLength() >= 10) {
         return StripIgnoredForNameSimilarity(fileName).Find(strippedTitle.Left(25)) > -1;


### PR DESCRIPTION
Embedded titles containing characters that are illegal in filenames (e.g. `/` or `:`) never match the sanitized filename produced by download tools like youtube-dl, so a near-duplicate title is shown in the recent files list instead of being suppressed.

This strips the illegal characters and their common sanitizer substitutes (`_` `-` `.` `'` and spaces) from both the title and the filename and compares again, covering all of youtube-dl's substitutions (replace, delete, and expand, e.g. `:` → ` -`). A minimum length guard on the stripped title avoids degenerate matches for punctuation-only titles.

Supersedes #1035, which relied on `[^[:print:]]` under the default C locale — that misclassifies all non-ASCII text, so it broke for the CJK/Cyrillic titles it was written for, and its three uniform substitution guesses did not match real sanitizer behavior. That PR can be closed.