### PR TITLE
Auto-load external subtitles/audio for multi-volume rar files

### DIFF
--- a/src/DSUtil/PathUtils.cpp
+++ b/src/DSUtil/PathUtils.cpp
@@ -21,6 +21,7 @@
 #include "stdafx.h"
 #include "PathUtils.h"
 #include <memory>
+#include <regex>
 #include "text.h"
 #include "DSUtil.h"
 
@@ -54,6 +55,19 @@ namespace PathUtils
     CString FileExt(LPCTSTR path)
     {
         return CPath(path).GetExtension();
+    }
+
+    CString StripExtensionAndRarVolumeSuffix(LPCTSTR path)
+    {
+        // base.mkv        -> base
+        // base.part01.rar -> base (multi-volume rar)
+        static const std::wregex re(_T("(\\.part\\d+\\.rar|\\.[^.\\\\/]+)$"),
+                                    std::wregex::icase | std::wregex::optimize);
+        std::wcmatch mc;
+        if (std::regex_search(path, mc, re)) {
+            return CString(path, (int)mc.position());
+        }
+        return path;
     }
 
     CString GetModulePath(HMODULE hModule)

--- a/src/DSUtil/PathUtils.h
+++ b/src/DSUtil/PathUtils.h
@@ -26,6 +26,7 @@ namespace PathUtils
     CString DirName(LPCTSTR path);
     CString FileName(LPCTSTR path);
     CString FileExt(LPCTSTR path);
+    CString StripExtensionAndRarVolumeSuffix(LPCTSTR path);
     CString GetModulePath(HMODULE hModule);
     CString GetAfxModulePath(bool bWithModuleName = false);
     CString GetProgramPath(bool bWithExeName = false);

--- a/src/Subtitles/SubtitleHelpers.cpp
+++ b/src/Subtitles/SubtitleHelpers.cpp
@@ -63,14 +63,10 @@ void Subtitle::GetSubFileNames(CString fn, const CAtlArray<CString>& paths, CAtl
 
     ExtendMaxPathLengthIfNeeded(fn, MAX_PATH);
 
-    int l  = fn.ReverseFind('\\') + 1;
-    int l2 = fn.ReverseFind('.');
-    if (l2 < l) { // no extension, read to the end
-        l2 = fn.GetLength();
-    }
+    int l = fn.ReverseFind('\\') + 1;
 
     CString orgpath = fn.Left(l);
-    CString title = fn.Mid(l, l2 - l);
+    CString title = PathUtils::StripExtensionAndRarVolumeSuffix(fn.Mid(l));
     int titleLength = title.GetLength();
 
     WIN32_FIND_DATA wfd;

--- a/src/mpc-hc/Playlist.cpp
+++ b/src/mpc-hc/Playlist.cpp
@@ -173,7 +173,7 @@ void CPlaylistItem::AutoLoadFiles()
 
                 WIN32_FIND_DATA fd;
                 ZeroMemory(&fd, sizeof(WIN32_FIND_DATA));
-                HANDLE hFind = FindFirstFile(fn.Left(i) + _T("*.*"), &fd);
+                HANDLE hFind = FindFirstFile(PathUtils::StripExtensionAndRarVolumeSuffix(fn) + _T("*.*"), &fd);
                 if (hFind != INVALID_HANDLE_VALUE) {
                     do {
                         if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
@@ -209,12 +209,8 @@ void CPlaylistItem::AutoLoadFiles()
 
         CString dir = fn;
         dir.Replace('\\', '/');
-        int l  = dir.ReverseFind('/') + 1;
-        int l2 = dir.ReverseFind('.');
-        if (l2 < l) { // no extension, read to the end
-            l2 = fn.GetLength();
-        }
-        CString title = dir.Mid(l, l2 - l);
+        int l = dir.ReverseFind('/') + 1;
+        CString title = PathUtils::StripExtensionAndRarVolumeSuffix(dir.Mid(l));
         paths.Add(title);
 
         CAtlArray<Subtitle::SubFile> ret;


### PR DESCRIPTION
When playing `base.partNN.rar`, the external subtitle/audio search derived its title from the full volume name and looked for `base.partNN.*`, so `base.srt` / `base.ac3` next to the archive were never found. This strips the whole `.partNN.rar` suffix (case-insensitively) when deriving the search title, in `Subtitle::GetSubFileNames` and both `CPlaylistItem::AutoLoadFiles` paths.

Tested against a real 46-volume set: `Mkv Sample.srt` beside `Mkv Sample.part01.rar` now auto-loads and renders.

Supersedes #1918, which had the same goal but can be closed: it added `BaseName`/`Path` overloads that silently captured existing `CString` call sites with different trailing-backslash semantics, its regex was case-sensitive (`.PART01.RAR` fell through), and it dropped the `/`-to-`\` path normalization in `AutoLoadFiles` (risking duplicate playlist entries via the string-compare dedupe). This version reuses a single new `PathUtils::StripExtensionAndRarVolumeSuffix` helper instead.
