### PR TITLE
Fix crash in unrar when reading archive headers into uninitialized RARHeaderDataEx

### DIFF
--- a/src/Subtitles/VobSubFile.cpp
+++ b/src/Subtitles/VobSubFile.cpp
@@ -850,7 +850,7 @@ bool CVobSubFile::ReadRar(CString fn)
     }
 
     RARHeaderDataEx HeaderDataEx;
-    HeaderDataEx.CmtBuf = nullptr;
+    ZeroMemory(&HeaderDataEx, sizeof(HeaderDataEx));
 
     while (ReadHeaderEx(hArcData, &HeaderDataEx) == 0) {
         CString subfn(HeaderDataEx.FileNameW);

--- a/src/mpc-hc/SubtitlesProvidersUtils.cpp
+++ b/src/mpc-hc/SubtitlesProvidersUtils.cpp
@@ -528,7 +528,7 @@ bool SubtitlesProvidersUtils::FileUnRar(CString fn, stringMap& dataOut)
     }
 
     RARHeaderDataEx HeaderDataEx;
-    HeaderDataEx.CmtBuf = nullptr;
+    ZeroMemory(&HeaderDataEx, sizeof(HeaderDataEx));
 
     while (ReadHeaderEx(hArcData, &HeaderDataEx) == 0) {
         if (wcslen(HeaderDataEx.FileNameW) >= 4 && Subtitle::IsTextSubtitleFileName(HeaderDataEx.FileNameW)) {


### PR DESCRIPTION
Fixes a crash reported via crashrpt (2.8.0.0, access violation in `RARReadHeaderEx`).

Both callers of the unrar API declare `RARHeaderDataEx` on the stack and initialize only `CmtBuf`, leaving all other fields as stack garbage. The UnRAR 7.2.7 update (8bf68d4577) added `ArcNameEx`/`FileNameEx` output-pointer fields to the struct, which unrar now writes through on every archive entry whenever they are non-null. With uninitialized garbage in those pointers, reading any rar header can write through a wild pointer and crash. Under UnRAR 6.24 the only conditional output pointer was `RedirName` (symlink entries only), so the uninitialized struct was latent until the 7.2.7 update.

Crash dump analysis: fault at dll.cpp:263, `wcsncpyz(D->ArcNameEx, ...)` with `D->ArcNameEx` containing non-canonical stack garbage; struct offsets +0x1894/+0x189c match `ArcNameEx`/`ArcNameExSize`.

Fix: zero the entire struct with `ZeroMemory`, matching the existing pattern used for `RAROpenArchiveDataEx` in the same functions. Applies to both call sites (`CVobSubFile::ReadRar` and `SubtitlesProvidersUtils::FileUnRar`).