### PR TITLE
Fix ASS subtitle anamorphic stretch with recent MPC Video Renderer builds

### DIFF
--- a/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/MPCVRAllocatorPresenter.cpp
@@ -390,7 +390,41 @@ STDMETHODIMP_(SIZE) CMPCVRAllocatorPresenter::GetVideoSize(bool bCorrectAR) cons
     SIZE size = {0, 0};
 
     if (!bCorrectAR) {
-        if (CComQIPtr<IBasicVideo> pBV = m_pMPCVR) {
+        // MPCVR 0.10.2.2540 and newer return an aspect ratio corrected size through
+        // IBasicVideo::GetVideoSize (matching VMR-9/madVR behavior, needed by the
+        // DVD Navigator), so read the coded frame size from the input connection.
+        if (CComQIPtr<IBaseFilter> pBF = m_pMPCVR) {
+            if (CComPtr<IPin> pPin = GetFirstPin(pBF, PINDIR_INPUT)) {
+                CMediaType mt;
+                if (SUCCEEDED(pPin->ConnectionMediaType(&mt)) && mt.pbFormat) {
+                    RECT rcSource = {};
+                    if (mt.formattype == FORMAT_VideoInfo2) {
+                        const VIDEOINFOHEADER2* vih2 = (VIDEOINFOHEADER2*)mt.pbFormat;
+                        rcSource = vih2->rcSource;
+                        size.cx = vih2->bmiHeader.biWidth;
+                        size.cy = abs(vih2->bmiHeader.biHeight);
+                    } else if (mt.formattype == FORMAT_VideoInfo) {
+                        const VIDEOINFOHEADER* vih = (VIDEOINFOHEADER*)mt.pbFormat;
+                        rcSource = vih->rcSource;
+                        size.cx = vih->bmiHeader.biWidth;
+                        size.cy = abs(vih->bmiHeader.biHeight);
+                    }
+                    // biWidth can include stride padding, so prefer rcSource
+                    if (rcSource.right > rcSource.left && rcSource.bottom > rcSource.top) {
+                        size.cx = rcSource.right - rcSource.left;
+                        size.cy = rcSource.bottom - rcSource.top;
+                    }
+                }
+            }
+        }
+        if (size.cx > 0 && size.cy > 0) {
+            if (CComQIPtr<IExFilterConfig> pIExFilterConfig = m_pMPCVR) {
+                int rotation = 0;
+                if (SUCCEEDED(pIExFilterConfig->Flt_GetInt("rotation", &rotation)) && (rotation == 90 || rotation == 270)) {
+                    std::swap(size.cx, size.cy);
+                }
+            }
+        } else if (CComQIPtr<IBasicVideo> pBV = m_pMPCVR) {
             pBV->GetVideoSize(&size.cx, &size.cy);
         }
     } else {


### PR DESCRIPTION
Fixes #4040

Since MPCVR 0.10.2.2540 (bundled with 2.7.2), `IBasicVideo::GetVideoSize` returns the aspect-corrected size instead of the coded frame size (Aleksoid1978/VideoRenderer@08d57f19, needed by DVD Navigator for PAL 16:9 menus; VMR-9 and madVR behave the same way).

`CMPCVRAllocatorPresenter::GetVideoSize(false)` forwarded to it, so in `ApplySubtitleRenderingParameters()` szVideoFrame became equal to szAspectRatio, dPARCompensation always came out as 1.0, and the internal renderer stopped stretching ASS subtitles on anamorphic video (720x480 16:9 renders subs at 3:2 glyph proportions). It also set `m_storageRes` to the display size instead of the coded size. EVR-CP was unaffected, but since 2.7.4 defaults to MPCVR this now hits default installs.

Instead of relying on IBasicVideo, take the coded frame size from the renderer's input pin connection (rcSource, falling back to the bitmap header, with the same 90/270 rotation swap the filter used to do). IBasicVideo remains as fallback if there is no connection yet.

Verified against the repro from the issue (720x480 SAR 32:27 + ASS with ScaleX 84/100): with this change the 2.7.2+ MPCVR builds render identical to 2.7.1 / EVR-CP again. Also restores correct window sizing at "keep aspect ratio off" with MPCVR.
