### PR TITLE
Ensure seekbar preview is in the topmost band when main window is always on top (#3849)

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -14177,6 +14177,13 @@ HRESULT CMainFrame::PreviewWindowShow(REFERENCE_TIME rtCur2) {
     if (!m_wndPreView.IsWindowVisible()) {
         m_wndPreView.SetRelativeSize(AfxGetAppSettings().iSeekPreviewSize);
         m_wndPreView.ShowWindow(SW_SHOWNOACTIVATE);
+        if (GetExStyle() & WS_EX_TOPMOST) {
+            // The preview is an owned popup, so it should already follow the main window into the
+            // topmost band. It has been reported behind an always-on-top main window (#3849), so
+            // put it in that band explicitly as a safeguard. Nothing to do when not topmost:
+            // Windows moves owned windows out of the topmost band along with their owner.
+            m_wndPreView.SetWindowPos(&wndTopMost, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
         m_wndPreView.SetWindowSize();
     }
 


### PR DESCRIPTION
Protective safeguard for #3849, per discussion in that issue.

The seek preview is an owned popup, so it should already follow the main window into the topmost band. It was reported showing up behind an always-on-top main window shortly after startup, which suggests it can occasionally end up in a different band than its owner. This puts it in the topmost band explicitly when it is first made visible.

Per review comment, the call is only made when the main window actually has `WS_EX_TOPMOST`. The non-topmost case needs nothing: Windows moves owned windows out of the topmost band along with their owner.

Note this is unverified against the original report - neither I nor @clsid2 could reproduce it, and the reporter never confirmed whether the test build helped. It runs only on the transition to visible.
