### PR TITLE
Harden MPCTestAPI launcher and command handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ _*.bat
 /src/mpc-hc/res/mpc-hc.exe.manifest
 /src/MPCTestAPI/bin
 /src/MPCTestAPI/bin17
+/src/MPCTestAPI/.vs
 /src/thirdparty/DoctorDump/obj
 /src/thirdparty/LAVFilters/obj
 /src/thirdparty/libxml2/generated/libxml/xmlversion.h

--- a/src/MPCTestAPI/MPCTestAPI.rc
+++ b/src/MPCTestAPI/MPCTestAPI.rc
@@ -71,8 +71,8 @@ CAPTION "About MPC-HC Test API"
 FONT 8, "MS Shell Dlg", 0, 0, 0x0
 BEGIN
     ICON            IDR_MAINFRAME,IDC_STATIC,11,17,20,20
-    LTEXT           "MPC-HC Test API Version 1.0.1.0",IDC_STATIC,40,10,120,10,SS_NOPREFIX
-    LTEXT           "Copyright © 2005-2013 all contributors, see Authors.txt",IDC_STATIC,40,27,197,10
+    LTEXT           "MPC-HC Test API Version 1.0.2.0",IDC_STATIC,40,10,120,10,SS_NOPREFIX
+    LTEXT           "Copyright © 2005-2026 all contributors, see Authors.txt",IDC_STATIC,40,27,197,10
     DEFPUSHBUTTON   "OK",IDOK,187,7,50,14,WS_GROUP
 END
 
@@ -98,8 +98,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,0,1,0
- PRODUCTVERSION 1,0,1,0
+ FILEVERSION    1,0,2,0
+ PRODUCTVERSION 1,0,2,0
  FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
  FILEFLAGS      VS_FF_DEBUG
@@ -116,12 +116,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "MPC-HC Team"
             VALUE "FileDescription",  "MPC-HC Test API"
-            VALUE "FileVersion",      "1.0.1.0"
+            VALUE "FileVersion",      "1.0.2.0"
             VALUE "InternalName",     "MPC-HC Test API"
-            VALUE "LegalCopyright",   "Copyright © 2005-2013 all contributors, see Authors.txt"
+            VALUE "LegalCopyright",   "Copyright © 2005-2026 all contributors, see Authors.txt"
             VALUE "OriginalFilename", "MPCTestAPI.exe"
             VALUE "ProductName",      "MPC-HC Test API"
-            VALUE "ProductVersion",   "1.0.1.0"
+            VALUE "ProductVersion",   "1.0.2.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -163,67 +163,6 @@ END
 //
 // Dialog Info
 //
-
-IDD_REGISTERCOPYDATA_DIALOG DLGINIT
-BEGIN
-    IDC_COMBO1, 0x403, 10, 0
-0x704f, 0x6e65, 0x6620, 0x6c69, 0x0065, 
-    IDC_COMBO1, 0x403, 5, 0
-0x7453, 0x706f, "\000" 
-    IDC_COMBO1, 0x403, 6, 0
-0x6c43, 0x736f, 0x0065, 
-    IDC_COMBO1, 0x403, 11, 0
-0x6c50, 0x7961, 0x502d, 0x7561, 0x6573, "\000" 
-    IDC_COMBO1, 0x403, 16, 0
-0x6441, 0x2064, 0x6f74, 0x7020, 0x616c, 0x6c79, 0x7369, 0x0074, 
-    IDC_COMBO1, 0x403, 15, 0
-0x7453, 0x7261, 0x2074, 0x6c70, 0x7961, 0x696c, 0x7473, "\000" 
-    IDC_COMBO1, 0x403, 15, 0
-0x6c43, 0x6165, 0x2072, 0x6c70, 0x7961, 0x696c, 0x7473, "\000" 
-    IDC_COMBO1, 0x403, 13, 0
-0x6553, 0x2074, 0x6f70, 0x6973, 0x6974, 0x6e6f, "\000" 
-    IDC_COMBO1, 0x403, 16, 0
-0x6553, 0x2074, 0x7561, 0x6964, 0x206f, 0x6564, 0x616c, 0x0079, 
-    IDC_COMBO1, 0x403, 19, 0
-0x6553, 0x2074, 0x7573, 0x7462, 0x7469, 0x656c, 0x6420, 0x6c65, 0x7961, 
-"\000" 
-    IDC_COMBO1, 0x403, 17, 0
-0x6547, 0x2074, 0x7561, 0x6964, 0x206f, 0x7274, 0x6361, 0x736b, "\000" 
-    IDC_COMBO1, 0x403, 20, 0
-0x6547, 0x2074, 0x7573, 0x7462, 0x7469, 0x656c, 0x7420, 0x6172, 0x6b63, 
-0x0073, 
-    IDC_COMBO1, 0x403, 13, 0
-0x6547, 0x2074, 0x6c70, 0x7961, 0x696c, 0x7473, "\000" 
-    IDC_COMBO1, 0x403, 25, 0
-0x6553, 0x2074, 0x6f70, 0x6973, 0x6974, 0x6e6f, 0x6920, 0x206e, 0x6c70, 
-0x7961, 0x696c, 0x7473, "\000" 
-    IDC_COMBO1, 0x403, 16, 0
-0x6553, 0x2074, 0x7561, 0x6964, 0x206f, 0x7274, 0x6361, 0x006b, 
-    IDC_COMBO1, 0x403, 19, 0
-0x6553, 0x2074, 0x7573, 0x7462, 0x7469, 0x656c, 0x7420, 0x6172, 0x6b63, 
-"\000" 
-    IDC_COMBO1, 0x403, 11, 0
-0x7546, 0x6c6c, 0x6353, 0x6572, 0x6e65, "\000" 
-    IDC_COMBO1, 0x403, 19, 0
-0x4d43, 0x5f44, 0x554a, 0x504d, 0x4f46, 0x5752, 0x5241, 0x4d44, 0x4445, 
-"\000" 
-    IDC_COMBO1, 0x403, 20, 0
-0x4d43, 0x5f44, 0x554a, 0x504d, 0x4142, 0x4b43, 0x4157, 0x4452, 0x454d, 
-0x0044, 
-    IDC_COMBO1, 0x403, 19, 0
-0x4d43, 0x5f44, 0x4e49, 0x5243, 0x4145, 0x4553, 0x4f56, 0x554c, 0x454d, 
-"\000" 
-    IDC_COMBO1, 0x403, 19, 0
-0x4d43, 0x5f44, 0x4544, 0x5243, 0x4145, 0x4553, 0x4f56, 0x554c, 0x454d, 
-"\000" 
-    IDC_COMBO1, 0x403, 18, 0
-0x4d43, 0x5f44, 0x4853, 0x4441, 0x5245, 0x545f, 0x474f, 0x4c47, 0x0045, 
-
-    IDC_COMBO1, 0x403, 13, 0
-0x4d43, 0x5f44, 0x4c43, 0x534f, 0x4145, 0x5050, "\000" 
-    0
-END
-
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/src/MPCTestAPI/MPCTestAPIDlg.cpp
+++ b/src/MPCTestAPI/MPCTestAPIDlg.cpp
@@ -27,11 +27,55 @@
 #include <psapi.h>
 
 
+struct APICommandEntry {
+    LPCTSTR label;
+    MPCAPI_COMMAND command;
+    bool usesParameter;
+};
+
+static const APICommandEntry apiCommands[] = {
+    { _T("CMD_OPENFILE"), CMD_OPENFILE, true },
+    { _T("CMD_STOP"), CMD_STOP, false },
+    { _T("CMD_CLOSEFILE"), CMD_CLOSEFILE, false },
+    { _T("CMD_PLAYPAUSE"), CMD_PLAYPAUSE, false },
+    { _T("CMD_PLAY"), CMD_PLAY, false },
+    { _T("CMD_PAUSE"), CMD_PAUSE, false },
+    { _T("CMD_ADDTOPLAYLIST"), CMD_ADDTOPLAYLIST, true },
+    { _T("CMD_STARTPLAYLIST"), CMD_STARTPLAYLIST, false },
+    { _T("CMD_CLEARPLAYLIST"), CMD_CLEARPLAYLIST, false },
+    { _T("CMD_SETPOSITION"), CMD_SETPOSITION, true },
+    { _T("CMD_SETAUDIODELAY"), CMD_SETAUDIODELAY, true },
+    { _T("CMD_SETSUBTITLEDELAY"), CMD_SETSUBTITLEDELAY, true },
+    { _T("CMD_GETAUDIOTRACKS"), CMD_GETAUDIOTRACKS, false },
+    { _T("CMD_GETSUBTITLETRACKS"), CMD_GETSUBTITLETRACKS, false },
+    { _T("CMD_GETPLAYLIST"), CMD_GETPLAYLIST, false },
+    { _T("CMD_SETINDEXPLAYLIST"), CMD_SETINDEXPLAYLIST, true },
+    { _T("CMD_SETAUDIOTRACK"), CMD_SETAUDIOTRACK, true },
+    { _T("CMD_SETSUBTITLETRACK"), CMD_SETSUBTITLETRACK, true },
+    { _T("CMD_GETCURRENTAUDIOTRACK"), CMD_GETCURRENTAUDIOTRACK, false },
+    { _T("CMD_GETCURRENTSUBTITLETRACK"), CMD_GETCURRENTSUBTITLETRACK, false },
+    { _T("CMD_GETCURRENTPOSITION"), CMD_GETCURRENTPOSITION, false },
+    { _T("CMD_GETNOWPLAYING"), CMD_GETNOWPLAYING, false },
+    { _T("CMD_JUMPOFNSECONDS"), CMD_JUMPOFNSECONDS, true },
+    { _T("CMD_TOGGLEFULLSCREEN"), CMD_TOGGLEFULLSCREEN, false },
+    { _T("CMD_JUMPFORWARDMED"), CMD_JUMPFORWARDMED, false },
+    { _T("CMD_JUMPBACKWARDMED"), CMD_JUMPBACKWARDMED, false },
+    { _T("CMD_INCREASEVOLUME"), CMD_INCREASEVOLUME, false },
+    { _T("CMD_DECREASEVOLUME"), CMD_DECREASEVOLUME, false },
+    { _T("CMD_GETVERSION"), CMD_GETVERSION, false },
+    { _T("CMD_SHADER_TOGGLE"), CMD_SHADER_TOGGLE, false },
+    { _T("CMD_CLOSEAPP"), CMD_CLOSEAPP, false },
+    { _T("CMD_SETSPEED"), CMD_SETSPEED, true },
+    { _T("CMD_SETPANSCAN"), CMD_SETPANSCAN, true },
+};
+
 LPCTSTR GetMPCCommandName(MPCAPI_COMMAND nCmd)
 {
     switch (nCmd) {
         case CMD_CONNECT:
             return _T("CMD_CONNECT");
+        case CMD_DISCONNECT:
+            return _T("CMD_DISCONNECT");
         case CMD_STATE:
             return _T("CMD_STATE");
         case CMD_PLAYMODE:
@@ -44,8 +88,22 @@ LPCTSTR GetMPCCommandName(MPCAPI_COMMAND nCmd)
             return _T("CMD_LISTAUDIOTRACKS");
         case CMD_PLAYLIST:
             return _T("CMD_PLAYLIST");
+        case CMD_CURRENTPOSITION:
+            return _T("CMD_CURRENTPOSITION");
+        case CMD_NOTIFYSEEK:
+            return _T("CMD_NOTIFYSEEK");
+        case CMD_NOTIFYENDOFSTREAM:
+            return _T("CMD_NOTIFYENDOFSTREAM");
+        case CMD_VERSION:
+            return _T("CMD_VERSION");
+        case CMD_CURRENTAUDIOTRACK:
+            return _T("CMD_CURRENTAUDIOTRACK");
+        case CMD_CURRENTSUBTITLETRACK:
+            return _T("CMD_CURRENTSUBTITLETRACK");
         default:
-            return _T("CMD_UNK");
+            static CString strResult;
+            strResult.Format(_T("UNKNOWN (0x%08X)"), (unsigned int)nCmd);
+            return strResult;
     }
 }
 
@@ -162,8 +220,6 @@ BOOL CRegisterCopyDataDlg::OnInitDialog()
     SetIcon(m_hIcon, TRUE);         // Set big icon
     SetIcon(m_hIcon, FALSE);        // Set small icon
 
-    // TODO: Add extra initialization here
-
 #if (_MSC_VER < 1910)
     m_strMPCPath = _T("..\\..\\..\\..\\bin15\\");
 #else
@@ -187,6 +243,14 @@ BOOL CRegisterCopyDataDlg::OnInitDialog()
 #else
     m_strMPCPath += _T("mpc-hc.exe");
 #endif // _WIN64
+
+    CComboBox* pCombo = static_cast<CComboBox*>(GetDlgItem(IDC_COMBO1));
+    if (pCombo) {
+        pCombo->ResetContent();
+        for (const auto& entry : apiCommands) {
+            pCombo->AddString(entry.label);
+        }
+    }
 
     UpdateData(FALSE);
 
@@ -238,122 +302,105 @@ HCURSOR CRegisterCopyDataDlg::OnQueryDragIcon()
 
 void CRegisterCopyDataDlg::OnButtonFindwindow()
 {
-    CString             strExec;
-    STARTUPINFO         StartupInfo;
-    PROCESS_INFORMATION ProcessInfo;
-
-    strExec.Format(_T("%s /slave %d"), (LPCTSTR)m_strMPCPath, PtrToInt(GetSafeHwnd()));
     UpdateData(TRUE);
 
-    ZeroMemory(&StartupInfo, sizeof(StartupInfo));
-    StartupInfo.cb = sizeof(StartupInfo);
-    GetStartupInfo(&StartupInfo);
-    if (CreateProcess(nullptr, (LPTSTR)(LPCTSTR)strExec, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &StartupInfo, &ProcessInfo)) {
-        CloseHandle(ProcessInfo.hProcess);
-        CloseHandle(ProcessInfo.hThread);
+    CString commandLine;
+    commandLine.Format(_T("\"%s\" /slave %d"), m_strMPCPath.GetString(), PtrToInt(GetSafeHwnd()));
+
+    STARTUPINFO startupInfo = { sizeof(startupInfo) };
+    PROCESS_INFORMATION processInfo = {};
+    const BOOL created = CreateProcess(m_strMPCPath.GetString(), commandLine.GetBuffer(), nullptr, nullptr,
+                                       FALSE, 0, nullptr, nullptr, &startupInfo, &processInfo);
+    const DWORD error = created ? ERROR_SUCCESS : GetLastError();
+    commandLine.ReleaseBuffer();
+
+    if (!created) {
+        LPTSTR systemMessage = nullptr;
+        CString detail;
+        if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                          nullptr, error, 0, reinterpret_cast<LPTSTR>(&systemMessage), 0, nullptr) && systemMessage) {
+            detail = systemMessage;
+            detail.Trim();
+            LocalFree(systemMessage);
+        }
+        if (detail.IsEmpty()) {
+            detail = _T("No system error message is available.");
+        }
+
+        CString message;
+        message.Format(_T("Failed to start MPC-HC.\nError %lu: %s"), error, detail.GetString());
+        AfxMessageBox(message, MB_ICONERROR | MB_OK);
+        return;
     }
+
+    CloseHandle(processInfo.hProcess);
+    CloseHandle(processInfo.hThread);
 }
 
 void CRegisterCopyDataDlg::Senddata(MPCAPI_COMMAND nCmd, LPCTSTR strCommand)
 {
-    if (m_hWndMPC) {
+    if (m_hWndMPC && IsWindow(m_hWndMPC)) {
         COPYDATASTRUCT MyCDS;
 
         MyCDS.dwData = nCmd;
         MyCDS.cbData = (DWORD)(_tcslen(strCommand) + 1) * sizeof(TCHAR);
         MyCDS.lpData = (LPVOID) strCommand;
 
-        ::SendMessage(m_hWndMPC, WM_COPYDATA, (WPARAM)GetSafeHwnd(), (LPARAM)&MyCDS);
+        DWORD_PTR result = 0;
+        SendMessageTimeout(m_hWndMPC, WM_COPYDATA, (WPARAM)GetSafeHwnd(), (LPARAM)&MyCDS,
+                           SMTO_ABORTIFHUNG | SMTO_ERRORONEXIT, 1000, &result);
     }
 }
 
 BOOL CRegisterCopyDataDlg::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCopyDataStruct)
 {
-    CString strMsg;
-
-    if (pCopyDataStruct->dwData == CMD_CONNECT) {
-        m_hWndMPC = (HWND)IntToPtr(_ttoi((LPCTSTR)pCopyDataStruct->lpData));
+    if (!pCopyDataStruct || !pCopyDataStruct->lpData
+            || pCopyDataStruct->cbData < sizeof(TCHAR)
+            || pCopyDataStruct->cbData % sizeof(TCHAR) != 0) {
+        return FALSE;
     }
 
-    strMsg.Format(_T("%s : %s"), GetMPCCommandName((MPCAPI_COMMAND)pCopyDataStruct->dwData), (LPCTSTR)pCopyDataStruct->lpData);
+    const LPCTSTR value = static_cast<LPCTSTR>(pCopyDataStruct->lpData);
+    const size_t length = pCopyDataStruct->cbData / sizeof(TCHAR);
+    if (value[length - 1] != _T('\0') || wmemchr(value, L'\0', length - 1)) {
+        return FALSE;
+    }
+
+    const HWND hSender = pWnd ? pWnd->GetSafeHwnd() : nullptr;
+    if (pCopyDataStruct->dwData == CMD_CONNECT && hSender && IsWindow(hSender)) {
+        m_hWndMPC = hSender;
+        Senddata(CMD_GETVERSION, _T(""));
+    } else if (pCopyDataStruct->dwData == CMD_DISCONNECT && hSender == m_hWndMPC) {
+        m_hWndMPC = nullptr;
+    }
+
+    CString strMsg;
+    strMsg.Format(_T("%s : %s"), GetMPCCommandName((MPCAPI_COMMAND)pCopyDataStruct->dwData), value);
     m_listBox.InsertString(0, strMsg);
-    return CDialog::OnCopyData(pWnd, pCopyDataStruct);
+    return TRUE;
 }
 
 void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
 {
-    CString strEmpty(_T(""));
     UpdateData(TRUE);
 
-    switch (m_nCommandType) {
-        case 0:
-            Senddata(CMD_OPENFILE, m_txtCommand);
-            break;
-        case 1:
-            Senddata(CMD_STOP, strEmpty);
-            break;
-        case 2:
-            Senddata(CMD_CLOSEFILE, strEmpty);
-            break;
-        case 3:
-            Senddata(CMD_PLAYPAUSE, strEmpty);
-            break;
-        case 4:
-            Senddata(CMD_ADDTOPLAYLIST, m_txtCommand);
-            break;
-        case 5:
-            Senddata(CMD_STARTPLAYLIST, strEmpty);
-            break;
-        case 6:
-            Senddata(CMD_CLEARPLAYLIST, strEmpty);
-            break;
-        case 7:
-            Senddata(CMD_SETPOSITION, m_txtCommand);
-            break;
-        case 8:
-            Senddata(CMD_SETAUDIODELAY, m_txtCommand);
-            break;
-        case 9:
-            Senddata(CMD_SETSUBTITLEDELAY, m_txtCommand);
-            break;
-        case 10:
-            Senddata(CMD_GETAUDIOTRACKS, strEmpty);
-            break;
-        case 11:
-            Senddata(CMD_GETSUBTITLETRACKS, strEmpty);
-            break;
-        case 12:
-            Senddata(CMD_GETPLAYLIST, strEmpty);
-            break;
-        case 13:
-            Senddata(CMD_SETINDEXPLAYLIST, m_txtCommand);
-            break;
-        case 14:
-            Senddata(CMD_SETAUDIOTRACK, m_txtCommand);
-            break;
-        case 15:
-            Senddata(CMD_SETSUBTITLETRACK, m_txtCommand);
-            break;
-        case 16:
-            Senddata(CMD_TOGGLEFULLSCREEN, m_txtCommand);
-            break;
-        case 17:
-            Senddata(CMD_JUMPFORWARDMED, m_txtCommand);
-            break;
-        case 18:
-            Senddata(CMD_JUMPBACKWARDMED, m_txtCommand);
-            break;
-        case 19:
-            Senddata(CMD_INCREASEVOLUME, m_txtCommand);
-            break;
-        case 20:
-            Senddata(CMD_DECREASEVOLUME, m_txtCommand);
-            break;
-        case 21:
-            //Senddata(CMD_SHADER_TOGGLE, m_txtCommand);
-            break;
-        case 22:
-            Senddata(CMD_CLOSEAPP, m_txtCommand);
-            break;
+    if (m_nCommandType >= 0 && m_nCommandType < _countof(apiCommands)) {
+        const APICommandEntry& entry = apiCommands[m_nCommandType];
+        Senddata(entry.command, entry.usesParameter ? m_txtCommand.GetString() : _T(""));
+    }
+}
+
+void CRegisterCopyDataDlg::OnOK()
+{
+    CWnd* pFocus = GetFocus();
+    if (!pFocus) {
+        return;
+    }
+
+    const int controlId = pFocus->GetDlgCtrlID();
+    if (controlId == IDC_EDIT1 || controlId == IDC_BUTTON_FINDWINDOW) {
+        OnButtonFindwindow();
+    } else if (controlId == IDC_EDIT2 || controlId == IDC_COMBO1 || controlId == IDC_BUTTON_SENDCOMMAND) {
+        OnBnClickedButtonSendcommand();
     }
 }

--- a/src/MPCTestAPI/MPCTestAPIDlg.h
+++ b/src/MPCTestAPI/MPCTestAPIDlg.h
@@ -70,5 +70,6 @@ public:
     CString     m_txtCommand;
     int         m_nCommandType;
     afx_msg void OnBnClickedButtonSendcommand();
+    void        OnOK() override;
     void        Senddata(MPCAPI_COMMAND nCmd, LPCTSTR strCommand);
 };


### PR DESCRIPTION
Split from #3403 so the example application's own reliability fixes can be reviewed independently of new MPC-HC API commands.

### What this PR changes

- reads the edited executable path before constructing the launch request;
- uses `CreateProcess` with an explicit application name, a quoted mutable command line, and initialized process structures;
- reports both the Win32 error number and available system text when launch fails;
- validates incoming `WM_COPYDATA` size, Unicode termination, and embedded NULs;
- derives the MPC-HC window from the actual message sender and bounds client sends with `SendMessageTimeout`;
- queries `CMD_GETVERSION` after a validated connection and clears the connection only for the matching disconnect sender;
- routes Enter safely from the path, payload, selector, and both action buttons;
- replaces the resource/index-dependent command dispatch with a typed data table covering the existing API;
- adds the missing existing response names and the requested exact fallback `UNKNOWN (0xXXXXXXXX)`;
- updates MPCTestAPI to version `1.0.2.0`, copyright year 2026, and ignores its nested `.vs` directory.

### Deliberate scope boundary

This branch does **not** define volume/mute, host-query, or status-message API commands. Their feature-specific implementation and example-client rows are kept in separate domain PRs. The extensible client-side combined-state example belongs with the volume/mute API PR because it demonstrates why independent scalar GETs can still be composed without changing the wire protocol.

### Validation

- [x] `git diff --check`
- [x] MPCTestAPI Release x86 rebuild — SHA-256 `4F703C7C0D703806A7E2621180CC180D5F4FD014DF43B4323CA0C16928D4A04C`
- [x] MPCTestAPI Release x64 rebuild — SHA-256 `360E3A3DA18092A0FAD5BAA8D8335F21C334E909E4CEEC78415EE0D03F644668`
- [ ] Maintainer CI/runtime UI review

Preservation note: the original #3403 work remains at `backup/pr-3403-pre-salvage-20260813`, and the fully recovered integration/reference branch remains at `recovery/pr-3403-c2-20260813` / fork `develop`.

### Related #3403 split and landing order

- #4065 — volume/mute API and client-composed state example
- #4064 — transient status messages
- #4061 — connected-host query
- #4063 — transparent legacy web-header assets

This is the intended first code PR in the sequence. The feature PRs currently target the same upstream base and add minimal example rows so each is independently reviewable; after this typed-table hardening lands, I will rebase them in the order #4065, #4064, #4061 and port their rows into this table. #4063 is independent.
