### PR TITLE
Add transient API status-bar messages

### DIFF
--- a/src/MPCTestAPI/MPCTestAPIDlg.cpp
+++ b/src/MPCTestAPI/MPCTestAPIDlg.cpp
@@ -188,6 +188,10 @@ BOOL CRegisterCopyDataDlg::OnInitDialog()
     m_strMPCPath += _T("mpc-hc.exe");
 #endif // _WIN64
 
+    // Keep this feature-specific addition independent of the existing resource/index table.
+    VERIFY(SendDlgItemMessage(IDC_COMBO1, CB_ADDSTRING, 0,
+                              reinterpret_cast<LPARAM>(_T("CMD_STATUSSHOWMESSAGE"))) == 23);
+
     UpdateData(FALSE);
 
     return TRUE;  // return TRUE unless you set the focus to a control
@@ -354,6 +358,9 @@ void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
             break;
         case 22:
             Senddata(CMD_CLOSEAPP, m_txtCommand);
+            break;
+        case 23:
+            Senddata(CMD_STATUSSHOWMESSAGE, m_txtCommand);
             break;
     }
 }

--- a/src/MPCTestAPI/MPCTestAPIDlg.cpp
+++ b/src/MPCTestAPI/MPCTestAPIDlg.cpp
@@ -189,8 +189,14 @@ BOOL CRegisterCopyDataDlg::OnInitDialog()
 #endif // _WIN64
 
     // Keep this feature-specific addition independent of the existing resource/index table.
-    VERIFY(SendDlgItemMessage(IDC_COMBO1, CB_ADDSTRING, 0,
-                              reinterpret_cast<LPARAM>(_T("CMD_STATUSSHOWMESSAGE"))) == 23);
+    const LRESULT statusCommandIndex = SendDlgItemMessage(
+        IDC_COMBO1, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(_T("CMD_STATUSSHOWMESSAGE")));
+    VERIFY(statusCommandIndex != CB_ERR && statusCommandIndex != CB_ERRSPACE);
+    if (statusCommandIndex != CB_ERR && statusCommandIndex != CB_ERRSPACE) {
+        VERIFY(SendDlgItemMessage(IDC_COMBO1, CB_SETITEMDATA,
+                                  static_cast<WPARAM>(statusCommandIndex),
+                                  static_cast<LPARAM>(CMD_STATUSSHOWMESSAGE)) != CB_ERR);
+    }
 
     UpdateData(FALSE);
 
@@ -289,6 +295,12 @@ void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
     CString strEmpty(_T(""));
     UpdateData(TRUE);
 
+    const LRESULT command = SendDlgItemMessage(IDC_COMBO1, CB_GETITEMDATA, m_nCommandType);
+    if (command != 0 && command != CB_ERR) {
+        Senddata(static_cast<MPCAPI_COMMAND>(static_cast<DWORD>(command)), m_txtCommand);
+        return;
+    }
+
     switch (m_nCommandType) {
         case 0:
             Senddata(CMD_OPENFILE, m_txtCommand);
@@ -358,9 +370,6 @@ void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
             break;
         case 22:
             Senddata(CMD_CLOSEAPP, m_txtCommand);
-            break;
-        case 23:
-            Senddata(CMD_STATUSSHOWMESSAGE, m_txtCommand);
             break;
     }
 }

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -4016,16 +4016,21 @@ void CMainFrame::OnMenuFilters()
 
 void CMainFrame::OnUpdatePlayerStatus(CCmdUI* pCmdUI)
 {
-    if (GetLoadState() == MLS::LOADING) {
+    const MLS loadState = GetLoadState();
+    if (loadState != MLS::CLOSING && !m_tempstatus_msg.IsEmpty()) {
+        m_wndStatusBar.SetStatusMessage(m_tempstatus_msg);
+        if (loadState == MLS::LOADING && AfxGetAppSettings().bUseEnhancedTaskBar && m_pTaskbarList) {
+            m_pTaskbarList->SetProgressState(m_hWnd, TBPF_NOPROGRESS);
+        }
+        return;
+    }
+
+    if (loadState == MLS::LOADING) {
         m_wndStatusBar.SetStatusMessage(StrRes(IDS_CONTROLS_OPENING));
         if (AfxGetAppSettings().bUseEnhancedTaskBar && m_pTaskbarList) {
             m_pTaskbarList->SetProgressState(m_hWnd, TBPF_NOPROGRESS);
         }
-    } else if (GetLoadState() == MLS::LOADED) {
-        if (!m_tempstatus_msg.IsEmpty()) {
-            m_wndStatusBar.SetStatusMessage(m_tempstatus_msg);
-            return;
-        }
+    } else if (loadState == MLS::LOADED) {
         CString msg;
         if (m_fCapturing) {
             msg.LoadString(IDS_CONTROLS_CAPTURING);
@@ -4216,7 +4221,7 @@ void CMainFrame::OnUpdatePlayerStatus(CCmdUI* pCmdUI)
         }
 
         m_wndStatusBar.SetStatusMessage(msg);
-    } else if (GetLoadState() == MLS::CLOSING) {
+    } else if (loadState == MLS::CLOSING) {
         m_wndStatusBar.SetStatusMessage(StrRes(IDS_CONTROLS_CLOSING));
         if (AfxGetAppSettings().bUseEnhancedTaskBar && m_pTaskbarList) {
             m_pTaskbarList->SetProgressState(m_hWnd, TBPF_NOPROGRESS);
@@ -5094,7 +5099,7 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
 
     if (pCDS->dwData != 0x6ABE51 || pCDS->cbData < sizeof(DWORD)) {
         if (s.hMasterWnd) {
-            ProcessAPICommand(pCDS);
+            ProcessAPICommand(pWnd ? pWnd->GetSafeHwnd() : nullptr, pCDS);
             return TRUE;
         } else {
             return FALSE;
@@ -19780,11 +19785,19 @@ void CMainFrame::StopWebServer()
     }
 }
 
-void CMainFrame::SendStatusMessage(CString msg, int nTimeOut, bool bError /* = false */)
+void CMainFrame::SendStatusMessage(CString msg, int nTimeOut, bool bRevealStatusBar /* = false */,
+                                   bool bKeepVisibleOnMediaLoad /* = false */)
 {
     const auto timerId = TimerOneTimeSubscriber::STATUS_ERASE;
 
     m_timerOneTime.Unsubscribe(timerId);
+
+    // A non-revealing replacement cannot inherit a forced-visible status bar from an API
+    // message whose timer has just been cancelled.
+    if (m_bKeepTempStatusBarVisibleOnMediaLoad && !(nTimeOut > 0 && bRevealStatusBar)) {
+        RestoreStatusBarMessageHold();
+    }
+    m_bKeepTempStatusBarVisibleOnMediaLoad = false;
 
     m_tempstatus_msg.Empty();
     if (nTimeOut <= 0) {
@@ -19792,19 +19805,21 @@ void CMainFrame::SendStatusMessage(CString msg, int nTimeOut, bool bError /* = f
     }
 
     m_tempstatus_msg = msg;
-    // For a transient error we briefly reveal a preset-hidden status bar; re-hide it when the
-    // message times out so a recurring error (e.g. a failing shader on each load) can't pin it open (#3256).
-    m_timerOneTime.Subscribe(timerId, [this, bError] {
+    m_bKeepTempStatusBarVisibleOnMediaLoad = bRevealStatusBar && bKeepVisibleOnMediaLoad;
+    // A caller may briefly reveal a preset-hidden status bar; re-hide it when the
+    // message times out so recurring messages cannot pin it open (#3256).
+    m_timerOneTime.Subscribe(timerId, [this, bRevealStatusBar] {
         m_tempstatus_msg.Empty();
-        if (bError) {
+        m_bKeepTempStatusBarVisibleOnMediaLoad = false;
+        if (bRevealStatusBar) {
             RestoreStatusBarMessageHold();
         }
     }, nTimeOut);
 
     if (!m_tempstatus_msg.IsEmpty()) {
         m_wndStatusBar.SetStatusMessage(m_tempstatus_msg);
-        if (bError) {
-            ShowStatusBarForMessage(); // reveal the status bar (if a preset hides it) for errors only
+        if (bRevealStatusBar) {
+            ShowStatusBarForMessage();
         }
     }
 
@@ -19861,8 +19876,11 @@ void CMainFrame::AddCurDevToPlaylist()
 
 void CMainFrame::OpenMedia(CAutoPtr<OpenMediaData> pOMD)
 {
-    // Next media load: stop force-showing the status bar that an earlier error revealed.
-    RestoreStatusBarMessageHold();
+    // Next media load: stop force-showing the status bar that an earlier error revealed. A
+    // host-supplied status message keeps its own three-second reveal across this transition.
+    if (!m_bKeepTempStatusBarVisibleOnMediaLoad) {
+        RestoreStatusBarMessageHold();
+    }
 
     auto pFileData = dynamic_cast<const OpenFileData*>(pOMD.m_p);
     //auto pDVDData = dynamic_cast<const OpenDVDData*>(pOMD.m_p);
@@ -21283,7 +21301,40 @@ void CMainFrame::ResetSubtitlePosAndSize(bool repaint /* = false*/)
 }
 
 
-void CMainFrame::ProcessAPICommand(COPYDATASTRUCT* pCDS)
+static bool ParseAPIStatusMessage(const COPYDATASTRUCT* pCDS, CStringW& message)
+{
+    constexpr size_t maxCodeUnits = 512;
+    if (!pCDS || !pCDS->lpData || pCDS->cbData < 2 * sizeof(wchar_t)
+            || pCDS->cbData > (maxCodeUnits + 1) * sizeof(wchar_t)
+            || pCDS->cbData % sizeof(wchar_t) != 0) {
+        return false;
+    }
+
+    const wchar_t* const value = static_cast<const wchar_t*>(pCDS->lpData);
+    const size_t codeUnits = pCDS->cbData / sizeof(wchar_t) - 1;
+    if (value[codeUnits] != L'\0' || wmemchr(value, L'\0', codeUnits)) {
+        return false;
+    }
+
+    for (size_t i = 0; i < codeUnits; i++) {
+        const wchar_t codeUnit = value[i];
+        if (codeUnit >= 0xD800 && codeUnit <= 0xDBFF) {
+            if (++i >= codeUnits || value[i] < 0xDC00 || value[i] > 0xDFFF) {
+                return false;
+            }
+        } else if ((codeUnit >= 0xDC00 && codeUnit <= 0xDFFF)
+                   || codeUnit < 0x20
+                   || (codeUnit >= 0x7F && codeUnit <= 0x9F)
+                   || codeUnit == 0x2028 || codeUnit == 0x2029) {
+            return false;
+        }
+    }
+
+    message.SetString(value, static_cast<int>(codeUnits));
+    return true;
+}
+
+void CMainFrame::ProcessAPICommand(HWND hSender, COPYDATASTRUCT* pCDS)
 {
     CAtlList<CString> fns;
     REFERENCE_TIME rtPos = 0;
@@ -21444,6 +21495,15 @@ void CMainFrame::ProcessAPICommand(COPYDATASTRUCT* pCDS)
         case CMD_OSDSHOWMESSAGE:
             ShowOSDCustomMessageApi((MPC_OSDDATA*)pCDS->lpData);
             break;
+        case CMD_STATUSSHOWMESSAGE: {
+            CStringW message;
+            const CAppSettings& settings = AfxGetAppSettings();
+            if (hSender == settings.hMasterWnd && IsWindow(hSender)
+                    && ParseAPIStatusMessage(pCDS, message)) {
+                SendStatusMessage(message, 3000, true, true);
+            }
+            break;
+        }
     }
 }
 

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -469,8 +469,10 @@ private:
 
     bool m_bIsMPCVRExclusiveMode = false;
 
-    void SendStatusMessage(CString msg, int nTimeOut, bool bError = false);
+    void SendStatusMessage(CString msg, int nTimeOut, bool bRevealStatusBar = false,
+                           bool bKeepVisibleOnMediaLoad = false);
     CString m_tempstatus_msg, m_closingmsg;
+    bool m_bKeepTempStatusBarVisibleOnMediaLoad = false;
 
     REFERENCE_TIME m_rtDurationOverride;
 
@@ -1287,7 +1289,7 @@ public:
     void        ResetSubtitlePosAndSize(bool repaint = false);
 
     // MPC API functions
-    void        ProcessAPICommand(COPYDATASTRUCT* pCDS);
+    void        ProcessAPICommand(HWND hSender, COPYDATASTRUCT* pCDS);
     void        SendAPICommand(MPCAPI_COMMAND nCommand, LPCWSTR fmt, ...);
     void        SendNowPlayingToApi(bool sendtrackinfo = true);
     void        SendSubtitleTracksToApi();

--- a/src/mpc-hc/MpcApi.h
+++ b/src/mpc-hc/MpcApi.h
@@ -281,6 +281,11 @@ typedef enum MPCAPI_COMMAND :
     CMD_SETPANSCAN          = 0xA0004009,
 
     // Show host defined OSD message string
-    CMD_OSDSHOWMESSAGE      = 0xA0005000
+    CMD_OSDSHOWMESSAGE      = 0xA0005000,
+
+    // Show a host-defined message in the status bar for three seconds
+    // Parameter 1: non-empty, single-line, well-formed UTF-16 text; maximum
+    //              512 UTF-16 code units, excluding the terminating null
+    CMD_STATUSSHOWMESSAGE   = 0xA0005001
 
 } MPCAPI_COMMAND;


### PR DESCRIPTION
Split from #3403 so the host-to-player status-bar message command can be reviewed independently of volume/mute, host discovery, and general MPCTestAPI hardening.

### Protocol

- Adds `CMD_STATUSSHOWMESSAGE = 0xA0005001`.
- Payload: one non-empty, null-terminated, well-formed UTF-16 line, up to 512 UTF-16 code units excluding the terminator.
- Rejects odd/truncated/missing-terminator data, embedded NULs, unpaired surrogates, control characters, and line/paragraph separators.
- Accepts the command only when the sender HWND matches the configured live API host.
- Displays the text for three seconds; a newer transient message replaces the previous timer/message.

The payload is deliberately just text rather than another binary parameter struct. That keeps the example client generic, avoids the validation/ABI hazards of `MPC_OSDDATA`, and gives this status-bar surface a narrow contract. A fixed three-second duration matches the existing transient status mechanism.

### UI behavior

- The message remains the active temporary status in CLOSED, LOADING, and LOADED states; CLOSING still takes precedence.
- A preset-hidden status bar is temporarily revealed and restored on expiry.
- If media starts loading during the three-second window, that reveal is retained only until the same timer expires.
- Existing callers retain their prior default behavior; the old `bError` parameter name is clarified to its actual `bRevealStatusBar` meaning.
- MPCTestAPI exposes a feature-specific command row using its existing text payload field.

Sender equality is a consistency boundary, not authentication: the legacy same-integrity `WM_COPYDATA` protocol allows caller-supplied `wParam`. This PR does not claim to harden the whole pre-existing API trust model.

### Scope

- [x] Status-message command, validation, display lifetime, and example row only.
- [x] No volume/mute, host-query, web UI, or general MPCTestAPI changes.

### Validation

- [x] `git diff --check`
- [x] MPCTestAPI Release x86 — SHA-256 `70DE938574A0A6ACF5349A9981419D705BE6CB03551F1DF98757D0CC0C5A64C4`
- [x] MPCTestAPI Release x64 — SHA-256 `2F75032646B675F39973CD795BC3DA42CEF3DE4BDABEC2D6B402EC89FE7AAE76`
- [x] MPC-HC Release x86 project build — SHA-256 `54F6E6E6F1C524DC62F834BDA006C4079ECDB9CC9502D222374EEBA564BBDCD7`
- [x] MPC-HC Release x64 project build — SHA-256 `E272C08B17EBEE889D12387ECD576FFDABAD2063239BAE800B97449D0A964085`
- [x] The recovered integration runtime verified visible status text and three-second expiry; this focused branch independently builds all four targets above.
- [ ] Maintainer CI/runtime review across CLOSED / LOADING / LOADED and preset-hidden status-bar states

The focused builds completed with zero errors. The player binaries cover the core status implementation; MPCTestAPI was rebuilt after the subsequent combo-item-data review fix, which does not touch the player project. The committed worktree and every recursive submodule are clean and pinned. This isolated branch does not yet have an automated GUI lifecycle test; the integration/runtime evidence above covers display and expiry, while the remaining matrix is left explicit for review.

Preservation note: the pre-recovery #3403 tip remains at `backup/pr-3403-pre-salvage-20260813`, and the fully recovered integration/reference branch remains at `recovery/pr-3403-c2-20260813` / fork `develop`.

### Related #3403 split and landing order

- #4062 — general MPCTestAPI hardening
- #4065 — volume/mute API and client-composed state example
- #4061 — connected-host query
- #4063 — transparent legacy web-header assets

All focused branches start at the same current `develop` commit. They are independently reviewable but share central dispatch/test files, so the planned order is #4062, #4065, this PR, then #4061; #4063 can land anytime. I will rebase after each predecessor and preserve one typed MPCTest command table and one sender-aware API dispatch path.
