### PR TITLE
Add independent volume/mute API and client state snapshot

### DIFF
--- a/src/MPCTestAPI/MPCTestAPI.vcxproj
+++ b/src/MPCTestAPI/MPCTestAPI.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="HScrollListBox.cpp" />
     <ClCompile Include="MPCTestAPI.cpp" />
     <ClCompile Include="MPCTestAPIDlg.cpp" />
+    <ClCompile Include="PlayerStateSnapshot.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -68,6 +69,7 @@
     <ClInclude Include="HScrollListBox.h" />
     <ClInclude Include="MPCTestAPI.h" />
     <ClInclude Include="MPCTestAPIDlg.h" />
+    <ClInclude Include="PlayerStateSnapshot.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>

--- a/src/MPCTestAPI/MPCTestAPI.vcxproj.filters
+++ b/src/MPCTestAPI/MPCTestAPI.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="HScrollListBox.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="PlayerStateSnapshot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MPCTestAPI.h">
@@ -45,6 +48,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="HScrollListBox.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayerStateSnapshot.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/MPCTestAPI/MPCTestAPIDlg.cpp
+++ b/src/MPCTestAPI/MPCTestAPIDlg.cpp
@@ -27,6 +27,17 @@
 #include <psapi.h>
 
 
+enum CLIENT_COMMAND_INDEX {
+    CLIENT_SETVOLUME = 23,
+    CLIENT_SETMUTE,
+    CLIENT_GETVOLUME,
+    CLIENT_GETMUTE,
+    CLIENT_QUERYPLAYERSTATE,
+};
+
+static const UINT_PTR PLAYER_STATE_QUERY_TIMER_ID = 0x5150;
+
+
 LPCTSTR GetMPCCommandName(MPCAPI_COMMAND nCmd)
 {
     switch (nCmd) {
@@ -44,6 +55,10 @@ LPCTSTR GetMPCCommandName(MPCAPI_COMMAND nCmd)
             return _T("CMD_LISTAUDIOTRACKS");
         case CMD_PLAYLIST:
             return _T("CMD_PLAYLIST");
+        case CMD_CURRENTVOLUME:
+            return _T("CMD_CURRENTVOLUME");
+        case CMD_CURRENTMUTE:
+            return _T("CMD_CURRENTMUTE");
         default:
             return _T("CMD_UNK");
     }
@@ -130,6 +145,7 @@ BEGIN_MESSAGE_MAP(CRegisterCopyDataDlg, CDialog)
     ON_WM_QUERYDRAGICON()
     ON_BN_CLICKED(IDC_BUTTON_FINDWINDOW, OnButtonFindwindow)
     ON_WM_COPYDATA()
+    ON_WM_TIMER()
     //}}AFX_MSG_MAP
     ON_BN_CLICKED(IDC_BUTTON_SENDCOMMAND, &CRegisterCopyDataDlg::OnBnClickedButtonSendcommand)
 END_MESSAGE_MAP()
@@ -187,6 +203,14 @@ BOOL CRegisterCopyDataDlg::OnInitDialog()
 #else
     m_strMPCPath += _T("mpc-hc.exe");
 #endif // _WIN64
+
+    if (CComboBox* commandList = static_cast<CComboBox*>(GetDlgItem(IDC_COMBO1))) {
+        commandList->AddString(_T("Set volume (0-100)"));
+        commandList->AddString(_T("Set mute (0 or 1)"));
+        commandList->AddString(_T("Get volume"));
+        commandList->AddString(_T("Get mute"));
+        commandList->AddString(_T("CLIENT_QUERYPLAYERSTATE (non-atomic)"));
+    }
 
     UpdateData(FALSE);
 
@@ -275,9 +299,51 @@ BOOL CRegisterCopyDataDlg::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCopyDataStruc
         m_hWndMPC = (HWND)IntToPtr(_ttoi((LPCTSTR)pCopyDataStruct->lpData));
     }
 
-    strMsg.Format(_T("%s : %s"), GetMPCCommandName((MPCAPI_COMMAND)pCopyDataStruct->dwData), (LPCTSTR)pCopyDataStruct->lpData);
-    m_listBox.InsertString(0, strMsg);
+    const MPCAPI_COMMAND command = (MPCAPI_COMMAND)pCopyDataStruct->dwData;
+    const LPCTSTR value = (LPCTSTR)pCopyDataStruct->lpData;
+    if (!m_playerStateSnapshot.Capture(command, value)) {
+        strMsg.Format(_T("%s : %s"), GetMPCCommandName(command), value);
+        m_listBox.InsertString(0, strMsg);
+    }
     return CDialog::OnCopyData(pWnd, pCopyDataStruct);
+}
+
+void CRegisterCopyDataDlg::OnTimer(UINT_PTR nIDEvent)
+{
+    if (nIDEvent == PLAYER_STATE_QUERY_TIMER_ID) {
+        KillTimer(PLAYER_STATE_QUERY_TIMER_ID);
+        CompletePlayerStateQuery();
+        return;
+    }
+
+    CDialog::OnTimer(nIDEvent);
+}
+
+void CRegisterCopyDataDlg::StartPlayerStateQuery()
+{
+    if (m_playerStateSnapshot.IsActive()) {
+        KillTimer(PLAYER_STATE_QUERY_TIMER_ID);
+        CompletePlayerStateQuery();
+    }
+
+    m_playerStateSnapshot.Begin();
+    const UINT_PTR timer = SetTimer(PLAYER_STATE_QUERY_TIMER_ID,
+                                    CPlayerStateSnapshot::COLLECTION_WINDOW_MS, nullptr);
+
+    for (size_t i = 0; i < CPlayerStateSnapshot::GetRequestCount(); i++) {
+        Senddata(CPlayerStateSnapshot::GetRequest(i), _T(""));
+    }
+
+    if (!timer) {
+        CompletePlayerStateQuery();
+    }
+}
+
+void CRegisterCopyDataDlg::CompletePlayerStateQuery()
+{
+    if (m_playerStateSnapshot.IsActive()) {
+        m_listBox.InsertString(0, m_playerStateSnapshot.Complete());
+    }
 }
 
 void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
@@ -354,6 +420,21 @@ void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
             break;
         case 22:
             Senddata(CMD_CLOSEAPP, m_txtCommand);
+            break;
+        case CLIENT_SETVOLUME:
+            Senddata(CMD_SETVOLUME, m_txtCommand);
+            break;
+        case CLIENT_SETMUTE:
+            Senddata(CMD_SETMUTE, m_txtCommand);
+            break;
+        case CLIENT_GETVOLUME:
+            Senddata(CMD_GETVOLUME, strEmpty);
+            break;
+        case CLIENT_GETMUTE:
+            Senddata(CMD_GETMUTE, strEmpty);
+            break;
+        case CLIENT_QUERYPLAYERSTATE:
+            StartPlayerStateQuery();
             break;
     }
 }

--- a/src/MPCTestAPI/MPCTestAPIDlg.cpp
+++ b/src/MPCTestAPI/MPCTestAPIDlg.cpp
@@ -27,14 +27,7 @@
 #include <psapi.h>
 
 
-enum CLIENT_COMMAND_INDEX {
-    CLIENT_SETVOLUME = 23,
-    CLIENT_SETMUTE,
-    CLIENT_GETVOLUME,
-    CLIENT_GETMUTE,
-    CLIENT_QUERYPLAYERSTATE,
-};
-
+static const DWORD_PTR CLIENT_QUERYPLAYERSTATE_TOKEN = static_cast<DWORD_PTR>(-2);
 static const UINT_PTR PLAYER_STATE_QUERY_TIMER_ID = 0x5150;
 
 
@@ -205,11 +198,18 @@ BOOL CRegisterCopyDataDlg::OnInitDialog()
 #endif // _WIN64
 
     if (CComboBox* commandList = static_cast<CComboBox*>(GetDlgItem(IDC_COMBO1))) {
-        commandList->AddString(_T("Set volume (0-100)"));
-        commandList->AddString(_T("Set mute (0 or 1)"));
-        commandList->AddString(_T("Get volume"));
-        commandList->AddString(_T("Get mute"));
-        commandList->AddString(_T("CLIENT_QUERYPLAYERSTATE (non-atomic)"));
+        const auto addCommand = [commandList](LPCTSTR label, DWORD_PTR command) {
+            const int item = commandList->AddString(label);
+            if (item >= 0) {
+                VERIFY(commandList->SetItemData(item, command) != CB_ERR);
+            }
+        };
+
+        addCommand(_T("Set volume (0-100)"), CMD_SETVOLUME);
+        addCommand(_T("Set mute (0 or 1)"), CMD_SETMUTE);
+        addCommand(_T("Get volume"), CMD_GETVOLUME);
+        addCommand(_T("Get mute"), CMD_GETMUTE);
+        addCommand(_T("CLIENT_QUERYPLAYERSTATE (non-atomic)"), CLIENT_QUERYPLAYERSTATE_TOKEN);
     }
 
     UpdateData(FALSE);
@@ -351,6 +351,31 @@ void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
     CString strEmpty(_T(""));
     UpdateData(TRUE);
 
+    if (CComboBox* commandList = static_cast<CComboBox*>(GetDlgItem(IDC_COMBO1))) {
+        const int item = commandList->GetCurSel();
+        if (item != CB_ERR) {
+            const DWORD_PTR commandData = commandList->GetItemData(item);
+            if (commandData == CLIENT_QUERYPLAYERSTATE_TOKEN) {
+                StartPlayerStateQuery();
+                return;
+            }
+
+            if (commandData != static_cast<DWORD_PTR>(CB_ERR)) {
+                const MPCAPI_COMMAND command = static_cast<MPCAPI_COMMAND>(commandData);
+                switch (command) {
+                    case CMD_SETVOLUME:
+                    case CMD_SETMUTE:
+                        Senddata(command, m_txtCommand);
+                        return;
+                    case CMD_GETVOLUME:
+                    case CMD_GETMUTE:
+                        Senddata(command, strEmpty);
+                        return;
+                }
+            }
+        }
+    }
+
     switch (m_nCommandType) {
         case 0:
             Senddata(CMD_OPENFILE, m_txtCommand);
@@ -420,21 +445,6 @@ void CRegisterCopyDataDlg::OnBnClickedButtonSendcommand()
             break;
         case 22:
             Senddata(CMD_CLOSEAPP, m_txtCommand);
-            break;
-        case CLIENT_SETVOLUME:
-            Senddata(CMD_SETVOLUME, m_txtCommand);
-            break;
-        case CLIENT_SETMUTE:
-            Senddata(CMD_SETMUTE, m_txtCommand);
-            break;
-        case CLIENT_GETVOLUME:
-            Senddata(CMD_GETVOLUME, strEmpty);
-            break;
-        case CLIENT_GETMUTE:
-            Senddata(CMD_GETMUTE, strEmpty);
-            break;
-        case CLIENT_QUERYPLAYERSTATE:
-            StartPlayerStateQuery();
             break;
     }
 }

--- a/src/MPCTestAPI/MPCTestAPIDlg.h
+++ b/src/MPCTestAPI/MPCTestAPIDlg.h
@@ -25,6 +25,7 @@
 
 #include "../mpc-hc/MpcApi.h"
 #include "HScrollListBox.h"
+#include "PlayerStateSnapshot.h"
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -53,6 +54,7 @@ protected:
 protected:
     HICON   m_hIcon;
     HWND    m_hWndMPC;
+    CPlayerStateSnapshot m_playerStateSnapshot;
 
     // Generated message map functions
     //{{AFX_MSG(CRegisterCopyDataDlg)
@@ -62,6 +64,7 @@ protected:
     afx_msg HCURSOR OnQueryDragIcon();
     afx_msg void OnButtonFindwindow();
     afx_msg BOOL OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCopyDataStruct);
+    afx_msg void OnTimer(UINT_PTR nIDEvent);
     //}}AFX_MSG
     DECLARE_MESSAGE_MAP()
 public:
@@ -71,4 +74,6 @@ public:
     int         m_nCommandType;
     afx_msg void OnBnClickedButtonSendcommand();
     void        Senddata(MPCAPI_COMMAND nCmd, LPCTSTR strCommand);
+    void        StartPlayerStateQuery();
+    void        CompletePlayerStateQuery();
 };

--- a/src/MPCTestAPI/PlayerStateSnapshot.cpp
+++ b/src/MPCTestAPI/PlayerStateSnapshot.cpp
@@ -1,0 +1,108 @@
+/*
+ * (C) 2008-2026 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "PlayerStateSnapshot.h"
+
+
+struct PlayerStateField
+{
+    LPCTSTR label;
+    MPCAPI_COMMAND request;
+    MPCAPI_COMMAND response;
+};
+
+// Add one row to extend the client-side snapshot with another independent
+// request/reply pair. The API has no atomic aggregate-state command.
+static const PlayerStateField playerStateFields[] = {
+    { _T("version"), CMD_GETVERSION, CMD_VERSION },
+    { _T("now-playing"), CMD_GETNOWPLAYING, CMD_NOWPLAYING },
+    { _T("position"), CMD_GETCURRENTPOSITION, CMD_CURRENTPOSITION },
+    { _T("audio-track"), CMD_GETCURRENTAUDIOTRACK, CMD_CURRENTAUDIOTRACK },
+    { _T("subtitle-track"), CMD_GETCURRENTSUBTITLETRACK, CMD_CURRENTSUBTITLETRACK },
+    { _T("volume"), CMD_GETVOLUME, CMD_CURRENTVOLUME },
+    { _T("mute"), CMD_GETMUTE, CMD_CURRENTMUTE },
+};
+
+void CPlayerStateSnapshot::Begin()
+{
+    m_responses.clear();
+    m_active = true;
+}
+
+bool CPlayerStateSnapshot::IsActive() const
+{
+    return m_active;
+}
+
+bool CPlayerStateSnapshot::Capture(MPCAPI_COMMAND response, LPCTSTR value)
+{
+    if (!m_active) {
+        return false;
+    }
+
+    for (const PlayerStateField& field : playerStateFields) {
+        if (field.response == response) {
+            return m_responses.emplace(response, value).second;
+        }
+    }
+
+    return false;
+}
+
+CString CPlayerStateSnapshot::Complete()
+{
+    m_active = false;
+
+    CString summary;
+    summary.Format(_T("CLIENT_QUERYPLAYERSTATE (non-atomic; replies collected for up to %u ms): "),
+                   COLLECTION_WINDOW_MS);
+
+    for (size_t i = 0; i < _countof(playerStateFields); i++) {
+        const PlayerStateField& field = playerStateFields[i];
+        if (i != 0) {
+            summary.Append(_T(" | "));
+        }
+
+        const auto response = m_responses.find(field.response);
+        if (response == m_responses.cend()) {
+            summary.AppendFormat(_T("%s=<no reply>"), field.label);
+        } else {
+            CString value = response->second;
+            value.Replace(_T("\r"), _T(" "));
+            value.Replace(_T("\n"), _T(" "));
+            summary.AppendFormat(_T("%s=\"%s\""), field.label, value.GetString());
+        }
+    }
+
+    m_responses.clear();
+    return summary;
+}
+
+size_t CPlayerStateSnapshot::GetRequestCount()
+{
+    return _countof(playerStateFields);
+}
+
+MPCAPI_COMMAND CPlayerStateSnapshot::GetRequest(size_t index)
+{
+    ASSERT(index < _countof(playerStateFields));
+    return playerStateFields[index].request;
+}

--- a/src/MPCTestAPI/PlayerStateSnapshot.h
+++ b/src/MPCTestAPI/PlayerStateSnapshot.h
@@ -1,0 +1,44 @@
+/*
+ * (C) 2008-2026 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "../mpc-hc/MpcApi.h"
+
+#include <map>
+
+
+class CPlayerStateSnapshot
+{
+public:
+    static const UINT COLLECTION_WINDOW_MS = 750;
+
+    void Begin();
+    bool IsActive() const;
+    bool Capture(MPCAPI_COMMAND response, LPCTSTR value);
+    CString Complete();
+
+    static size_t GetRequestCount();
+    static MPCAPI_COMMAND GetRequest(size_t index);
+
+private:
+    bool m_active = false;
+    std::map<MPCAPI_COMMAND, CString> m_responses;
+};

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -5094,7 +5094,7 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
 
     if (pCDS->dwData != 0x6ABE51 || pCDS->cbData < sizeof(DWORD)) {
         if (s.hMasterWnd) {
-            ProcessAPICommand(pCDS);
+            ProcessAPICommand(pWnd ? pWnd->GetSafeHwnd() : nullptr, pCDS);
             return TRUE;
         } else {
             return FALSE;
@@ -5121,6 +5121,8 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
     s.ParseCommandLine(cmdln);
 
     if (s.nCLSwitches & CLSW_SLAVE) {
+        m_lastApiVolume = GetVolume();
+        m_lastApiMute = IsMuted() ? 1 : 0;
         SendAPICommand(CMD_CONNECT, L"%d", PtrToInt(GetSafeHwnd()));
         s.nCLSwitches &= ~CLSW_SLAVE;
     }
@@ -10689,21 +10691,32 @@ void CMainFrame::OnPlayFiltersStreams(UINT nID)
 
 void CMainFrame::OnPlayVolume(UINT nID)
 {
+    const int volume = GetVolume();
+    const int mute = IsMuted() ? 1 : 0;
+    if (volume == m_lastProcessedVolume && mute == m_lastProcessedMute) {
+        return;
+    }
+    m_lastProcessedVolume = volume;
+    m_lastProcessedMute = mute;
+
     if (GetLoadState() == MLS::LOADED) {
         CString strVolume;
         m_pBA->put_Volume(m_wndToolBar.Volume);
 
         //strVolume.Format (L"Vol : %d dB", m_wndToolBar.Volume / 100);
-        if (m_wndToolBar.Volume == -10000) {
+        if (mute) {
             strVolume.Format(IDS_VOLUME_OSD, 0);
         } else {
-            strVolume.Format(IDS_VOLUME_OSD, m_wndToolBar.m_volctrl.GetPos());
+            strVolume.Format(IDS_VOLUME_OSD, volume);
         }
         m_OSD.DisplayMessage(OSD_TOPLEFT, strVolume);
         //SendStatusMessage(strVolume, 3000); // Now the volume is displayed in three places at once.
     }
 
-    m_Lcd.SetVolume((m_wndToolBar.Volume > -10000 ? m_wndToolBar.m_volctrl.GetPos() : 1));
+    m_Lcd.SetVolume(mute ? 1 : volume);
+
+    SendCurrentVolumeToApi();
+    SendCurrentMuteToApi();
 }
 
 void CMainFrame::OnPlayVolumeBoost(UINT nID)
@@ -21283,7 +21296,32 @@ void CMainFrame::ResetSubtitlePosAndSize(bool repaint /* = false*/)
 }
 
 
-void CMainFrame::ProcessAPICommand(COPYDATASTRUCT* pCDS)
+static bool ParseAPIInteger(const COPYDATASTRUCT* pCDS, int minimum, int maximum, int& result)
+{
+    if (!pCDS || !pCDS->lpData || pCDS->cbData < sizeof(wchar_t)
+            || pCDS->cbData % sizeof(wchar_t) != 0) {
+        return false;
+    }
+
+    const wchar_t* const value = static_cast<const wchar_t*>(pCDS->lpData);
+    const size_t length = pCDS->cbData / sizeof(wchar_t);
+    if (length > 4 || value[length - 1] != L'\0'
+            || wmemchr(value, L'\0', length - 1)
+            || value[0] < L'0' || value[0] > L'9') {
+        return false;
+    }
+
+    wchar_t* end = nullptr;
+    const long parsed = wcstol(value, &end, 10);
+    if (end == value || *end != L'\0' || parsed < minimum || parsed > maximum) {
+        return false;
+    }
+
+    result = static_cast<int>(parsed);
+    return true;
+}
+
+void CMainFrame::ProcessAPICommand(HWND hSender, COPYDATASTRUCT* pCDS)
 {
     CAtlList<CString> fns;
     REFERENCE_TIME rtPos = 0;
@@ -21368,6 +21406,24 @@ void CMainFrame::ProcessAPICommand(COPYDATASTRUCT* pCDS)
                 m_OSD.DisplayMessage(OSD_TOPLEFT, m_wndStatusBar.GetStatusTimer(), 2000);
             }
             break;
+        case CMD_SETVOLUME: {
+            int volume;
+            if (hSender == AfxGetAppSettings().hMasterWnd
+                    && ParseAPIInteger(pCDS, 0, 100, volume) && volume != GetVolume()) {
+                // SetVolume posts the canonical volume-change notification.
+                m_wndToolBar.SetVolume(volume);
+            }
+            break;
+        }
+        case CMD_SETMUTE: {
+            int mute;
+            if (hSender == AfxGetAppSettings().hMasterWnd
+                    && ParseAPIInteger(pCDS, 0, 1, mute) && (mute != 0) != IsMuted()) {
+                m_wndToolBar.SetMute(mute != 0);
+                OnPlayVolume(ID_VOLUME_MUTE);
+            }
+            break;
+        }
         case CMD_SETAUDIODELAY:
             rtPos = (REFERENCE_TIME)_wtol((LPCWSTR)pCDS->lpData) * 10000;
             SetAudioDelay(rtPos);
@@ -21403,6 +21459,12 @@ void CMainFrame::ProcessAPICommand(COPYDATASTRUCT* pCDS)
             break;
         case CMD_GETCURRENTPOSITION:
             SendCurrentPositionToApi();
+            break;
+        case CMD_GETVOLUME:
+            SendCurrentVolumeToApi(true);
+            break;
+        case CMD_GETMUTE:
+            SendCurrentMuteToApi(true);
             break;
         case CMD_GETNOWPLAYING:
             SendNowPlayingToApi();
@@ -21445,6 +21507,19 @@ void CMainFrame::ProcessAPICommand(COPYDATASTRUCT* pCDS)
             ShowOSDCustomMessageApi((MPC_OSDDATA*)pCDS->lpData);
             break;
     }
+}
+
+void CMainFrame::SendAPIStringTo(HWND hTarget, MPCAPI_COMMAND nCommand, const CStringW& payload)
+{
+    COPYDATASTRUCT data = {};
+    data.cbData = static_cast<DWORD>((payload.GetLength() + 1) * sizeof(wchar_t));
+    data.dwData = nCommand;
+    data.lpData = const_cast<wchar_t*>(payload.GetString());
+
+    DWORD_PTR result = 0;
+    SendMessageTimeout(hTarget, WM_COPYDATA, reinterpret_cast<WPARAM>(GetSafeHwnd()),
+                       reinterpret_cast<LPARAM>(&data),
+                       SMTO_ABORTIFHUNG | SMTO_ERRORONEXIT, 100, &result);
 }
 
 void CMainFrame::SendAPICommand(MPCAPI_COMMAND nCommand, LPCWSTR fmt, ...)
@@ -21825,6 +21900,36 @@ void CMainFrame::SendCurrentPositionToApi(bool fNotifySeek)
         }
 
         SendAPICommand(fNotifySeek ? CMD_NOTIFYSEEK : CMD_CURRENTPOSITION, strPos);
+    }
+}
+
+void CMainFrame::SendCurrentVolumeToApi(bool force)
+{
+    if (!AfxGetAppSettings().hMasterWnd) {
+        return;
+    }
+
+    const int volume = GetVolume();
+    if (force || volume != m_lastApiVolume) {
+        CStringW payload;
+        payload.Format(L"%d", volume);
+        SendAPIStringTo(AfxGetAppSettings().hMasterWnd, CMD_CURRENTVOLUME, payload);
+        m_lastApiVolume = volume;
+    }
+}
+
+void CMainFrame::SendCurrentMuteToApi(bool force)
+{
+    if (!AfxGetAppSettings().hMasterWnd) {
+        return;
+    }
+
+    const int mute = IsMuted() ? 1 : 0;
+    if (force || mute != m_lastApiMute) {
+        CStringW payload;
+        payload.Format(L"%d", mute);
+        SendAPIStringTo(AfxGetAppSettings().hMasterWnd, CMD_CURRENTMUTE, payload);
+        m_lastApiMute = mute;
     }
 }
 

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -472,6 +472,11 @@ private:
     void SendStatusMessage(CString msg, int nTimeOut, bool bError = false);
     CString m_tempstatus_msg, m_closingmsg;
 
+    int m_lastApiVolume = -1;
+    int m_lastApiMute = -1;
+    int m_lastProcessedVolume = -1;
+    int m_lastProcessedMute = -1;
+
     REFERENCE_TIME m_rtDurationOverride;
 
     void CleanGraph();
@@ -536,7 +541,7 @@ public:
     }
     void SetPlaybackMode(int iNewStatus);
     bool IsMuted() {
-        return m_wndToolBar.GetVolume() == -10000;
+        return m_wndToolBar.IsMuted();
     }
     int GetVolume() {
         return m_wndToolBar.m_volctrl.GetPos();
@@ -1287,8 +1292,9 @@ public:
     void        ResetSubtitlePosAndSize(bool repaint = false);
 
     // MPC API functions
-    void        ProcessAPICommand(COPYDATASTRUCT* pCDS);
+    void        ProcessAPICommand(HWND hSender, COPYDATASTRUCT* pCDS);
     void        SendAPICommand(MPCAPI_COMMAND nCommand, LPCWSTR fmt, ...);
+    void        SendAPIStringTo(HWND hTarget, MPCAPI_COMMAND nCommand, const CStringW& payload);
     void        SendNowPlayingToApi(bool sendtrackinfo = true);
     void        SendSubtitleTracksToApi();
     void        SendAudioTracksToApi();
@@ -1296,6 +1302,8 @@ public:
     afx_msg void OnFileOpendirectory();
 
     void        SendCurrentPositionToApi(bool fNotifySeek = false);
+    void        SendCurrentVolumeToApi(bool force = false);
+    void        SendCurrentMuteToApi(bool force = false);
     void        ShowOSDCustomMessageApi(const MPC_OSDDATA* osdData);
     void        JumpOfNSeconds(int seconds);
 

--- a/src/mpc-hc/MpcApi.h
+++ b/src/mpc-hc/MpcApi.h
@@ -130,6 +130,14 @@ typedef enum MPCAPI_COMMAND :
     // Send index of currently selected subtitle track
     CMD_CURRENTSUBTITLETRACK   = 0x5000000D,
 
+    // Send the current volume after it changes or in response to CMD_GETVOLUME
+    // Parameter 1: volume (0-100)
+    CMD_CURRENTVOLUME       = 0x5000000E,
+
+    // Send the current mute state after it changes or in response to CMD_GETMUTE
+    // Parameter 1: mute state (0 or 1)
+    CMD_CURRENTMUTE         = 0x5000000F,
+
     // Send current playback position in response
     // of CMD_GETCURRENTPOSITION.
     // Parameter 1: current position in seconds
@@ -252,6 +260,22 @@ typedef enum MPCAPI_COMMAND :
     // Ask for the index of the currently selected subtitle track
     // return a CMD_CURRENTSUBTITLETRACK
     CMD_GETCURRENTSUBTITLETRACK   = 0xA0003008,
+
+    // Ask for the current volume
+    // Returns CMD_CURRENTVOLUME
+    CMD_GETVOLUME           = 0xA0003009,
+
+    // Ask for the current mute state
+    // Returns CMD_CURRENTMUTE
+    CMD_GETMUTE             = 0xA000300A,
+
+    // Set the volume without changing the mute state
+    // Parameter 1: volume (0-100)
+    CMD_SETVOLUME           = 0xA0003010,
+
+    // Set the mute state without changing the volume
+    // Parameter 1: mute state (0 or 1)
+    CMD_SETMUTE             = 0xA0003011,
 
     // Toggle FullScreen
     CMD_TOGGLEFULLSCREEN    = 0xA0004000,

--- a/src/mpc-hc/MpcApi.h
+++ b/src/mpc-hc/MpcApi.h
@@ -20,17 +20,17 @@
 
 
 /*
-This file defines commands used for "MPC-HC" API. To send commands
-to MPC-HC and receive playback notifications, first launch MPC-HC with the /slave command line
-argument followed by a HWnd handle used to receive notification:
+This file defines commands used for the MPC-HC API. To send commands
+to MPC-HC and receive playback notifications, first launch MPC-HC with the /slave command-line
+argument followed by an HWND that will receive notifications:
 
 ..\bin\mpc-hc /slave 125421
 
-After startup, MPC-HC sends a WM_COPYDATA message to host with COPYDATASTRUCT struct filled with:
+After startup, MPC-HC sends the host a WM_COPYDATA message with COPYDATASTRUCT filled with:
      - dwData :  CMD_CONNECT
      - lpData :  Unicode string containing MPC-HC's main window handle
 
-To control MPC-HC, send WM_COPYDATA messages to Hwnd provided on connection. All messages should be
+To control MPC-HC, send WM_COPYDATA messages to the HWND provided on connection. All messages must be
 formatted as null-terminated Unicode strings. For commands or notifications with multiple parameters,
 values are separated by |.
 If a string contains a |, it will be escaped with a \ so a \| is not a separator.
@@ -84,15 +84,15 @@ typedef enum MPCAPI_COMMAND :
     unsigned int {
     // ==== Commands from MPC-HC to host
 
-    // Send after connection
-    // Parameter 1: MPC-HC window handle (command should be sent to this HWnd)
+    // Sent after connecting to the host
+    // Parameter 1: MPC-HC window handle (commands must be sent to this HWND)
     CMD_CONNECT             = 0x50000000,
 
     // Send when opening or closing file
     // Parameter 1: current state (see MPC_LOADSTATE enum)
     CMD_STATE               = 0x50000001,
 
-    // Send when playing, pausing or closing file
+    // Send when playing, pausing or closing a file
     // Parameter 1: current play mode (see MPC_PLAYSTATE enum)
     CMD_PLAYMODE            = 0x50000002,
 
@@ -153,7 +153,7 @@ typedef enum MPCAPI_COMMAND :
     // Parameter 1: none.
     CMD_NOTIFYENDOFSTREAM   = 0x50000009,
 
-    // Send version str
+    // Send version string
     // Parameter 1: MPC-HC's version
     CMD_VERSION             = 0x5000000A,
 
@@ -229,16 +229,16 @@ typedef enum MPCAPI_COMMAND :
     // return a CMD_LISTSUBTITLETRACKS
     CMD_GETSUBTITLETRACKS   = 0xA0003000,
 
-    // Ask for the current playback position,
-    // see CMD_CURRENTPOSITION.
-    // Parameter 1: current position in seconds
+    // Ask for the current playback position
+    // Returns CMD_CURRENTPOSITION
     CMD_GETCURRENTPOSITION  = 0xA0003004,
 
     // Jump forward/backward of N seconds,
     // Parameter 1: seconds (negative values for backward)
     CMD_JUMPOFNSECONDS      = 0xA0003005,
 
-    // Ask slave for version
+    // Ask MPC-HC for its version
+    // Returns CMD_VERSION
     CMD_GETVERSION          = 0xA0003006,
 
     // Ask for a list of the audio tracks of the file

--- a/src/mpc-hc/PlayerToolBar.cpp
+++ b/src/mpc-hc/PlayerToolBar.cpp
@@ -1015,13 +1015,15 @@ BOOL CPlayerToolBar::OnCustomAction(UINT nID) {
 BOOL CPlayerToolBar::OnVolumeUp(UINT nID)
 {
     m_volctrl.IncreaseVolume();
-    return FALSE;
+    // SetPosInternal posts the canonical WM_HSCROLL notification.
+    return TRUE;
 }
 
 BOOL CPlayerToolBar::OnVolumeDown(UINT nID)
 {
     m_volctrl.DecreaseVolume();
-    return FALSE;
+    // SetPosInternal posts the canonical WM_HSCROLL notification.
+    return TRUE;
 }
 
 BOOL CPlayerToolBar::OnFullscreenButton(UINT nID) {

--- a/src/mpc-hc/PlayerToolBar.h
+++ b/src/mpc-hc/PlayerToolBar.h
@@ -40,6 +40,8 @@ public:
         LOCK_RIGHT,
     };
 private:
+    friend class CMainFrame;
+
     CMainFrame* m_pMainFrame;
 
     CImage volumeOn, volumeOff;

--- a/src/mpc-hc/VolumeCtrl.cpp
+++ b/src/mpc-hc/VolumeCtrl.cpp
@@ -71,8 +71,12 @@ bool CVolumeCtrl::Create(CWnd* pParentWnd)
 
 void CVolumeCtrl::SetPosInternal(int pos)
 {
+    const int previousPos = GetPos();
     SetPos(pos);
-    GetParent()->PostMessage(WM_HSCROLL, MAKEWPARAM(static_cast<WORD>(pos), SB_THUMBPOSITION), reinterpret_cast<LPARAM>(m_hWnd)); // this will be reflected back on us
+    const int currentPos = GetPos();
+    if (currentPos != previousPos) {
+        GetParent()->PostMessage(WM_HSCROLL, MAKEWPARAM(static_cast<WORD>(currentPos), SB_THUMBPOSITION), reinterpret_cast<LPARAM>(m_hWnd)); // this will be reflected back on us
+    }
     POINT p;
     ::GetCursorPos(&p);
     ScreenToClient(&p);
@@ -292,8 +296,8 @@ void CVolumeCtrl::HScroll(UINT nSBCode, UINT nPos)
 
     CFrameWnd* pFrame = GetParentFrame();
     if (pFrame && pFrame != GetParent()) {
-        pFrame->PostMessage(WM_HSCROLL, MAKEWPARAM(static_cast<WORD>(nPos), static_cast<WORD>(nSBCode)), reinterpret_cast<LPARAM>(m_hWnd));
         if (s.nVolume != oldVolume) {
+            pFrame->PostMessage(WM_HSCROLL, MAKEWPARAM(static_cast<WORD>(nPos), static_cast<WORD>(nSBCode)), reinterpret_cast<LPARAM>(m_hWnd));
             CRect r;
             getCustomChannelRect(r);
             InvalidateRect(r); //needed to redraw the volume text

--- a/src/mpc-hc/WebClientSocket.cpp
+++ b/src/mpc-hc/WebClientSocket.cpp
@@ -427,10 +427,9 @@ bool CWebClientSocket::OnCommand(CStringA& hdr, CStringA& body, CStringA& mime)
                 if (_stscanf_s(arg, _T("%f"), &percent) == 1) {
                     m_pMainFrame->SeekTo((REFERENCE_TIME)(percent / 100 * rtDur));
                 }
-            } else if (arg == _T(CMD_SETVOLUME) && m_request.Lookup("volume", arg)) {
+            } else if (arg == _T(WEB_CMD_SETVOLUME) && m_request.Lookup("volume", arg)) {
                 int volume = _tcstol(arg, nullptr, 10);
                 m_pMainFrame->m_wndToolBar.Volume = std::min(std::max(volume, 0), 100);
-                m_pMainFrame->OnPlayVolume(0);
             }
         }
     }

--- a/src/mpc-hc/WebServer.cpp
+++ b/src/mpc-hc/WebServer.cpp
@@ -487,7 +487,7 @@ void CWebServer::OnRequest(CWebClientSocket* pClient, CStringA& hdr, CStringA& b
         body.Replace("[indexpath]", "/index.html");
         body.Replace("[path]", pClient->m_path);
         body.Replace("[setposcommand]", CMD_SETPOS);
-        body.Replace("[setvolumecommand]", CMD_SETVOLUME);
+        body.Replace("[setvolumecommand]", WEB_CMD_SETVOLUME);
         body.Replace("[wmcname]", "wm_command");
         // TODO: add more general tags to replace
     }

--- a/src/mpc-hc/WebServer.h
+++ b/src/mpc-hc/WebServer.h
@@ -27,8 +27,8 @@
 
 #define UTF8(str)     UTF16To8(TToW(str))
 #define UTF8Arg(str)  UrlEncode(UTF8(str))
-#define CMD_SETPOS    "-1"
-#define CMD_SETVOLUME "-2"
+#define CMD_SETPOS         "-1"
+#define WEB_CMD_SETVOLUME  "-2"
 
 
 class CWebServerSocket;


### PR DESCRIPTION
Split from #3403 as the focused native volume/mute API domain. This implements the exact C2 design selected by @clsid2: separate GET volume, GET mute, SET volume, and SET mute operations.

### Wire contract

- `CMD_GETVOLUME` -> `CMD_CURRENTVOLUME`, scalar `0..100`.
- `CMD_GETMUTE` -> `CMD_CURRENTMUTE`, scalar `0` or `1`.
- `CMD_SETVOLUME`, scalar `0..100`; preserves the mute toggle.
- `CMD_SETMUTE`, scalar `0` or `1`; preserves the slider value.
- Input is accepted only as a complete null-terminated decimal scalar in range.
- Explicit GETs always reply; automatic replies are emitted only for the independently changed value.

This also corrects `CMainFrame::IsMuted()`: slider position `0` is no longer treated as equivalent to the mute toggle. Consequently the native API, classic web variables, #4053's `/status.json`, and its remote page can distinguish `volume=0, muted=false` from a genuinely muted nonzero slider.

### Effective-change handling

Toolbar buttons, themed/classic slider paths, web volume commands, and API setters converge on the canonical change path. Same-value/boundary updates no longer repeat `OnPlayVolume()`, and a final `(volume, mute)` guard protects against asynchronously coalesced slider messages. The new high-frequency API notifications use a bounded 100 ms callback rather than an unbounded UI-thread send.

The legacy web pseudo-command keeps its public value `-2`; it is renamed internally to `WEB_CMD_SETVOLUME` solely to avoid colliding with the new native enum.

### Combined example without a combined protocol command

MPCTestAPI adds a client-only `CLIENT_QUERYPLAYERSTATE` operation. It composes the independent existing request/reply pairs for:

- version;
- now-playing data;
- playback position;
- current audio track;
- current subtitle track;
- volume;
- mute.

The result is labelled **non-atomic** and reports missing replies after a bounded 750 ms collection window. Its data-driven field table can be extended with another independent request/response pair in one row.

This preserves C2 and keeps each wire command simple. A monolithic aggregate command would duplicate existing contracts, create versioning/partial-availability questions, and misleadingly suggest that values gathered from separate player subsystems were captured atomically. Composition belongs in the example client unless MPC-HC later provides a real synchronized snapshot primitive.

### Scope

- [x] Volume/mute API and correct state semantics.
- [x] Effective-change/deduplication behavior required by #3403.
- [x] Client-side multi-field state composition example.
- [x] Related native API protocol-comment cleanup preserved from #3403.
- [x] No host query, status-bar command, web page replay, PNG assets, or general MPCTestAPI launcher changes.

### Validation

- [x] `git diff --check`
- [x] MPCTestAPI Release x86 — SHA-256 `4694FAC991017568B1F1B209D6796F9D8786336A2BC0ECE36A3D8019349D38D9`
- [x] MPCTestAPI Release x64 — SHA-256 `B865A0A918ABD94218168CC4E42CA8A62D87C2D8EDB7D947FFDE710CC9B30F86`
- [x] MPC-HC Release x86 project compile/link — SHA-256 `90A991C7CB2CC41D6F3B182568335AD92CE6A15C2A70D3A1A1EB4EC3E8BB8870`
- [x] MPC-HC Release x64 project compile/link — SHA-256 `95F71490C7A5CA2F7AEF6D53CB21FFCF1C0D595BA878126E6874C83994F22E05`
- [x] The recovered integration runtime passed 55/55 checks, including C2 state preservation, volume-zero/unmuted semantics, forced GET replies, effective-change notifications, and no-op setters.
- [ ] Maintainer CI/runtime review

The two focused player projects compiled and linked; the aggregate `build.bat` workflows subsequently failed in the bundled LAV/FFmpeg dependency because this machine lacks matching x86 MinGW and x64 gnutls/pkg-config configuration. The player artifacts predate the final history rewrite and the subsequent MPCTest-only combo-item-data review fix, so they embed the prior equivalent Git description; player-source semantics did not change, making them compile/link evidence rather than byte-for-byte final-tip artifacts. MPCTestAPI was rebuilt after the final review fix. The committed worktree is clean, and all 23 recursive submodules are initialized and pinned.

Preservation note: the rejected combined `volume|mute` wire payload is not carried forward because it conflicts with the explicit C2 decision; its intended independent control is met more precisely by the four scalar commands above. The original tips remain at `backup/pr-3403-pre-salvage-20260813` and `recovery/pr-3403-c2-20260813` / fork `develop`.

### Related #3403 split and landing order

- #4062 — general MPCTestAPI hardening
- #4064 — transient status messages
- #4061 — connected-host query
- #4063 — transparent legacy web-header assets

All focused branches start at the same current `develop` commit. They are independently reviewable but share central dispatch/test files. Planned order is #4062 first, then this PR, #4064, and #4061; #4063 can land anytime. After #4062 lands, I will rebase and port this PR's feature rows/snapshot capture into its typed, validated MPCTest message path while preserving the C2 wire contract.
