### PR TITLE
Fit the Time on seekbar drop-down list to its longest item

### DIFF
--- a/src/mpc-hc/PPageTheme.cpp
+++ b/src/mpc-hc/PPageTheme.cpp
@@ -183,7 +183,7 @@ BOOL CPPageTheme::OnInitDialog()
     m_TimeOnSeekBar.AddString(ResStr(IDS_TIME_ON_SEEKBAR_ALWAYS));
     m_TimeOnSeekBar.AddString(ResStr(IDS_TIME_ON_SEEKBAR_WHEN_STATUSBAR_HIDDEN));
     m_TimeOnSeekBar.SetCurSel(s.nTimeOnSeekBar);
-    m_TimeOnSeekBar.SetDroppedWidth(200); // the longest option is wider than the combo field
+    CorrectComboListWidth(m_TimeOnSeekBar); // the longest option is wider than the combo field
 
     m_nOSDSize = s.nOSDSize;
     m_strOSDFont = s.strOSDFont;


### PR DESCRIPTION
The drop-down list width was hard-coded to 200 px. That is DPI-blind, and it never exceeded the combo's own width (231 px at 175%), so the list was always as narrow as the field and longer translations were clipped. Measure the items instead, like the other combo boxes on this page already do.

Dropped-list width for `Time on seekbar`, 175% DPI:

| | before | after |
|---|---|---|
| English | 231 | 231 |
| German | 231 | 303 |
| Turkish | 231 | 257 |

https://github.com/clsid2/mpc-hc/issues/4036
