### PR TITLE
Restore a floating playlist when leaving fullscreen

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -12695,7 +12695,9 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
             }
 
             if (m_wndPlaylistBar.IsHiddenDueToFullscreen() && !m_controls.ControlChecked(CMainFrameControls::Panel::PLAYLIST)) {
-                if (s.bHideWindowedControls) {
+                // A floating playlist can not be revealed by the autohide logic, which only knows about dock zones,
+                // so it has to be restored right away even when windowed controls are set to autohide.
+                if (s.bHideWindowedControls && !m_wndPlaylistBar.IsFloating()) {
                     m_wndPlaylistBar.SetHiddenDueToFullscreen(false, true);
                 } else {
                     m_wndPlaylistBar.SetHiddenDueToFullscreen(false);


### PR DESCRIPTION
Fixes #3965.

With "Hide on fullscreen" and "Hide windowed controls" both enabled, the playlist was left flagged as autohidden on fullscreen exit. That only works for docked panels: the autohide logic reveals panels by dock zone, and a floating bar has none, so it never came back.

Floating playlists are now restored right away; docked ones still stay hidden until hovered.