### PR TITLE
Fix size grip painted for the wrong DPI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,4 +48,4 @@
 	url = https://github.com/nothings/stb
 [submodule "src/thirdparty/ResizableLib/ResizableLib"]
 	path = src/thirdparty/ResizableLib/ResizableLib
-	url = https://github.com/ppescher/resizablelib
+	url = https://github.com/adipose/resizablelib

--- a/src/mpc-hc/DpiAwareResizableDialog.cpp
+++ b/src/mpc-hc/DpiAwareResizableDialog.cpp
@@ -184,12 +184,6 @@ BOOL CDpiAwareResizableDialog::OnInitDialog() {
     UpdateMinMaxTrackSizeForDPI();
     ApplyDialogSizeAndDpi(m_currentDpi, GetTargetDluSize());
 
-    // Refresh grip (initialized with primary monitor DPI, not current monitor)
-    CWnd* pGrip = GetSizeGripWnd();
-    if (pGrip && ::IsWindow(pGrip->GetSafeHwnd())) {
-        pGrip->SendMessage(WM_SETTINGCHANGE, 0, 0);
-    }
-
     return ret;
 }
 
@@ -424,11 +418,6 @@ LRESULT CDpiAwareResizableDialog::OnDpiChanged(WPARAM wParam, LPARAM lParam)
 
     ApplyDialogSizeAndDpi(m_currentDpi, targetDluSize);
     RefreshStaticImages();
-
-    CWnd* pGrip = GetSizeGripWnd();
-    if (pGrip && ::IsWindow(pGrip->GetSafeHwnd())) {
-        pGrip->SendMessage(WM_SETTINGCHANGE, 0, 0);
-    }
 
     SetupAnchors();
 


### PR DESCRIPTION
Fixes #4037.

The size grip is ResizableLib's `SBS_SIZEGRIP` scroll bar. In the modern theme it is painted transparently, and that paint path blits a square whose size the library caches from `GetSystemMetrics(SM_CXVSCROLL)` — a value that follows the session's system DPI. `CDpiAwareResizableDialog::UpdateSizeGripDPI()` sizes the grip window with `GetSystemMetricsForDpi()`, for the DPI of the monitor the dialog is on.

Those two agree on a single-DPI session, and diverge whenever the dialog's monitor DPI is higher than the process's system DPI: after a scaling change while the player is running, a dock or monitor hotplug, or a mixed-DPI multi-monitor setup. The grip is then painted short of the corner, its bottom right is never drawn, and the triangular window region clips what remains.

Measured on Windows 10 22H2 by taking the display from 100% to 125% with the player running:

    monitorDpi=120  systemDpi=96  SM_CXVSCROLL=17  grip window 21x21

The fix belongs in the library, so the submodule now tracks our own resizablelib again, with one commit on top of upstream master (upstream pull request: ppescher/resizablelib#42, issue ppescher/resizablelib#39). It sizes the grip from the DPI of the window rather than the session, handles `WM_DPICHANGED_AFTERPARENT`, applies the size in `UpdateSizeGrip()` (it passed `SWP_NOSIZE`, so a recomputed size never reached the window), rebuilds the triangular region on `WM_SIZE` so a grip resized by its owner is not clipped, and paints the size box where the control actually draws it instead of assuming it fills the client area.

With the library keeping the grip in step, the `SendMessage(WM_SETTINGCHANGE)` refresh in `OnInitDialog` and `OnDpiChanged` is no longer needed and is removed here. That was verified rather than assumed: the patched build was run with those calls already deleted, and the grip is correct across the DPI change, in a process that was running before it and in one started after.

Everything else in `CDpiAwareResizableDialog` is untouched — dialog re-layout, anchors, min/max tracking and cross-DPI placement restore are unchanged. Rendering on a single-DPI session is pixel-identical to before.
