### PR TITLE
Avoid madVR freeze on close caused by pre-close SMTC pause

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -1301,6 +1301,12 @@ void CMainFrame::OnClose()
 
     ASSERT(GetCurrentThreadId() == AfxGetApp()->m_nThreadID);
 
+    // Set the closing state before doing anything else, so that the various m_fClosingState
+    // guards throughout this file (and the pre-close MediaControlPause below) take effect
+    // immediately and no further UI/media work (e.g. a synchronous renderer frame grab) is
+    // kicked off while we're already tearing down.
+    AfxGetMyApp()->SetClosingState();
+
     s.bToggleShader = m_bToggleShader;
     s.bToggleShaderScreenSpace = m_bToggleShaderScreenSpace;
     s.dZoomX = m_ZoomX;
@@ -1351,7 +1357,6 @@ void CMainFrame::OnClose()
 
     {
         CAutoLock ga(&lockGraphAccess);
-        AfxGetMyApp()->SetClosingState();
 
         MSG msg;
         while (PeekMessage(&msg, nullptr, WM_GRAPHNOTIFY, WM_MPC_OPENCURPLAYLIST, PM_REMOVE)) {
@@ -24534,6 +24539,11 @@ void CMainFrame::MediaTransportControlUpdateAutoRepeat() {
 
 #if MPC_SMTC_VIDEO_THUMBNAIL
 void CMainFrame::MediaTransportControlUpdateThumbnail() {
+    if (AfxGetMyApp()->m_fClosingState) {
+        // Avoid a synchronous renderer frame grab (CaptureVideoThumbnail) while closing;
+        // with madVR this can block for several seconds.
+        return;
+    }
     if (m_fAudioOnly || GetLoadState() != MLS::LOADED || IsPlaybackCaptureMode() || !m_media_trans_control.IsActive()) {
         return;
     }


### PR DESCRIPTION
## Summary

Fixes the multi-second freeze on close reported in #4077 (madVR + SMTC enabled).

`CMainFrame::OnClose()` pauses playback before doing anything else if media is
running. That pause synchronously calls into `MediaTransportControlUpdateState()`,
which (when SMTC video thumbnails are enabled) would call
`MediaTransportControlUpdateThumbnail()` to grab the current video frame for the
"Now Playing" thumbnail. For madVR, that frame grab is a synchronous call into the
renderer, made right as the app is already tearing down — and it can block for
several seconds, which is the freeze reported in #4077.

`OnClose()` was only marking the app as closing (`AfxGetMyApp()->SetClosingState()`)
well after the pre-close pause had already run, so the existing `m_fClosingState`
guards used throughout the file to stop further work during shutdown weren't yet
active at the point the pause fired.

This moves `SetClosingState()` to the very top of `OnClose()`, before the pause,
and adds an explicit early-return guard in `MediaTransportControlUpdateThumbnail()`
for the closing case as well, so a frame grab can never be triggered by the
pre-close pause regardless of call ordering elsewhere.

SMTC video thumbnails (`MPC_SMTC_VIDEO_THUMBNAIL`) are left disabled as they
currently are on develop — this is a hardening fix for the underlying race, not a
re-enable of that feature.

## Test plan

- [x] x64 Release build compiles clean (0 errors, no new warnings)
- [ ] Manual repro with madVR + SMTC enabled, closing via the window X button