### PR TITLE
Fix web remote playlist clicks colliding with chapter navigation

### DIFF
--- a/src/mpc-hc/WebClientSocket.cpp
+++ b/src/mpc-hc/WebClientSocket.cpp
@@ -430,6 +430,17 @@ bool CWebClientSocket::OnCommand(CStringA& hdr, CStringA& body, CStringA& mime)
             } else if (arg == _T(WEB_CMD_SETVOLUME) && m_request.Lookup("volume", arg)) {
                 int volume = _tcstol(arg, nullptr, 10);
                 m_pMainFrame->m_wndToolBar.Volume = std::min(std::max(volume, 0), 100);
+            } else if (arg == _T(CMD_SETPLAYLISTINDEX) && m_request.Lookup("index", arg)) {
+                int index = _tstoi(arg);
+                if (index >= 0 && index < m_pMainFrame->m_wndPlaylistBar.GetCount()) {
+                    m_pMainFrame->m_wndPlaylistBar.SetSelIdx(index);
+                    // Post rather than call directly: OpenCurPlaylistItem() tears down and
+                    // rebuilds the graph, which is only safe from the top of the message
+                    // loop. Every other call site (playlist double-click, context menu,
+                    // X-button prev/next) posts this same message instead of calling it
+                    // inline; calling it synchronously from here crashes MPC-HC.
+                    m_pMainFrame->PostMessage(WM_MPC_OPENCURPLAYLIST, 0, 0);
+                }
             }
         }
     }
@@ -1415,10 +1426,9 @@ bool CWebClientSocket::OnPlaylistJSON(CStringA& hdr, CStringA& body, CStringA& m
         if (!items.IsEmpty()) {
             items += ",";
         }
-        items.AppendFormat("{\"index\":%d,\"label\":%s,\"duration\":%ld,\"id\":%u}",
+        items.AppendFormat("{\"index\":%d,\"label\":%s,\"duration\":%ld}",
                            index, JSONString(pli.GetLabel()).GetString(),
-                           std::lround(pli.m_duration / 10000i64),
-                           ID_NAVIGATE_JUMPTO_SUBITEM_START + index);
+                           std::lround(pli.m_duration / 10000i64));
         index++;
     }
 

--- a/src/mpc-hc/WebServer.h
+++ b/src/mpc-hc/WebServer.h
@@ -27,8 +27,9 @@
 
 #define UTF8(str)     UTF16To8(TToW(str))
 #define UTF8Arg(str)  UrlEncode(UTF8(str))
-#define CMD_SETPOS         "-1"
-#define WEB_CMD_SETVOLUME  "-2"
+#define CMD_SETPOS            "-1"
+#define WEB_CMD_SETVOLUME     "-2"
+#define CMD_SETPLAYLISTINDEX  "-3"
 
 
 class CWebServerSocket;

--- a/src/mpc-hc/res/web/remote.html
+++ b/src/mpc-hc/res/web/remote.html
@@ -383,7 +383,7 @@ select.pick:focus-visible { outline: 2px solid var(--accent); outline-offset: 1p
         mute: 909,          // ID_VOLUME_MUTE
         fullscreen: 830     // ID_VIEW_FULLSCREEN
     };
-    var SETPOS = -1, SETVOL = -2;
+    var SETPOS = -1, SETVOL = -2, SETPLIDX = -3;
 
     var $ = function (id) { return document.getElementById(id); };
 
@@ -570,7 +570,7 @@ select.pick:focus-visible { outline: 2px solid var(--accent); outline-offset: 1p
                     b.children[1].textContent = item.label;
                     b.children[2].textContent = item.duration ? fmt(item.duration) : "";
                     b.addEventListener("click", function () {
-                        send(item.id);
+                        send(SETPLIDX, "&index=" + item.index);
                         toast("Playing " + item.label);
                     });
                     li.appendChild(b);


### PR DESCRIPTION
## Summary
Fixes #4078.

`CWebClientSocket::OnPlaylistJSON` built each playlist item's clickable web-remote ID as `ID_NAVIGATE_JUMPTO_SUBITEM_START + index`. That ID range is shared with the Navigate submenu's chapter/BD-playlist/playlist-item numbering for the *currently playing* file — chapters occupy the low end of the range, playlist items come after. When the playing file has chapters, clicking a playlist item in `remote.html` could land on a chapter jump within the current file instead of switching to the clicked file.

The fix adds a dedicated `CMD_SETPLAYLISTINDEX` command (`WebServer.h`/`WebClientSocket.cpp`), independent of that menu ID range, following the existing `CMD_SETPOS`/`CMD_SETVOLUME` pattern already used for seek/volume. `remote.html`'s playlist click handler now sends the item's plain index instead of the reused menu ID.

The handler posts `WM_MPC_OPENCURPLAYLIST` rather than calling `OpenCurPlaylistItem()` directly — matching every other playlist-switch call site (double-click, context menu "Open", X-button prev/next). Calling it synchronously from the socket command handler reliably crashed MPC-HC (access violation inside MFC's idle-time command-UI update), confirmed via a controlled A/B test against the pre-existing `OnNavigateJumpTo` path.

## Test plan
- [x] Built locally (Release|x64).
- [x] Reproduced the original bug: a playlist with a chaptered file followed by a second file — clicking the second file via the web remote jumped to a chapter of the first file instead of switching.
- [x] Confirmed the fix: same setup, clicking the second file now correctly switches to it; switching back to the chaptered file correctly reopens it from the start rather than seeking a chapter.
- [x] Repeated the switch ~10 times rapidly (including replaying the exact original crash-repro sequence) with no crash and a responsive process throughout.
- [x] Confirmed `playlist.json` no longer emits the bogus `id` field.