### PR TITLE
Fix button layout and anchoring issues in Media Info dialog (#4098)

### DIFF
--- a/src/mpc-hc/PPageFileInfoSheet.cpp
+++ b/src/mpc-hc/PPageFileInfoSheet.cpp
@@ -73,10 +73,10 @@ BOOL CPPageFileInfoSheet::OnInitDialog()
     GetDlgItem(ID_APPLY_NOW)->GetWindowRect(&r);
     ScreenToClient(r);
     RemoveAnchor(IDOK); //otherwise it crashes when we add it later
-    AddAnchor(IDOK, BOTTOM_RIGHT);
     GetDlgItem(IDOK)->MoveWindow(r);
+    AddAnchor(IDOK, BOTTOM_RIGHT);
 
-    r.MoveToX(5);
+    r.MoveToX(11);
     r.right += 24;
     m_Button_MI.Create(ResStr(IDS_AG_SAVE_AS), WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE, r, this, IDC_BUTTON_MI);
     m_Button_MI.SetFont(GetFont());


### PR DESCRIPTION
### Description
This PR resolves the layout and responsiveness bugs in the Media Info dialog as reported in #4098.

### Changes
1. **Fix Close Button (`IDOK`) anchoring**: 
Moved `AddAnchor(IDOK, BOTTOM_RIGHT)` after `MoveWindow(r)`. 
This ensures the calculation uses the correct repositioned coordinates, allowing the button to properly track the right edge of the window.

2. **Fix Save As Button (`IDC_BUTTON_MI`) margin**: 
Adjusted the left margin using `r.MoveToX(11)` to properly align its left edge with the upper main tab control content.

### Related Issue
Closes #4098
