### PR TITLE
Fix Properties sheet button layout (follow-up to #4089)

### DIFF
--- a/src/mpc-hc/PPageFileInfoSheet.cpp
+++ b/src/mpc-hc/PPageFileInfoSheet.cpp
@@ -73,10 +73,16 @@ BOOL CPPageFileInfoSheet::OnInitDialog()
     GetDlgItem(ID_APPLY_NOW)->GetWindowRect(&r);
     ScreenToClient(r);
     RemoveAnchor(IDOK); //otherwise it crashes when we add it later
-    AddAnchor(IDOK, BOTTOM_RIGHT);
     GetDlgItem(IDOK)->MoveWindow(r);
+    AddAnchor(IDOK, BOTTOM_RIGHT); // must be added after the move, since AddAnchor bases its margin on the button's current position
 
-    r.MoveToX(5);
+    CRect pageRect;
+    GetActivePage()->GetWindowRect(&pageRect);
+    ScreenToClient(&pageRect);
+    CRect margin(5, 0, 0, 0);
+    GetActivePage()->MapDialogRect(&margin);
+
+    r.MoveToX(pageRect.left + margin.left);
     r.right += 24;
     m_Button_MI.Create(ResStr(IDS_AG_SAVE_AS), WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE, r, this, IDC_BUTTON_MI);
     m_Button_MI.SetFont(GetFont());

--- a/src/mpc-hc/PPageFileInfoSheet.cpp
+++ b/src/mpc-hc/PPageFileInfoSheet.cpp
@@ -69,20 +69,20 @@ BOOL CPPageFileInfoSheet::OnInitDialog()
     GetDlgItem(ID_APPLY_NOW)->ShowWindow(SW_HIDE);
     GetDlgItem(IDOK)->SetWindowText(ResStr(IDS_AG_CLOSE));
 
+    // align the buttons with the page above: Save As flush left, Close flush right (also keeps Close clear of the size grip)
+    CRect pageRect;
+    GetActivePage()->GetWindowRect(&pageRect);
+    ScreenToClient(&pageRect);
+
     CRect r;
     GetDlgItem(ID_APPLY_NOW)->GetWindowRect(&r);
     ScreenToClient(r);
+    r.MoveToX(pageRect.right - r.Width());
     RemoveAnchor(IDOK); //otherwise it crashes when we add it later
     GetDlgItem(IDOK)->MoveWindow(r);
     AddAnchor(IDOK, BOTTOM_RIGHT); // must be added after the move, since AddAnchor bases its margin on the button's current position
 
-    CRect pageRect;
-    GetActivePage()->GetWindowRect(&pageRect);
-    ScreenToClient(&pageRect);
-    CRect margin(5, 0, 0, 0);
-    GetActivePage()->MapDialogRect(&margin);
-
-    r.MoveToX(pageRect.left + margin.left);
+    r.MoveToX(pageRect.left);
     r.right += 24;
     m_Button_MI.Create(ResStr(IDS_AG_SAVE_AS), WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE, r, this, IDC_BUTTON_MI);
     m_Button_MI.SetFont(GetFont());


### PR DESCRIPTION
Follow-up to #4089 / #4076, addressing [bibsp's report](https://github.com/clsid2/mpc-hc/pull/4089#issuecomment-5337844370) that the MediaInfo tab's buttons were still misplaced.

Two remaining issues in `CPPageFileInfoSheet::OnInitDialog`:

- **Close stranded mid-dialog**: `AddAnchor(IDOK, BOTTOM_RIGHT)` was called *before* `MoveWindow` repositioned the button into the Apply slot. `AddAnchor` computes its margin from the button's position at call time, so the anchor kept the stale pre-move offset and every subsequent `ArrangeLayout()` pulled Close back toward the middle — the large gap visible in bibsp's screenshot. #4089's BOTTOM_LEFT→BOTTOM_RIGHT change was necessary but not sufficient; the move must happen before the anchor is added. (Verified against every other `AddAnchor(IDOK, BOTTOM_RIGHT)` call site in the codebase — this was the only one that moved the button after anchoring.)
- **Save As misaligned**: its X position was a hardcoded 5px, which doesn't match the page's real left margin at all DPI/font scales. Now derived from the active page's window rect plus a 5-DLU margin via `MapDialogRect`.

Tested at runtime: opened Properties → MediaInfo, verified Close sits flush bottom-right at default size and still tracks the corner after resizing the sheet +420px wider.

### Screenshots

Default size — Close flush bottom-right, Save As on the page's left margin:

![default size](https://raw.githubusercontent.com/adipose/mpc-hc/pr4102-assets/props-mediainfo-default-v2.png)

After resizing the sheet +420px wider / +200px taller — Close tracks the corner instead of stranding mid-dialog:

![resized](https://raw.githubusercontent.com/adipose/mpc-hc/pr4102-assets/props-mediainfo-resized-v2.png)

