### PR TITLE
Fix Color Controls dialog resize behavior and layout corruption on reopen

### DIFF
--- a/src/mpc-hc/ColorControlsDlg.cpp
+++ b/src/mpc-hc/ColorControlsDlg.cpp
@@ -37,9 +37,9 @@ BOOL CColorControlsDlg::OnInitDialog()
 {
     EnableSaveRestoreKey(IDS_R_DLG_COLOR_CONTROLS);
 
-    SetupAnchors();
-
     __super::OnInitDialog();
+
+    SetupAnchors();
 
     m_SliBrightness.EnableWindow(TRUE);
     m_SliBrightness.SetRange(-100, 100, true);
@@ -86,6 +86,15 @@ void CColorControlsDlg::SetupAnchors()
     AddAnchor(IDC_SLI_SATURATION, TOP_LEFT, TOP_RIGHT);
     AddAnchor(IDC_RESET, TOP_RIGHT);
     AddAnchor(IDCANCEL,  TOP_RIGHT);
+}
+
+TrackSizeConstraints CColorControlsDlg::GetTrackSizeConstraints() const
+{
+    // The dialog's height is fixed; only its width can be resized, and only up to 2x the template width.
+    TrackSizeConstraints constraints;
+    constraints.max.enabled = true;
+    constraints.max.xMultiplier = 2.0;
+    return constraints;
 }
 
 void CColorControlsDlg::UpdateSliders()

--- a/src/mpc-hc/ColorControlsDlg.h
+++ b/src/mpc-hc/ColorControlsDlg.h
@@ -34,6 +34,8 @@ public:
     enum { IDD = IDD_COLORCONTROLS_DLG };
 
     UINT GetDialogTemplateID() const override { return IDD; }
+    void SetupAnchors() override;
+    TrackSizeConstraints GetTrackSizeConstraints() const override;
 
 protected:
     CMPCThemeSliderCtrl m_SliBrightness;
@@ -46,7 +48,6 @@ protected:
     CString m_sSaturation;
 
     void UpdateSliders();
-    void SetupAnchors();
 
     virtual void DoDataExchange(CDataExchange* pDX) override;
     virtual BOOL OnInitDialog() override;


### PR DESCRIPTION
## Summary
- Fixes #4096
- The Color Controls dialog (Brightness/Contrast/Hue/Saturation) could be resized both horizontally and vertically with no benefit: height resize was pointless, width resize had no sane bounds, and sliders didn't stretch to fill the extra width.
- Worse, after resizing and closing/reopening the dialog, the layout came back corrupted/overlapping.
- Vertical resize is now locked to the template height. Horizontal resize is capped at 2x the template width, and the four sliders now stretch with the window (anchored TOP_LEFT/TOP_RIGHT) while Reset/Close track the right edge.

## Test plan
- [x] Full pipeline build succeeds (`build.bat x64 Main Release`)
- [x] Default dialog layout renders correctly
- [x] Widening the dialog stretches the sliders and moves Reset/Close with the right edge, no overlap
- [x] Attempting to resize taller has no effect (height locked)
- [x] Closing and reopening the dialog after widening no longer corrupts the layout