### PR TITLE
Restore playlist scroll to current item when opening the playlist panel (#4094)

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -8488,6 +8488,9 @@ void CMainFrame::OnViewPlaylist()
     m_controls.ToggleControl(CMainFrameControls::Panel::PLAYLIST);
     m_wndPlaylistBar.SetHiddenDueToFullscreen(false);
     UpdatePlaylistButton();
+    if (m_controls.ControlChecked(CMainFrameControls::Panel::PLAYLIST)) {
+        m_wndPlaylistBar.EnsureCurrentVisible();
+    }
 }
 
 void CMainFrame::OnUpdateViewPlaylist(CCmdUI* pCmdUI)

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1310,6 +1310,19 @@ void CPlayerPlaylistBar::EnsureVisible(POSITION pos)
     m_list.Invalidate();
 }
 
+void CPlayerPlaylistBar::EnsureCurrentVisible()
+{
+    if (!m_pl.IsEmpty()) {
+        POSITION pos = m_pl.GetPos();
+        int i = FindItem(pos);
+        if (i < 0) {
+            return;
+        }
+        m_list.EnsureVisible(i, TRUE);
+        m_list.Invalidate();
+    }
+}
+
 int CPlayerPlaylistBar::FindItem(const POSITION pos) const
 {
     auto it = m_posToIndex.find(pos);

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -170,6 +170,7 @@ public:
     void SetFirstSelected();
     void SetFirst();
     void SetLast();
+    void EnsureCurrentVisible();
     void SetCurValid(bool fValid);
     void SetCurLabel(CString label);
     void SetCurTime(REFERENCE_TIME rt);


### PR DESCRIPTION
Fixes #4094.

When the playlist panel is closed, a file is opened, and the panel is then reopened, the list is scrolled down by exactly one row — the playing item is no longer visible and the user has to scroll up to reach item 1.

### Cause

A hidden docked player bar is collapsed to a degenerate rect, so the playlist `SysListView32` has a client height of **0**. `CPlayerPlaylistBar::EnsureVisible()` still runs during file open, and in a zero-height viewport the target row is entirely below the visible area, so comctl32 takes the bottom-alignment branch:

```
scrollTop = (i+1) * rowHeight - clientHeight   =   (i+1) * rowHeight
```

Bottom-aligning row `i` in a zero-height view lands one full row past its top, which is why the list is always off by exactly one. Showing the panel afterwards only grows the viewport; it never resets the scroll offset.

This is a regression. 870d35a40e ("Ensure current playing item is visible in list when toggling playlist control") added `EnsureCurrentVisible()` for precisely this case, and 419dadc920 (#3899) removed the method and its call site as collateral in an unrelated list-control cleanup. This restores it verbatim.

### Screenshots

30-item playlist opened with the panel hidden, then the panel toggled on:

![before and after](https://raw.githubusercontent.com/adipose/mpc-hc/pr4094-assets/issue4094-before-after.png)

### Testing

Verified by querying the control directly rather than by eye — `LVM_GETTOPINDEX` reads 1 (item 2 at top) before the fix and 0 after, with identical geometry on both builds:

```
                                    before          after
after load, playlist hidden      topIndex=1      topIndex=1
playlist shown                   topIndex=1      topIndex=0
```

The first row is unchanged by design: the fix does not prevent the zero-height scroll, it re-runs `EnsureVisible` once the bar has real geometry.
