### PR TITLE
Defer playlist scroll while the panel is hidden instead of re-scrolling on every toggle

### DIFF
--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -1291,6 +1291,10 @@ void CPlayerPlaylistBar::SyncSelectionToPos(POSITION pos)
     m_list.SetItemState(-1, 0, LVIS_SELECTED | LVIS_FOCUSED);
     m_list.SetItemState(idx, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
     m_list.SetSelectionMark(idx);
+    if (!ListHasGeometry()) {
+        m_bScrollToCurrentPending = true;
+        return;
+    }
     m_list.EnsureVisible(idx, TRUE);
 }
 
@@ -1300,10 +1304,27 @@ void CPlayerPlaylistBar::UpdateList()
     m_list.Invalidate();
 }
 
+bool CPlayerPlaylistBar::ListHasGeometry() const
+{
+    if (!::IsWindow(m_list.GetSafeHwnd())) {
+        return false;
+    }
+    CRect r;
+    m_list.GetClientRect(r);
+    return r.Height() > 0;
+}
+
 void CPlayerPlaylistBar::EnsureVisible(POSITION pos)
 {
     int i = FindItem(pos);
     if (i < 0) {
+        return;
+    }
+    if (!ListHasGeometry()) {
+        // A hidden bar is collapsed to zero height. LVM_ENSUREVISIBLE would bottom-align
+        // the row in a zero-height viewport, leaving the scroll one row past it, and
+        // showing the bar later does not undo that. Defer instead. (#4094)
+        m_bScrollToCurrentPending = true;
         return;
     }
     m_list.EnsureVisible(i, TRUE);
@@ -1312,15 +1333,21 @@ void CPlayerPlaylistBar::EnsureVisible(POSITION pos)
 
 void CPlayerPlaylistBar::EnsureCurrentVisible()
 {
-    if (!m_pl.IsEmpty()) {
-        POSITION pos = m_pl.GetPos();
-        int i = FindItem(pos);
-        if (i < 0) {
-            return;
-        }
-        m_list.EnsureVisible(i, TRUE);
-        m_list.Invalidate();
+    // Only scroll if one was deferred while the bar had no geometry; a plain panel
+    // toggle must not move the user's scroll position. (#3899)
+    if (!m_bScrollToCurrentPending) {
+        return;
     }
+    m_bScrollToCurrentPending = false;
+    if (m_pl.IsEmpty()) {
+        return;
+    }
+    int i = FindItem(m_pl.GetPos());
+    if (i < 0) {
+        return;
+    }
+    m_list.EnsureVisible(i, TRUE);
+    m_list.Invalidate();
 }
 
 int CPlayerPlaylistBar::FindItem(const POSITION pos) const

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -111,6 +111,8 @@ private:
     void SyncSelectionToPos(POSITION pos);
     void UpdateList();
     void EnsureVisible(POSITION pos);
+    bool ListHasGeometry() const;
+    bool m_bScrollToCurrentPending = false; // a scroll was deferred while the bar had no geometry
     int FindItem(const POSITION pos) const;
     POSITION FindPos(int i);
     void RebuildPosMap();


### PR DESCRIPTION
Follow-up to #4105. That PR fixed #4094 by restoring `EnsureCurrentVisible()`, which re-scrolls to the current item every time the playlist panel is shown — but that is the behaviour 6958a68481 deliberately removed ("Remove EnsureCurrentVisible; scrolled playlist unnecessarily on panel toggle"). As merged, scrolling the playlist and then toggling the panel off and on throws the view back to the playing item.

This fixes the cause instead, so both hold.

### Cause

A hidden docked player bar is collapsed to a degenerate rect, so the playlist `SysListView32` has a client height of **0**. `EnsureVisible()` still runs during file open, and in a zero-height viewport comctl32 bottom-aligns the target row, leaving `scrollTop = (i+1) * rowHeight` — off by exactly one row. Showing the panel grows the viewport but never rewinds that offset. This is long-standing behaviour; #4105 did not introduce it.

Re-scrolling on every panel toggle repairs the damage after the fact, at the cost of discarding the user's scroll position. Suppressing the corrupting call is strictly better: there is then nothing to repair.

### Change

- `EnsureVisible()` and `SyncSelectionToPos()` no longer issue `LVM_ENSUREVISIBLE` when the list has no geometry; they record that a scroll was deferred. Selection and focus are still applied.
- `EnsureCurrentVisible()` is now a no-op unless a scroll was actually deferred, so a plain panel toggle leaves the view alone.
- The deferral is a `bool`, not the `POSITION` — a POSITION is a list-node pointer that can dangle or alias after items are removed. The row is resolved from `m_pl.GetPos()` at apply time.

`CMainFrame::OnViewPlaylist()` is unchanged.

### Testing

Both checks measured via `LVM_GETTOPINDEX` on the real control, 30-item playlist:

| check | develop (#4105 merged) | this PR |
|---|---|---|
| A (#4094) — open the panel after loading a file with it hidden | `topIndex=0` — PASS | `topIndex=0` — PASS |
| B (#3899) — scroll to row 11, then toggle the panel off and on | `topIndex=0` — **FAIL** | `topIndex=11` — PASS |

#4094 stays fixed either way — the difference is B.
