### PR TITLE
Fix overdrawn OSD font label in translated user interface page

### DIFF
--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1226,7 +1226,7 @@ CPoint CMPCThemeUtil::GetClientRectOffset(CWnd* window) {
     return offset;
 }
 
-void CMPCThemeUtil::AdjustDynamicWidgetPair(CWnd* window, int leftWidget, int rightWidget) {
+void CMPCThemeUtil::AdjustDynamicWidgetPair(CWnd* window, int leftWidget, int rightWidget, bool allowShrinkRight) {
     if (window && IsWindow(window->m_hWnd)) {
         DpiHelper dpiWindow;
         dpiWindow.Override(window->GetSafeHwnd());
@@ -1301,9 +1301,24 @@ void CMPCThemeUtil::AdjustDynamicWidgetPair(CWnd* window, int leftWidget, int ri
                 }
             }
             CRect cl = l, cr = r;
-            if (leftWantsRight > rightWantsLeft - dynamicSpace //overlaps; we will assume defaults are best
-                || (leftWantsRight < l.right && rightWantsLeft > r.left) // there is no need to resize
-                || (lType == WidgetPairText && DT_RIGHT == (leftW->GetStyle() & DT_RIGHT)) ) //right aligned text not supported, as the right edge is fixed
+            if (lType == WidgetPairText && DT_RIGHT == (leftW->GetStyle() & DT_RIGHT)) //right aligned text not supported, as the right edge is fixed
+            {
+                //do nothing
+            } else if (allowShrinkRight) {
+                //the left widget always gets the width its text needs, and the right widget yields from its left edge
+                //a combo box still lists full width text when the dropdown is opened, so a narrower closed state
+                //is an acceptable trade for a label which is not overdrawn
+                //never shrink the right widget below a usable minimum: the drop-down arrow plus a readable
+                //sample of its text, and never past half the width the template gave it
+                LONG minWidth = std::max(dpiWindow.GetSystemMetricsDPI(SM_CXVSCROLL) + dpiWindow.ScaleX(40), cr.Width() / 2);
+                minWidth = std::min(minWidth, (LONG)cr.Width()); //a widget that is already narrower than the floor just keeps its size
+                LONG want = std::min(leftWantsRight, r.right - minWidth - dynamicSpace);
+                if (want > l.left) { //a pathological translation clips the label rather than collapsing the right widget
+                    l.right = want;
+                    r.left = std::max(l.right + dynamicSpace, r.left); //only ever shrinks the right widget, never widens it
+                }
+            } else if (leftWantsRight > rightWantsLeft - dynamicSpace //overlaps; we will assume defaults are best
+                || (leftWantsRight < l.right && rightWantsLeft > r.left) ) // there is no need to resize
             {
                 //do nothing
             } else {

--- a/src/mpc-hc/CMPCThemeUtil.h
+++ b/src/mpc-hc/CMPCThemeUtil.h
@@ -114,7 +114,7 @@ public:
     static void drawParentDialogBGClr(CWnd* wnd, CDC* pDC, CRect r, bool fill = true);
     static void fulfillThemeReqs(CProgressCtrl* ctl);
     static void enableWindows10DarkFrame(CWnd* window);
-    static void AdjustDynamicWidgetPair(CWnd* window, int left, int right);
+    static void AdjustDynamicWidgetPair(CWnd* window, int left, int right, bool allowShrinkRight = false);
     static void UpdateAnalogCaptureDeviceSlider(CScrollBar* pScrollBar);
     static bool IsWindowVisibleAndRendered(CWnd* window);
     static void RefreshBitmapIconControls(CWnd* parentWnd);

--- a/src/mpc-hc/PPageTheme.cpp
+++ b/src/mpc-hc/PPageTheme.cpp
@@ -440,6 +440,6 @@ void CPPageTheme::AdjustDynamicWidgets() {
     AdjustDynamicWidgetPair(this, IDC_STATIC5, IDC_COMBO2);
     AdjustDynamicWidgetPair(this, IDC_STATIC11, IDC_COMBO3);
     AdjustDynamicWidgetPair(this, IDC_STATIC7, IDC_EDIT4);
-    AdjustDynamicWidgetPair(this, IDC_STATIC6, IDC_COMBO5);
+    AdjustDynamicWidgetPair(this, IDC_STATIC6, IDC_COMBO5, true);
     AdjustDynamicWidgetPair(this, IDC_STATIC23, IDC_COMBO6);
 }


### PR DESCRIPTION
Fixes the first half of #4107: on the User Interface options page, a translated OSD "Font:" label is overdrawn by the font-name combo box, so its tail goes missing (Polish "Czcionka:" renders as "Czcionka").

### Cause

In `IDD_PPAGETHEME` the two template rects already overlap:

```
LTEXT    "Font:",IDC_STATIC6,187,71,80,11      -> spans x=187..267
COMBOBOX IDC_COMBO5,217,71,128,61              -> starts x=217
```

English "Font:" is short enough that nothing shows, but a longer translation runs under the combo box, which is declared later and so paints over it.

`AdjustDynamicWidgetPair` is already applied to this pair, but it declines to act. Both of its early-outs leave the overlap in place:

- `leftWantsRight > rightWantsLeft - dynamicSpace` fires when the font list is wide, since `rightWantsLeft` comes from `CorrectComboListWidth`;
- `leftWantsRight < l.right && rightWantsLeft > r.left` ("no need to resize") fires when both texts fit their own declared rects -- which they do here, because the label is declared 80 DLU wide. It is the *rects* that overlap, not the text that is too long.

Which one fires just depends on how many fonts are installed, so both had to be bypassed.

### Change

`AdjustDynamicWidgetPair` gains an opt-in `allowShrinkRight` parameter, defaulting to `false`. Every existing call site is unchanged in both signature and behaviour; only the OSD font pair opts in.

In aggressive mode the label takes the width its text needs and the right widget yields from its left edge. A combo box still lists full-width text when its dropdown is opened, so a narrower closed state is a cheap trade for a label that is not overdrawn.

Two properties keep this safe:

- `r.left = std::max(l.right + dynamicSpace, r.left)` means the right widget can only ever be pushed right, never widened, so a layout that was already correct is left exactly as it was.
- The right widget will not shrink below a usable minimum -- the drop-down arrow plus a readable sample of text, and never past half the width the template gave it -- so a pathological translation clips the label rather than collapsing the control.

No `.rc` change is needed: the overlap is now resolved at runtime, so no per-language resources are regenerated.

### Result

Polish, before (top) and after (bottom):

![OSD font row before and after](https://raw.githubusercontent.com/adipose/mpc-hc/patch674-assets/pl-osd-before-after.png)

The combo box loses about 8 DLU of its 128 and the label is fully readable. The gap between label text and combo is 12px, the same spacing the existing code path produces whenever it tightens a pair.

English is unaffected: `leftWantsRight` for "Font:" falls short of the combo's template position, so `std::max` leaves it in place. Screenshots of the English page before and after the change are pixel-identical (same MD5), confirming the default path is untouched.

<details>
<summary>Full page, Polish, before and after</summary>

![before](https://raw.githubusercontent.com/adipose/mpc-hc/patch674-assets/pl-full-before.png)

![after](https://raw.githubusercontent.com/adipose/mpc-hc/patch674-assets/pl-full-after.png)

</details>

The second half of #4107 (Advanced page column widths) is not addressed here.
