### PR TITLE
Add a tooltip on the Color controls Open button

### DIFF
--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -4312,6 +4312,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_AG_COLOR_CONTROLS   "Color Controls"
+    IDC_COLOR_CONTROLS      "You can also open Color controls from the Play menu"
 END
 
 #endif    // English (United States) resources


### PR DESCRIPTION
Follow-up to #4087.

The `Open` button on the Miscellaneous options page is a new entry point to the Color controls dialog, so this adds a tooltip pointing users at the pre-existing one:

> You can also open Color controls from the Play menu

One-line `STRINGTABLE` addition — the page already calls `CreateToolTip()`, which attaches a tooltip to any control whose ID has a matching string resource, so no code changes are needed.

Note there is currently no default keyboard shortcut for `ID_COLOR_CONTROLS` (it is unbound in the hotkey table), so the tooltip mentions only the menu path.

## Test plan
- [x] Builds clean (x64 Debug)
- [x] Confirmed string resource 22103 resolves in the built binary to the expected text, which is what `CreateToolTip()`'s `LoadString(GetDlgCtrlID())` looks up