### PR TITLE
Fix truncated values in the advanced options list

### DIFF
--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -78,7 +78,7 @@ BOOL CPPageAdvanced::OnInitDialog()
 
     InitSettings();
 
-    m_list.SetColumnWidth(COL_VALUE, LVSCW_AUTOSIZE_USEHEADER);
+    AutoSizeValueColumn();
     m_list.SetColumnWidth(COL_NAME, LVSCW_AUTOSIZE_USEHEADER);
     m_list.SetColumnWidth(COL_DUMMYCOL, 0);
 
@@ -218,6 +218,88 @@ void CPPageAdvanced::InitSettings()
     addBoolItem(CRASHREPORTER, IDS_RS_ENABLE_CRASH_REPORTER, true, s.bEnableCrashReporter, StrRes(IDS_PPAGEADVANCED_CRASHREPORTER));
 #endif
     addIntItem(LOGGING, IDS_RS_LOGGING, 0, s.DebugLogMask, std::make_pair(0, 31), /*StrRes(IDS_PPAGEADVANCED_LOGGER)*/ L"Enables logging to file (requires restart).\nThis option for debugging purposes only and should not be enabled during normal use!\nLogs are saved in folder: %appdata%\\MPC-HC\nValue to set is the sum of the loggers that you want to enable:\n1: General\n2: Graph builder\n4: Subtitle search\n8: yt-dlp processing\n16: DVB scanning");
+}
+
+std::pair<CString, bool> CPPageAdvanced::GetWidestValue(const std::shared_ptr<SettingsBase>& pItem, CDC* pDC)
+{
+    // Every value the setting can display, paired with the flagged (bold) state it would be drawn in.
+    std::deque<std::pair<CString, bool>> candidates;
+
+    if (auto pItemBool = std::dynamic_pointer_cast<SettingsBool>(pItem)) {
+        candidates.emplace_back(m_strTrue, !pItemBool->GetDefaultValue());
+        candidates.emplace_back(m_strFalse, pItemBool->GetDefaultValue());
+    } else if (auto pItemCombo = std::dynamic_pointer_cast<SettingsCombo>(pItem)) {
+        int nValue = 0;
+        for (const auto& str : pItemCombo->GetList()) {
+            candidates.emplace_back(str, nValue != pItemCombo->GetDefaultValue());
+            nValue++;
+        }
+    } else if (auto pItemInt = std::dynamic_pointer_cast<SettingsInt>(pItem)) {
+        const auto& range = pItemInt->GetRange();
+        CString str;
+        for (const auto& nValue : { range.first, range.second }) {
+            str.Format(_T("%d"), nValue);
+            candidates.emplace_back(str, nValue != pItemInt->GetDefaultValue());
+        }
+    } else if (auto pItemCString = std::dynamic_pointer_cast<SettingsCString>(pItem)) {
+        // Free text, so only the current value is knowable.
+        candidates.emplace_back(pItemCString->GetValue(), !pItemCString->IsDefault());
+    } else {
+        UNREACHABLE_CODE();
+    }
+
+    CFont* pNormalFont = m_list.GetFont();
+    std::pair<CString, bool> widest(_T(""), false);
+    int nMaxWidth = -1;
+    for (const auto& candidate : candidates) {
+        CFont* pFont = (candidate.second && m_fontBold.m_hObject) ? &m_fontBold : pNormalFont;
+        CFont* pOldFont = pFont ? pDC->SelectObject(pFont) : nullptr;
+        const int nWidth = pDC->GetTextExtent(candidate.first).cx;
+        if (pOldFont) {
+            pDC->SelectObject(pOldFont);
+        }
+        if (nWidth > nMaxWidth) {
+            nMaxWidth = nWidth;
+            widest = candidate;
+        }
+    }
+
+    return widest;
+}
+
+// The value column is sized once, to the widest value any setting can ever display, so that
+// changing a value during the session neither truncates it nor resizes the column. The list
+// control does the measuring itself (it reports the flagged/bold font through the custom draw
+// win32 runs for auto-size), which keeps the padding exact.
+void CPPageAdvanced::AutoSizeValueColumn()
+{
+    const int nCount = m_list.GetItemCount();
+    std::vector<std::pair<CString, bool>> savedValues(nCount);
+    CClientDC dc(&m_list);
+
+    m_list.SetRedraw(FALSE);
+
+    for (int i = 0; i < nCount; i++) {
+        if (IsHeaderRow(i)) {
+            continue;
+        }
+        auto eSetting = static_cast<ADVANCED_SETTINGS>(m_list.GetItemData(i));
+        savedValues[i] = std::make_pair(m_list.GetItemText(i, COL_VALUE), m_list.getFlaggedItem(i));
+        const auto widest = GetWidestValue(m_hiddenOptions.at(eSetting), &dc);
+        m_list.setItemTextWithDefaultFlag(i, COL_VALUE, widest.first, widest.second);
+    }
+
+    m_list.SetColumnWidth(COL_VALUE, LVSCW_AUTOSIZE_USEHEADER);
+    const int nWidth = m_list.GetColumnWidth(COL_VALUE);
+
+    for (int i = 0; i < nCount; i++) {
+        if (!IsHeaderRow(i)) {
+            m_list.setItemTextWithDefaultFlag(i, COL_VALUE, savedValues[i].first, savedValues[i].second);
+        }
+    }
+
+    m_list.SetColumnWidth(COL_VALUE, nWidth);
+    m_list.SetRedraw(TRUE);
 }
 
 BOOL CPPageAdvanced::OnApply()
@@ -371,8 +453,8 @@ void CPPageAdvanced::OnNMCustomdraw(NMHDR* pNMHDR, LRESULT* pResult)
                     ::SelectObject(pLVCD->nmcd.hdc, m_fontBold.GetSafeHandle());
                     *pResult |= CDRF_NEWFONT;
                 } else {
-                    auto eSetting = static_cast<ADVANCED_SETTINGS>(m_list.GetItemData(iItem));
-                    if (!IsDefault(eSetting)) {
+                    // the flagged state, not IsDefault(), so that auto-size measures the font the value will be drawn in
+                    if (m_list.getFlaggedItem(iItem)) {
                         ::SelectObject(pLVCD->nmcd.hdc, m_fontBold.GetSafeHandle());
                         *pResult |= CDRF_NEWFONT;
                     } else {
@@ -591,4 +673,5 @@ void CPPageAdvanced::DoDPIChanged()
     }
     initBoldFont();
     m_list.DoDPIChanged(); //themed listctrl stores its own font, and isn't drawn through CPPageAdvanced::OnNMCustomdraw
+    AutoSizeValueColumn(); //the widest value is measured in pixels, so it must be recalculated
 }

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <map>
 #include <deque>
+#include <vector>
 #include "CMPCThemeComboBox.h"
 #include "CMPCThemeSpinButtonCtrl.h"
 #include "CMPCThemePlayerListCtrl.h"
@@ -81,6 +82,9 @@ public:
     bool GetValue() const {
         return currentValue;
     }
+    bool GetDefaultValue() const {
+        return defaultValue;
+    }
     void Apply() {
         settingReference = currentValue;
     }
@@ -116,6 +120,9 @@ public:
     }
     int GetValue() const {
         return currentValue;
+    }
+    int GetDefaultValue() const {
+        return defaultValue;
     }
     void Apply() {
         settingReference = currentValue;
@@ -269,6 +276,9 @@ private:
     CString m_strFalse;
 
     void InitSettings();
+    // The widest value the setting can ever display, and whether it would be drawn flagged (bold).
+    std::pair<CString, bool> GetWidestValue(const std::shared_ptr<SettingsBase>& pItem, CDC* pDC);
+    void AutoSizeValueColumn();
     bool IsDefault(ADVANCED_SETTINGS) const;
     inline bool IsHeaderRow(int iItem) const {
         return m_list.GetItemData(iItem) == HEADER_ITEM_DATA;


### PR DESCRIPTION
Fixes the second half of #4107: values in the Advanced options list are truncated with an ellipsis.

### Cause

`CPPageAdvanced::OnInitDialog` sized the Value column once, right after `InitSettings()`. `LVSCW_AUTOSIZE_USEHEADER` on that column resolves to the *content* width (the header text is far narrower), so the column locked to the widest value that happened to be present at that instant. Any later `setItemTextWithDefaultFlag` — a combo pick, a typed string, a bool toggle — can produce a wider string, and nothing ever resized the column, so it ellipsised until Options was reopened.

Measured at 96 DPI: Polish opens with `StartupPreset` = `Zapamiętaj ostatni` and the column locks at 98px; selecting `Widok niestandardowy` needs 108px, so it clips. Reopening Options resizes to 140px and the text is fine again, which is why the truncation looks intermittent.

This is not really a localization bug. English escapes only by luck of short strings (widest reachable value `Remember last` = 70px against an 82px column). Free-text `CString` settings are empty at init, contribute nothing to the initial sizing, and truncate the same way in English as soon as the user types a value into one.

### Change

The column is now sized once, at init, to the widest value it can *ever* need, so it never resizes during a session.

`GetWidestValue()` enumerates the reachable values per settings type — `m_strTrue`/`m_strFalse`, every `GetList()` entry, both `GetRange()` bounds formatted exactly as `addIntItem` does, and for `SettingsCString` the current value, since free text has no bound. Each candidate is measured in the font it would actually be drawn in: non-default rows render in `m_fontBold`, so a bold candidate can outweigh a longer normal one.

Rather than hardcoding a padding constant, the control does the measuring: each row's value is temporarily set to its widest candidate with the matching flag, the existing autosize runs once, the resulting width is captured, every row is restored, and the captured width is applied explicitly.

`OnNMCustomdraw` now selects the bold font from the row's flagged state rather than `IsDefault()`. comctl32 performs a custom-draw pass during auto-size to pick up font changes, and during the measuring pass the setting is still at its default while the displayed candidate is a bold one — keying off `IsDefault()` would undercount. The two are kept in sync by `setItemTextWithDefaultFlag`, so normal rendering is unchanged; the themed path already used the flag.

`DoDPIChanged()` recomputes, since these are pixel measurements.

### Result

Polish, before and after — same in-session change to `Widok niestandardowy`:

![before](https://raw.githubusercontent.com/adipose/mpc-hc/patch675-assets/pl-before.png)

![after](https://raw.githubusercontent.com/adipose/mpc-hc/patch675-assets/pl-after.png)

Polish goes 98px → 140px and stays there when the value changes. English goes 82px → 92px.

<details>
<summary>English after the change</summary>

![english](https://raw.githubusercontent.com/adipose/mpc-hc/patch675-assets/en-after.png)

</details>

Checked the widest reachable value across all 44 languages (measured in each language's own dialog font, bold): the worst cases are Romanian `Vizualizează setările personalizate` at 188px and German `Fenster-Profil: Benutzerdefiniert` at 183px, against a median of 104px. Those give a Value column of roughly 220px next to the 213px Name column, which still fits the list without a horizontal scrollbar.

Verified in modern dark and classic themes. The `DoDPIChanged` path was not exercised.
