### PR TITLE
Fix cramped Japanese Color Controls dialog

### DIFF
--- a/src/mpc-hc/mpcresources/cfg/mpc-hc.ja.cfg
+++ b/src/mpc-hc/mpcresources/cfg/mpc-hc.ja.cfg
@@ -5,4 +5,4 @@ langDefine: LANG_JAPANESE, SUBLANG_DEFAULT
 langDefineMFC: AFX_TARG_JPN
 langID: 1041
 fileDesc: Japanese language resource for MPC-HC
-font: FONT 9, "MS UI Gothic", 400, 0, 0x1
+font: FONT 9, "Segoe UI", 400, 0, 0x1


### PR DESCRIPTION
## Summary

Fixes #4112. The Color Controls dialog rendered visibly shorter and cramped when the app language was set to Japanese, with the Reset/Close buttons flush against the bottom edge. Several other dialogs were affected the same way.

Dialog templates are authored in dialog units, which Windows resolves to pixels using the metrics of the font declared for that localized resource. `mpc-hc.ja.cfg` declared `FONT 9, "MS UI Gothic"` — a Windows 2000/XP-era font whose metrics are narrower than the Segoe UI the templates were laid out against, so every Japanese dialog that follows the `.rc` font came out undersized.

- `src/mpc-hc/mpcresources/cfg/mpc-hc.ja.cfg`: `FONT 9, "MS UI Gothic"` → `FONT 9, "Segoe UI"`

### Why Japanese was the last one on a legacy font

Not a deliberate choice — it simply never matched a bulk edit. Before 2019, 41 of 43 language configs shared one generic `FONT 8, "MS Shell Dlg"` line. #164 replaced all 41 of those with `FONT 9, "Segoe UI"` in a single sweep. Only two configs had a language-specific font and so fell outside it: `ja` (`MS UI Gothic`) and `zh_CN` (`Tahoma`). `zh_CN` was later given a deliberate modern choice in #656. `ja` has not been touched since 2013.

Segoe UI has no CJK coverage, so Japanese text renders via Windows font-linking — same as Korean and Traditional Chinese already do. In practice the linked face is the same MS Gothic family that `MS UI Gothic` was using, so the kana/kanji are unchanged (see the 8× comparison below); only the Latin runs embedded in Japanese strings change, picking up real Segoe UI with ClearType instead of MS UI Gothic's monoline Latin.

## Test plan

Built the Japanese resource DLL both ways from the same tree and compared, with an English capture as reference (175% display DPI):

| Dialog | JA before | JA after | English |
|---|---|---|---|
| Color controls | 1000×342 | **1089×462** | 1089×462 |
| About | 739×605 | **804×837** | 804×837 |
| Open (media/URL) | 739×366 | **804×495** | 804×495 |
| Command line help | 874×529 | **951×728** | 951×728 |

Exact parity with English in every case, no clipping, truncation or overlap anywhere in the "after" set.

The Options property sheet is unaffected either way — all 12 pages are pixel-identical between the two builds, because `CPropertyPage::PreProcessPageTemplate` rewrites each page template's font to the sheet's font before creation, so the per-language `.rc` `FONT` line cannot reach them.

### Screenshots

Color controls — the reported bug:

![Color controls](https://raw.githubusercontent.com/adipose/mpc-hc/pr4113-assets/CMP-colorcontrols-3up.png)

Command line help — before, the line spacing was tight enough to slice the bottom row:

![Command line help](https://raw.githubusercontent.com/adipose/mpc-hc/pr4113-assets/CMP-cmdline-3up.png)

About:

![About](https://raw.githubusercontent.com/adipose/mpc-hc/pr4113-assets/CMP-about-3up.png)

Open media:

![Open media](https://raw.githubusercontent.com/adipose/mpc-hc/pr4113-assets/CMP-openmedia-3up.png)

Japanese glyphs at 8×, confirming font-linking resolves to the same face and the kanji are unchanged:

![Glyph comparison](https://raw.githubusercontent.com/adipose/mpc-hc/pr4113-assets/zoom-about-kanji.png)