### PR TITLE
Fix default button and focus rectangle rendering in modern themes

### DIFF
--- a/src/mpc-hc/CMPCThemeButton.cpp
+++ b/src/mpc-hc/CMPCThemeButton.cpp
@@ -19,7 +19,16 @@ BEGIN_MESSAGE_MAP(CMPCThemeButton, CButton)
     ON_WM_GETFONT()
     ON_NOTIFY_REFLECT(NM_CUSTOMDRAW, &CMPCThemeButton::OnNMCustomdraw)
     ON_MESSAGE(BCM_SETSHIELD, &setShieldIcon)
+    ON_WM_UPDATEUISTATE()
 END_MESSAGE_MAP()
+
+void CMPCThemeButton::OnUpdateUIState(UINT nAction, UINT nUIElement)
+{
+    if (nUIElement & (UISF_HIDEACCEL | UISF_HIDEFOCUS)) {
+        Invalidate(); //we draw the accel and focus indicators ourselves, so repaint when windows toggles them
+    }
+    return __super::OnUpdateUIState(nAction, nUIElement);
+}
 
 LRESULT CMPCThemeButton::setShieldIcon(WPARAM wParam, LPARAM lParam)
 {
@@ -27,7 +36,7 @@ LRESULT CMPCThemeButton::setShieldIcon(WPARAM wParam, LPARAM lParam)
     return Default(); //pass it along so the native button draws the shield when we don't paint it ourselves
 }
 
-void CMPCThemeButton::drawButtonBase(CDC* pDC, CRect rect, CString strText, bool selected, bool highLighted, bool focused, bool disabled, bool thin, bool shield, HWND accelWindow)
+void CMPCThemeButton::drawButtonBase(CDC* pDC, CRect rect, CString strText, bool selected, bool highLighted, bool focused, bool isDefault, bool disabled, bool thin, bool shield, HWND accelWindow)
 {
     CBrush fb, fb2;
     fb.CreateSolidBrush(CMPCTheme::ButtonBorderOuterColor);
@@ -46,7 +55,7 @@ void CMPCThemeButton::drawButtonBase(CDC* pDC, CRect rect, CString strText, bool
         fb2.CreateSolidBrush(CMPCTheme::ButtonBorderInnerColor);
         bg = CMPCTheme::ButtonFillHoverColor;
         dottedClr = CMPCTheme::ButtonBorderHoverKBFocusColor;
-    } else if (focused) {
+    } else if (focused || isDefault) {
         fb2.CreateSolidBrush(CMPCTheme::ButtonBorderInnerFocusedColor);
     } else {
         fb2.CreateSolidBrush(CMPCTheme::ButtonBorderInnerColor);
@@ -114,9 +123,15 @@ void CMPCThemeButton::drawButton(HDC hdc, CRect rect, UINT state)
     CString strText;
     GetWindowText(strText);
     bool selected = CDIS_SELECTED == (state & CDIS_SELECTED);
-    bool focused = CDIS_FOCUS == (state & CDIS_FOCUS);
+    //comctl32 still reports CDIS_FOCUS while the ui state asks for focus indicators to be hidden,
+    //so query it ourselves or we draw the dotted rect where native draws none.
+    bool focused = CDIS_FOCUS == (state & CDIS_FOCUS) && (::SendMessage(m_hWnd, WM_QUERYUISTATE, 0, 0) & UISF_HIDEFOCUS) == 0;
     bool disabled = CDIS_DISABLED == (state & CDIS_DISABLED);
     bool hot = CDIS_HOT == (state & CDIS_HOT);
+    //comctl32 never actually sets CDIS_DEFAULT in the custom draw notification for push buttons
+    //(confirmed: state came back 0 for the property sheet's OK button even though its window
+    //style has BS_DEFPUSHBUTTON set), so the default-button state has to be read from the style bit.
+    bool isDefault = BS_DEFPUSHBUTTON == (GetStyle() & BS_DEFPUSHBUTTON);
 
     BUTTON_IMAGELIST imgList;
     GetImageList(&imgList);
@@ -125,7 +140,7 @@ void CMPCThemeButton::drawButton(HDC hdc, CRect rect, UINT state)
     bool thin = true;
 
 
-    drawButtonBase(pDC, rect, strText, selected, hot, focused, disabled, thin, drawShield, m_hWnd);
+    drawButtonBase(pDC, rect, strText, selected, hot, focused, isDefault, disabled, thin, drawShield, m_hWnd);
 
     int imageIndex = 0; //Normal
     if (disabled) {

--- a/src/mpc-hc/CMPCThemeButton.h
+++ b/src/mpc-hc/CMPCThemeButton.h
@@ -10,10 +10,11 @@ public:
     CMPCThemeButton();
     virtual ~CMPCThemeButton();
     LRESULT setShieldIcon(WPARAM wParam, LPARAM lParam);
-    static void drawButtonBase(CDC* pDC, CRect rect, CString strText, bool selected, bool highLighted, bool focused, bool disabled, bool thin, bool shield, HWND accelWindow=nullptr);
+    static void drawButtonBase(CDC* pDC, CRect rect, CString strText, bool selected, bool highLighted, bool focused, bool isDefault, bool disabled, bool thin, bool shield, HWND accelWindow=nullptr);
     DECLARE_DYNAMIC(CMPCThemeButton)
     DECLARE_MESSAGE_MAP()
     afx_msg void OnNMCustomdraw(NMHDR* pNMHDR, LRESULT* pResult);
+    afx_msg void OnUpdateUIState(UINT nAction, UINT nUIElement);
     afx_msg void OnSetFont(CFont* pFont, BOOL bRedraw);
     afx_msg HFONT OnGetFont();
 };

--- a/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
+++ b/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
@@ -63,7 +63,9 @@ void CMPCThemeRadioOrCheck::OnPaint()
         COLORREF oldTextColor = dc.GetTextColor();
 
         bool isDisabled = !IsWindowEnabled();
-        bool isFocused = (GetFocus() == this);
+        //windows hides focus indicators until the user navigates by keyboard, and native drawing honors
+        //that ui state.  match it, or we draw a focus rect where classic/light draw none.
+        bool isFocused = (GetFocus() == this) && (::SendMessage(m_hWnd, WM_QUERYUISTATE, 0, 0) & UISF_HIDEFOCUS) == 0;
 
         LRESULT checkState = SendMessage(BM_GETCHECK);
 
@@ -74,7 +76,7 @@ void CMPCThemeRadioOrCheck::OnPaint()
         if (0 != (buttonStyle & BS_PUSHLIKE)) {
             CFont* oFont, *font = GetFont();
             oFont = dc.SelectObject(font);
-            CMPCThemeButton::drawButtonBase(&dc, rectItem, sTitle, checkState != BST_UNCHECKED, isHover, isFocused, checkState == BST_INDETERMINATE, false, false, m_hWnd);
+            CMPCThemeButton::drawButtonBase(&dc, rectItem, sTitle, checkState != BST_UNCHECKED, isHover, isFocused, false, checkState == BST_INDETERMINATE, false, false, m_hWnd);
             dc.SelectObject(oFont);
         } else {
             CRect rectCheck;
@@ -159,6 +161,15 @@ void CMPCThemeRadioOrCheck::OnPaint()
                     cb.Detach();
                 }
 
+                if (isFocused) { //drawn before the text like drawButtonBase does: the halftone brush is
+                                 //opaque, so framing over the glyphs would erase the pixels it runs across
+                    dc.SetTextColor(CMPCTheme::ButtonBorderKBFocusColor); //no example of this in explorer, but white seems too harsh
+                    CBrush* dotted = dc.GetHalftoneBrush();
+                    dc.FrameRect(focusRect, dotted);
+                    DeleteObject(dotted);
+                }
+
+                int nMode = dc.SetBkMode(TRANSPARENT); //keep the text from filling over the focus rect
                 if (isDisabled) {
                     dc.SetTextColor(CMPCTheme::ButtonDisabledFGColor);
                     dc.DrawTextW(sTitle, -1, &rectItem, uFormat); // DT_NOPREFIX not needed
@@ -166,14 +177,8 @@ void CMPCThemeRadioOrCheck::OnPaint()
                     dc.SetTextColor(CMPCTheme::TextFGColor);
                     dc.DrawTextW(sTitle, -1, &rectItem, uFormat); // DT_NOPREFIX not needed
                 }
+                dc.SetBkMode(nMode);
                 dc.SelectObject(pOldFont);
-
-                if (isFocused) {
-                    dc.SetTextColor(CMPCTheme::ButtonBorderKBFocusColor); //no example of this in explorer, but white seems too harsh
-                    CBrush* dotted = dc.GetHalftoneBrush();
-                    dc.FrameRect(focusRect, dotted);
-                    DeleteObject(dotted);
-                }
 
             }
         }
@@ -272,7 +277,7 @@ BOOL CMPCThemeRadioOrCheck::OnEraseBkgnd(CDC* pDC)
 
 
 void CMPCThemeRadioOrCheck::OnUpdateUIState(UINT nAction, UINT nUIElement) {
-    if (nUIElement & UISF_HIDEACCEL) {
+    if (nUIElement & (UISF_HIDEACCEL | UISF_HIDEFOCUS)) {
         Invalidate();
     }
     return __super::OnUpdateUIState(nAction, nUIElement);

--- a/src/mpc-hc/WinHotkeyCtrl.cpp
+++ b/src/mpc-hc/WinHotkeyCtrl.cpp
@@ -150,7 +150,7 @@ void CWinHotkeyCtrl::DrawButton(CRect rectButton)
         bool selected = GetButtonThemeState() == PBS_PRESSED;
         bool highlighted = GetButtonThemeState() == PBS_HOT;
         CFont* pOldFont = dc.SelectObject(GetFont());
-        CMPCThemeButton::drawButtonBase(&dc, rectButton, GetButtonText(), selected, highlighted, false, disabled, true, false);
+        CMPCThemeButton::drawButtonBase(&dc, rectButton, GetButtonText(), selected, highlighted, false, false, disabled, true, false);
         dc.SelectObject(pOldFont);
     } else {
         __super::DrawButton(rectButton);


### PR DESCRIPTION
Fixes #4114.

Three related rendering problems in the modern theme, all in the owner-drawn control paths. Classic and light render these controls natively (`drawThemedControls` is only set in the dark branch of `InitializeColors`), so none of this is visible there — dark is the only mode that goes through this code.

### Default push button had no highlight

`CMPCThemeButton::drawButton` never checked whether the button was the dialog's default, so in dark theme OK rendered identically to Cancel and there was no way to tell which one Enter would activate.

`CDIS_DEFAULT` looks like the obvious source for that state, but comctl32 does not actually deliver it: `uItemState` comes back `0` for the property sheet's OK button even though its window style has `BS_DEFPUSHBUTTON` set. The style bit is read directly instead.

![default push button, before and after](https://raw.githubusercontent.com/adipose/mpc-hc/pr4116-assets/bug1_default_button.png)

### Focus rectangle erased the text it framed

The dotted focus rectangle is drawn with `FrameRect` and `GetHalftoneBrush()`. That brush is opaque, so the pattern's off-pixels repaint whatever they cross in the background colour. Because the rectangle was drawn *after* the label, it erased glyph pixels wherever it ran over them — which is the "cut off" appearance in the report: the bottom edge sits on the descender row, so the tails of g/y/p lost pixels, and the left and right edges ate into the first and last glyphs.

The fix is ordering, matching what `drawButtonBase` already does: draw the focus rectangle first, then the text over it, with the text draw made transparent so it does not fill back over the rectangle.

The geometry itself was already correct and is unchanged. Measured against classic as the reference, the existing rectangle matches native on the top, bottom and right edges, so adding padding to "uncramp" it would move it *away* from native.

![focus rectangle over descenders, zoomed](https://raw.githubusercontent.com/adipose/mpc-hc/pr4116-assets/bug2_focus_rect.png)

### Focus rectangle shown where native shows none

Windows hides focus indicators until the user navigates by keyboard (`UISF_HIDEFOCUS`), and native drawing honours that. The themed paths did not, so dark theme drew a focus rectangle after a plain mouse click where classic and light draw nothing.

`CMPCThemeRadioOrCheck` and `CMPCThemeButton` now both query the UI state, and both invalidate on the flag transition so the indicator appears and disappears at the right moment. comctl32 still reports `CDIS_FOCUS` while `UISF_HIDEFOCUS` is set, so the button needed the explicit query too.

![focus indicator hidden until keyboard navigation](https://raw.githubusercontent.com/adipose/mpc-hc/pr4116-assets/bug3_hidefocus.png)

`WinHotkeyCtrl.cpp` is touched only to pass the new argument.

### Testing

Verified by pixel-sampling the captures rather than by eye. Dark OK border is now `(255,255,255)` against Cancel/Apply at `(155,155,155)`; glyph erosion under the focus rectangle went from 9 pixels to 0 with the rectangle's geometry unchanged; and with `UISF_HIDEFOCUS` set neither control draws focus dots.

Captures are `PrintWindow`-based, which exercises the paint logic and the state reads but is not the same as a live keyboard pass, so a manual Tab/Alt check is still worth doing.
