### PR TITLE
Fix missing Open dialog icon when a translation is active

### DIFF
--- a/src/mpc-hc/DpiAwareResizableDialog.cpp
+++ b/src/mpc-hc/DpiAwareResizableDialog.cpp
@@ -717,7 +717,7 @@ void CDpiAwareResizableDialog::LoadStaticIcon(int controlID, LPCTSTR iconResourc
     int iconSize = std::min(controlRect.Width(), controlRect.Height());
 
     HICON hIcon = nullptr;
-    HINSTANCE hInst = isSystemIcon ? nullptr : AfxGetResourceHandle();
+    HINSTANCE hInst = isSystemIcon ? nullptr : AfxGetInstanceHandle();
 
     if (SUCCEEDED(LoadIconWithScaleDown(hInst, iconResourceID, iconSize, iconSize, &hIcon))) {
         pStatic->SetIcon(hIcon);
@@ -744,7 +744,7 @@ void CDpiAwareResizableDialog::RefreshStaticImages()
 
         HICON hOldIcon = pStatic->GetIcon();
         HICON hIcon = nullptr;
-        HINSTANCE hInst = info.isSystemIcon ? nullptr : AfxGetResourceHandle();
+        HINSTANCE hInst = info.isSystemIcon ? nullptr : AfxGetInstanceHandle();
 
         if (SUCCEEDED(LoadIconWithScaleDown(hInst, info.resourceID, iconSize, iconSize, &hIcon))) {
             pStatic->SetIcon(hIcon);


### PR DESCRIPTION
## Summary
Fixes #4118 — the MPC-HC icon in the Open dialog is blank whenever a UI translation is active.

`COpenDlg` loads its icon via `CDpiAwareResizableDialog::LoadStaticIcon(IDR_MAINFRAME, ...)`, which resolved the icon's module handle with `AfxGetResourceHandle()`. That call returns whatever module MFC currently treats as the resource module, and `Translations.cpp` points it at the loaded satellite language DLL while a translation is active. `IDR_MAINFRAME`'s icon only exists in the main executable, not in the language DLL, so the load silently failed and the static control was left blank.

`CAboutDlg` already works around the identical situation for the same `IDR_MAINFRAME` icon by using `AfxGetInstanceHandle()` (the stable main-exe module handle) instead — this applies the same fix to `LoadStaticIcon`/`RefreshStaticImages`, the two places in `CDpiAwareResizableDialog` that resolve a non-system icon's module handle.

## Test plan
- [x] Built x64 Debug, clean compile
- [x] English (no translation): icon renders correctly
- [x] French translation active: icon renders correctly (previously blank)
- [x] Confirmed regression by temporarily reverting the fix under French: icon reproduces as blank, matching the reported bug