### PR TITLE
Fix panel autohiding while its context menu is open (#4117)

### DIFF
--- a/src/mpc-hc/PlayerBar.cpp
+++ b/src/mpc-hc/PlayerBar.cpp
@@ -197,3 +197,8 @@ bool CPlayerBar::HasActivePopup() const
 {
     return m_bHasActivePopup;
 }
+
+void CPlayerBar::SetHasActivePopup(bool bValue)
+{
+    m_bHasActivePopup = bValue;
+}

--- a/src/mpc-hc/PlayerBar.h
+++ b/src/mpc-hc/PlayerBar.h
@@ -64,4 +64,5 @@ public:
 
     bool IsAutohidden() const;
     bool HasActivePopup() const;
+    void SetHasActivePopup(bool bValue);
 };

--- a/src/mpc-hc/PlayerNavigationDialog.cpp
+++ b/src/mpc-hc/PlayerNavigationDialog.cpp
@@ -20,6 +20,7 @@
 
 #include "stdafx.h"
 #include "PlayerNavigationDialog.h"
+#include "PlayerBar.h"
 #include "DSUtil.h"
 #include "mplayerc.h"
 #include "MainFrm.h"
@@ -259,7 +260,16 @@ void CPlayerNavigationDialog::OnContextMenu(CWnd* pWnd, CPoint point)
     if (AppNeedsThemedControls()) {
         m.fulfillThemeReqs();
     }
+    //this dialog is the menu owner, which bypasses CPlayerBar::OnEnterMenuLoop,
+    //so we set the flag on the owning bar directly to keep it from autohiding
+    CPlayerBar* pBar = DYNAMIC_DOWNCAST(CPlayerBar, GetParent());
+    if (pBar) {
+        pBar->SetHasActivePopup(true);
+    }
     int nID = (int)m.TrackPopupMenu(TPM_LEFTBUTTON | TPM_RETURNCMD, point.x, point.y, this);
+    if (pBar) {
+        pBar->SetHasActivePopup(false);
+    }
 
     try {
         switch (nID) {

--- a/src/mpc-hc/PlayerPlaylistBar.cpp
+++ b/src/mpc-hc/PlayerPlaylistBar.cpp
@@ -2592,11 +2592,11 @@ void CPlayerPlaylistBar::OnContextMenu(CWnd* /*pWnd*/, CPoint point)
         m.fulfillThemeReqs();
     }
 
-    m_bHasActivePopup = true;
+    SetHasActivePopup(true);
     //use mainframe as parent to take advantage of measure redirect (was 'this' but text was not printed)
-    //adipose: note this will bypass CPlayerBar::OnEnterMenuLoop, so we set m_bHasActivePopup directly here
+    //adipose: note this will bypass CPlayerBar::OnEnterMenuLoop, so we set the flag directly here
     int nID = (int)m.TrackPopupMenu(TPM_LEFTBUTTON | TPM_RETURNCMD, point.x, point.y, m_pMainFrame);
-    m_bHasActivePopup = false;
+    SetHasActivePopup(false);
     m_list.SetFocus();
     switch (nID) {
         case M_OPEN:

--- a/src/mpc-hc/PlayerSubresyncBar.cpp
+++ b/src/mpc-hc/PlayerSubresyncBar.cpp
@@ -1085,7 +1085,11 @@ void CPlayerSubresyncBar::OnRclickList(NMHDR* pNMHDR, LRESULT* pResult)
         if (AppNeedsThemedControls()) {
             m.fulfillThemeReqs();
         }
+        SetHasActivePopup(true);
+        //mainframe is the menu owner, so it receives WM_ENTERMENULOOP instead of us,
+        //bypassing CPlayerBar::OnEnterMenuLoop; set the flag directly to avoid autohiding
         UINT id = m.TrackPopupMenu(TPM_LEFTBUTTON | TPM_RETURNCMD, p.x, p.y, m_pMainFrame);
+        SetHasActivePopup(false);
 
         bool bNeedsUpdate = false;
 


### PR DESCRIPTION
Fixes #4117.

### Cause

`CMainFrameControls::UpdateToolbarsVisibility()` suppresses autohide while `CPlayerBar::HasActivePopup()` is true, but that flag is only set from `CPlayerBar::OnEnterMenuLoop`. Windows sends `WM_ENTERMENULOOP` solely to the window passed as the *owner* argument of `TrackPopupMenu`, and two bars pass something other than themselves:

- `CPlayerSubresyncBar::OnRclickList` passes `m_pMainFrame`
- `CPlayerNavigationDialog::OnContextMenu` passes `this` (the child dialog)

So the bar's handler never ran, `m_bHasActivePopup` stayed false, and the panel autohid out from under the open menu.

The playlist bar had the same bug and was fixed in 5ca3b735e4 by setting the flag manually around the call; subresync and navigation were missed.

### Change

Neither `TrackPopupMenu` owner argument is changed — the owner also receives `WM_MEASUREITEM`/`WM_DRAWITEM` for the owner-drawn themed menus, so repointing it would break menu rendering (the reason the playlist bar deliberately uses the main frame).

Instead `CPlayerBar` gains a public `SetHasActivePopup(bool)`, used around the menu in both affected places. The navigation dialog is not a `CPlayerBar`, so it reaches its owning bar via `DYNAMIC_DOWNCAST(CPlayerBar, GetParent())`, null-checked, and clears the flag immediately after `TrackPopupMenu` returns — before the existing `try` block, so no exception or early return can leave it stuck true.

The playlist bar's two existing direct writes are converted to the same setter so all sites use one idiom. That also removes a reliance on `m_bHasActivePopup` being reachable only by accident: it sits in the private section, but `DECLARE_DYNAMIC` expands to something beginning with `public:` and never restores private, so the members below it are silently public.

### Testing

Verified with an external probe: the right-click puts the app in a modal menu loop, so the bar is measured from another process while the menu is open, and an autohidden bar is detected by `IsWindowVisible` going false.

Against a build from before this change, Subresync **collapsed** ~2.4s after the menu opened (matching the configured hide delay); with the change it stayed up for the full ~6.8s sample window. The playlist bar passed on both, as expected given it was already fixed. Each run asserted that a popup menu window actually appeared, so a mis-aimed click cannot be mistaken for a pass.

The navigation panel path is not covered by that run — it needs `PM_DIGITAL_CAPTURE`, so it rests on code inspection plus the shared code path the other two exercise.
