### PR TITLE
Sanitize external text used in menu labels (#4130)

### DIFF
--- a/src/DSUtil/text.cpp
+++ b/src/DSUtil/text.cpp
@@ -221,6 +221,56 @@ CStringW ShortenURL(const CStringW url, int targetLength, bool returnHostnameIfT
     return t;
 }
 
+static CStringW SanitizeMenuLabelPart(const CStringW& text, int maxChars)
+{
+    CStringW label;
+    for (int i = 0; i < text.GetLength(); i++) {
+        const wchar_t c = text[i];
+        // A tab starts the right-aligned accelerator column of a menu item, so
+        // a label carrying one would render as two columns; nothing else below
+        // the space is printable there either.
+        label += (c < L' ' || c == 0x7F) ? L' ' : c;
+    }
+    label.Trim();
+
+    if (maxChars > 0 && label.GetLength() > maxChars) {
+        int cut = maxChars - 1; // the ellipsis takes the last character
+        if (cut > 0 && label[cut - 1] >= 0xD800 && label[cut - 1] <= 0xDBFF) {
+            cut--; // never leave half of a surrogate pair behind
+        }
+        label = label.Left(cut);
+        label.TrimRight();
+        label += L'\x2026';
+    }
+
+    // last, so that the escaping is not what the length was spent on
+    label.Replace(L"&", L"&&");
+    return label;
+}
+
+CStringW SanitizeMenuLabel(const CStringW& text, int maxChars, bool allowColumn)
+{
+    CStringW label;
+
+    const int tab = allowColumn ? text.Find(L'\t') : -1;
+    if (tab >= 0) {
+        // The caller composed its own right-aligned column, so keep the first
+        // tab, but only that one: the text cannot manufacture a column of its
+        // own. The right half is our own short text, so it is not truncated.
+        label = SanitizeMenuLabelPart(text.Left(tab), maxChars);
+        label += L'\t';
+        label += SanitizeMenuLabelPart(text.Mid(tab + 1), 0);
+    } else {
+        label = SanitizeMenuLabelPart(text, maxChars);
+    }
+
+    if (label.IsEmpty()) {
+        label = L" "; // a zero-length label gives the item nothing to measure
+    }
+
+    return label;
+}
+
 CString ExtractTag(CString tag, CMapStringToString& attribs, bool& fClosing)
 {
     tag.Trim();

--- a/src/DSUtil/text.h
+++ b/src/DSUtil/text.h
@@ -190,6 +190,27 @@ extern CStringA UrlDecode(const CStringA& strIn);
 extern CStringW UrlDecodeWithUTF8(const CStringW in, bool keepEncodedSpecialChar = false);
 extern CStringW URLGetHostName(const CStringW in);
 extern CStringW ShortenURL(const CStringW url, int targetLength = 100, bool returnHostnameIfTooLong = false);
+// How much of an externally supplied name (a track title, a disc label, a
+// channel name, ...) a menu item shows. Long enough for any real name, short
+// enough to bound a pathological one.
+#define MENU_NAME_MAX 256
+// Makes an arbitrary, possibly untrusted string safe to use as the label of a
+// menu item. What it guarantees:
+//   - every '&' is escaped to "&&", so the text cannot silently claim a
+//     mnemonic (or lose a character to one);
+//   - tabs, which would otherwise split the label into a right-aligned
+//     accelerator column, and every other control character are replaced by a
+//     space, and leading and trailing whitespace is dropped;
+//   - the result is at most maxChars characters, truncated with a trailing
+//     ellipsis and never in the middle of a surrogate pair;
+//   - the result is never empty, so a menu item always has something to
+//     measure.
+// The length is counted before the escaping, so the label is as long as it
+// looks. maxChars <= 0 means no truncation, and it defaults to MENU_NAME_MAX.
+// With allowColumn the first tab is kept, so that a caller composing its own
+// right-aligned column keeps it: both halves are sanitized separately, any
+// further tab still becomes a space, and only the left half is truncated.
+extern CStringW SanitizeMenuLabel(const CStringW& text, int maxChars = MENU_NAME_MAX, bool allowColumn = false);
 extern CStringA HtmlSpecialChars(CStringA str, bool bQuotes = false);
 extern CStringA HtmlSpecialCharsDecode(CStringA str);
 extern DWORD CharSetToCodePage(DWORD dwCharSet);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -3877,6 +3877,8 @@ void CMainFrame::OnInitMenuPopup(CMenu* pPopupMenu, UINT nIndex, BOOL bSysMenu) 
     if (!AppIsThemeLoaded()) { //themed menus draw accelerators already, no need to append
         for (UINT i = 0; i < uiMenuCount; ++i) {
             UINT nID = pPopupMenu->GetMenuItemID(i);
+            //the dynamically named items not listed here (filters, shader presets, favorite discs, optical drives)
+            //have no accelerator, so the key.IsEmpty() && k < 0 test below already skips them
             if (nID == ID_SEPARATOR || nID == -1
                 || nID >= ID_FAVORITES_FILE_START && nID <= ID_FAVORITES_FILE_END
                 || nID >= ID_RECENT_FILE_START && nID <= ID_RECENT_FILE_END
@@ -3940,7 +3942,7 @@ void CMainFrame::OnInitMenuPopup(CMenu* pPopupMenu, UINT nIndex, BOOL bSysMenu) 
         INT_PTR i = 0, j = s.m_pnspresets.GetCount();
         for (; i < j; i++) {
             int k = 0;
-            CString label = s.m_pnspresets[i].Tokenize(_T(","), k);
+            CString label = SanitizeMenuLabel(s.m_pnspresets[i].Tokenize(_T(","), k));
             VERIFY(pPopupMenu->InsertMenu(ID_VIEW_RESET, MF_BYCOMMAND, ID_PANNSCAN_PRESETS_START + i, label));
             CMPCThemeMenu::fulfillThemeReqsItem(pPopupMenu, (UINT)(ID_PANNSCAN_PRESETS_START + i), true);
         }
@@ -10462,6 +10464,7 @@ void CMainFrame::OnPlayFiltersCopyToClipboard()
     for (int i = 2, count = m_filtersMenu.GetMenuItemCount(); i < count; i++) {
         CString filterName;
         m_filtersMenu.GetMenuString(i, filterName, MF_BYPOSITION);
+        filterName.Replace(_T("&&"), _T("&")); //the label is escaped for the menu, this list is plain text
         filtersList.AppendFormat(_T("  - %s\r\n"), filterName.GetString());
     }
 
@@ -17384,7 +17387,7 @@ void CMainFrame::SetupOpenCDSubMenu()
             }
 
             CString str;
-            str.Format(_T("%s (%c:)"), label.GetString(), drive);
+            str.Format(_T("%s (%c:)"), SanitizeMenuLabel(label).GetString(), drive);
 
             VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, str));
         }
@@ -17406,10 +17409,7 @@ void CMainFrame::SetupFiltersSubMenu()
         UINT idl = ID_FILTERSTREAMS_SUBITEM_START;
 
         BeginEnumFilters(m_pGB, pEF, pBF) {
-            CString filterName(GetFilterName(pBF));
-            if (filterName.GetLength() >= 43) {
-                filterName = filterName.Left(40) + _T("...");
-            }
+            CString filterName(SanitizeMenuLabel(GetFilterName(pBF), 43));
 
             CLSID clsid = GetCLSID(pBF);
             if (clsid == CLSID_AVIDec) {
@@ -17466,8 +17466,7 @@ void CMainFrame::SetupFiltersSubMenu()
             nPPages++;
 
             BeginEnumPins(pBF, pEP, pPin) {
-                CString pinName = GetPinName(pPin);
-                pinName.Replace(_T("&"), _T("&&"));
+                CString pinName = SanitizeMenuLabel(GetPinName(pPin));
 
                 if (pSPP = pPin) {
                     CAUUID caGUID;
@@ -17534,8 +17533,7 @@ void CMainFrame::SetupFiltersSubMenu()
                         streamName.LoadString(IDS_AG_UNKNOWN_STREAM);
                         streamName.AppendFormat(_T(" %lu"), i + 1);
                     } else {
-                        streamName = wname;
-                        streamName.Replace(_T("&"), _T("&&"));
+                        streamName = SanitizeMenuLabel(wname);
                         CoTaskMemFree(wname);
                     }
 
@@ -17679,8 +17677,7 @@ void CMainFrame::SetupAudioSubMenu()
                 iSel = i;
             }
 
-            CString name(pName);
-            name.Replace(_T("&"), _T("&&"));
+            CString name(SanitizeMenuLabel(pName));
 
             VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, name));
 
@@ -17841,20 +17838,20 @@ void CMainFrame::SetupSubtitlesSubMenu()
                         iSelected = i;
                     }
 
-                    CString name(pszName);
+                    //a tab in a name coming from the splitter is part of the name, not a column
+                    CString name = SanitizeMenuLabel(CString(pszName));
                     /*
                     CString lcname = CString(name).MakeLower();
                     if (lcname.Find(_T(" off")) >= 0) {
                         name.LoadString(IDS_AG_DISABLED);
                     }
                     */
-                    if (lcid != 0 && name.Find(L'\t') < 0) {
+                    if (lcid != 0) {
                         CString lcidstr;
                         GetLocaleString(lcid, LOCALE_SENGLANGUAGE, lcidstr);
                         name.Append(_T("\t") + lcidstr);
                     }
 
-                    name.Replace(_T("&"), _T("&&"));
                     VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, name));
                     i++;
                 }
@@ -17879,7 +17876,7 @@ void CMainFrame::SetupSubtitlesSubMenu()
                             name.Append(_T("\t") + lcidstr);
                         }
 
-                        name.Replace(_T("&"), _T("&&"));
+                        name = SanitizeMenuLabel(name, MENU_NAME_MAX, true);
                         VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, name));
                     } else {
                         VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, id++, ResStr(IDS_AG_UNKNOWN_STREAM)));
@@ -18018,8 +18015,7 @@ void CMainFrame::SetupSecondarySubtitleSubMenu()
         CComHeapPtr<WCHAR> pName;
         CString name;
         if (SUCCEEDED(subInput.pSubStream->GetStreamInfo(0, &pName, nullptr)) && pName) {
-            name = pName;
-            name.Replace(_T("&"), _T("&&"));
+            name = SanitizeMenuLabel(CString(pName), MENU_NAME_MAX, true);
         } else {
             name.LoadString(IDS_AG_UNKNOWN_STREAM);
         }
@@ -18138,7 +18134,7 @@ void CMainFrame::SetupJumpToSubMenus(CMenu* parentMenu /*= nullptr*/, int iInser
                     idSelected = id;
                 }
 
-                name.Replace(_T("&"), _T("&&"));
+                name = SanitizeMenuLabel(name);
                 VERIFY(m_BDPlaylistMenu.AppendMenu(flags, id++, name + '\t' + time));
             }
             menuEndRadioSection(m_BDPlaylistMenu);
@@ -18159,9 +18155,7 @@ void CMainFrame::SetupJumpToSubMenus(CMenu* parentMenu /*= nullptr*/, int iInser
 
                 CString time = _T("[") + ReftimeToString2(rt) + _T("]");
 
-                CString name = CString(bstr);
-                name.Replace(_T("&"), _T("&&"));
-                name.Replace(_T("\t"), _T(" "));
+                CString name = SanitizeMenuLabel(CString(bstr));
 
                 UINT flags = MF_BYCOMMAND | MF_STRING | MF_ENABLED;
                 if (i == j) {
@@ -18183,8 +18177,7 @@ void CMainFrame::SetupJumpToSubMenus(CMenu* parentMenu /*= nullptr*/, int iInser
                     idSelected = id;
                 }
                 CPlaylistItem& pli = m_wndPlaylistBar.m_pl.GetNext(pos);
-                CString name = pli.GetLabel();
-                name.Replace(_T("&"), _T("&&"));
+                CString name = SanitizeMenuLabel(pli.GetLabel());
                 VERIFY(m_playlistMenu.AppendMenu(flags, id++, name));
             }
             menuEndRadioSection(m_playlistMenu);
@@ -18243,7 +18236,7 @@ void CMainFrame::SetupJumpToSubMenus(CMenu* parentMenu /*= nullptr*/, int iInser
             if (channel.GetPrefNumber() == s.nDVBLastChannel) {
                 idSelected = id;
             }
-            VERIFY(m_channelsMenu.AppendMenu(flags, ID_NAVIGATE_JUMPTO_SUBITEM_START + channel.GetPrefNumber(), channel.GetName()));
+            VERIFY(m_channelsMenu.AppendMenu(flags, ID_NAVIGATE_JUMPTO_SUBITEM_START + channel.GetPrefNumber(), SanitizeMenuLabel(channel.GetName())));
             id++;
         }
         menuEndRadioSection(m_channelsMenu);
@@ -18277,14 +18270,15 @@ DWORD CMainFrame::SetupNavStreamSelectSubMenu(CMenu& subMenu, UINT id, DWORD dwS
                 continue;
             }
 
-            CString name(pszName);
+            //a tab in a name coming from the splitter is part of the name, not a column
+            CString name = SanitizeMenuLabel(CString(pszName));
             /*
             CString lcname = CString(name).MakeLower();
             if (dwGroup == 2 && lcname.Find(_T(" off")) >= 0) {
                 name.LoadString(IDS_AG_DISABLED);
             }
             */
-            if (dwGroup == 2 && lcid != 0 && name.Find(L'\t') < 0) {
+            if (dwGroup == 2 && lcid != 0) {
                 CString lcidstr;
                 GetLocaleString(lcid, LOCALE_SENGLANGUAGE, lcidstr);
                 name.Append(_T("\t") + lcidstr);
@@ -18304,7 +18298,6 @@ DWORD CMainFrame::SetupNavStreamSelectSubMenu(CMenu& subMenu, UINT id, DWORD dwS
             }
             bAdded = true;
 
-            name.Replace(_T("&"), _T("&&"));
             VERIFY(subMenu.AppendMenu(flags, id++, name));
         }
 
@@ -18547,7 +18540,7 @@ void CMainFrame::SetupRecentFilesSubMenu()
                         p.Format(_T("%s~~~%s"), static_cast<LPCWSTR>(p.Left(60)), static_cast<LPCWSTR>(p.Right(87)));
                     }
                 }
-                p.Replace(_T("&"), _T("&&"));
+                p = SanitizeMenuLabel(p, 0); //already shortened above, in a way that keeps the extension visible
                 VERIFY(subMenu.AppendMenu(flags, id, p));
             } else {
                 ASSERT(false);
@@ -18578,13 +18571,14 @@ void CMainFrame::SetupFavoritesSubMenu()
         UINT flags = MF_BYCOMMAND | MF_STRING | MF_ENABLED;
 
         CString f_str = favs.GetNext(pos);
-        f_str.Replace(_T("&"), _T("&&"));
-        f_str.Replace(_T("\t"), _T(" "));
 
         FileFavorite ff;
-        VERIFY(FileFavorite::TryParse(f_str, ff));
+        VERIFY(FileFavorite::TryParse(f_str, ff)); //parse before sanitizing, the escaping is not part of the format
 
         f_str = ff.Name;
+        if (!f_str.IsEmpty()) {
+            f_str = SanitizeMenuLabel(f_str);
+        }
 
         CString str = ff.ToString();
         if (!str.IsEmpty()) {
@@ -18615,7 +18609,6 @@ void CMainFrame::SetupFavoritesSubMenu()
         UINT flags = MF_BYCOMMAND | MF_STRING | MF_ENABLED;
 
         CString str = favs.GetNext(pos);
-        str.Replace(_T("&"), _T("&&"));
 
         CAtlList<CString> sl;
         ExplodeEsc(str, sl, _T(';'), 2);
@@ -18627,7 +18620,7 @@ void CMainFrame::SetupFavoritesSubMenu()
         }
 
         if (!str.IsEmpty()) {
-            VERIFY(subMenu.AppendMenu(flags, id, str));
+            VERIFY(subMenu.AppendMenu(flags, id, SanitizeMenuLabel(str)));
         }
 
         id++;
@@ -18651,7 +18644,6 @@ void CMainFrame::SetupFavoritesSubMenu()
         UINT flags = MF_BYCOMMAND | MF_STRING | MF_ENABLED;
 
         CString str = favs.GetNext(pos);
-        str.Replace(_T("&"), _T("&&"));
 
         CAtlList<CString> sl;
         ExplodeEsc(str, sl, _T(';'), 2);
@@ -18659,7 +18651,7 @@ void CMainFrame::SetupFavoritesSubMenu()
         str = sl.RemoveHead();
 
         if (!str.IsEmpty()) {
-            VERIFY(subMenu.AppendMenu(flags, id, str));
+            VERIFY(subMenu.AppendMenu(flags, id, SanitizeMenuLabel(str)));
         }
 
         id++;
@@ -18699,7 +18691,7 @@ bool CMainFrame::SetupShadersSubMenu()
                 ASSERT(FALSE);
                 break;
             }
-            VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, nID, pair.first));
+            VERIFY(subMenu.AppendMenu(MF_STRING | MF_ENABLED, nID, SanitizeMenuLabel(pair.first)));
             if (selected && pair.first == current) {
                 VERIFY(subMenu.CheckMenuRadioItem(nID, nID, nID, MF_BYCOMMAND));
                 selected = false;
@@ -24314,7 +24306,7 @@ CHdmvClipInfo::BDMVMeta CMainFrame::GetBDMVMeta()
 
 BOOL CMainFrame::AppendMenuEx(CMenu& menu, UINT nFlags, UINT nIDNewItem, CString& text)
 {
-    text.Replace(_T("&"), _T("&&"));
+    text = SanitizeMenuLabel(text);
     auto bResult = menu.AppendMenu(nFlags, nIDNewItem, text.GetString());
     if (bResult && (nFlags & MF_DEFAULT)) {
         bResult = menu.SetDefaultItem(nIDNewItem);

--- a/src/mpc-hc/PlayerSubresyncBar.cpp
+++ b/src/mpc-hc/PlayerSubresyncBar.cpp
@@ -997,8 +997,8 @@ void CPlayerSubresyncBar::OnRclickList(NMHDR* pNMHDR, LRESULT* pResult)
                         CString key;
                         STSStyle* val;
                         m_sts.m_styles.GetNextAssoc(pos, key, val);
-                        stylesNames.Add(key);
-                        m.AppendMenu(MF_STRING | MF_ENABLED, id++, key);
+                        stylesNames.Add(key); //the array keeps the real key, only the label is sanitized
+                        m.AppendMenu(MF_STRING | MF_ENABLED, id++, SanitizeMenuLabel(key));
                     }
 
                     if (id > STYLEFIRST && m_list.GetSelectedCount() == 1) {
@@ -1042,9 +1042,9 @@ void CPlayerSubresyncBar::OnRclickList(NMHDR* pNMHDR, LRESULT* pResult)
                             void* val;
                             actormap.GetNextAssoc(pos, key, val);
 
-                            actors.Add(key);
+                            actors.Add(key); //the array keeps the real key, only the label is sanitized
 
-                            m.AppendMenu(MF_STRING | MF_ENABLED, id++, key);
+                            m.AppendMenu(MF_STRING | MF_ENABLED, id++, SanitizeMenuLabel(key));
                         }
                     }
                 }
@@ -1070,9 +1070,9 @@ void CPlayerSubresyncBar::OnRclickList(NMHDR* pNMHDR, LRESULT* pResult)
                             void* val;
                             effectmap.GetNextAssoc(pos, key, val);
 
-                            effects.Add(key);
+                            effects.Add(key); //the array keeps the real key, only the label is sanitized
 
-                            m.AppendMenu(MF_STRING | MF_ENABLED, id++, key);
+                            m.AppendMenu(MF_STRING | MF_ENABLED, id++, SanitizeMenuLabel(key));
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #4130.

Text that comes from media files, discs, broadcast streams and the filesystem was going into `AppendMenu`/`InsertMenu` unescaped. In a Win32 menu string `&` introduces a mnemonic, so a track named `English & Commentary` renders as `English _Commentary` and silently steals a mnemonic from the surrounding menu; `\t` splits the label into the right-aligned column; control characters render as garbage; and nothing bounded the length. The modern themes reproduce all of this faithfully — `CMPCThemeMenu::DrawItem` calls `DrawTextW` without `DT_NOPREFIX`.

The escaping was already about 80% done, but by hand: fourteen separate `Replace(_T("&"), _T("&&"))` calls, plus one helper that two call sites used. The sites that were broken were simply the ones nobody had happened to hit.

### One shared helper

`SanitizeMenuLabel` in `src/DSUtil/text.h`, alongside `ShortenURL` and `HtmlSpecialChars`. It escapes `&`, maps tabs and other control characters to a space, trims, truncates on a character boundary without splitting a surrogate pair, and never returns empty. The length is counted *before* the escaping, so the label is as long as it looks and a truncation can never split a `&&` pair.

The hand-rolled `Replace` calls are gone; twenty call sites now go through it, including the ones that had no escaping at all: DVB channel names, disc volume labels, filter names, shader and Pan&Scan preset names, and the ASS/SSA style, actor and effect names in the subresync bar.

### The tab needs care, so this is not a blanket wrap

`\t` is load-bearing — it is the only mechanism a menu item has for a right-hand column, and both the classic and themed renderers read it from the same caption. So the helper is applied to the *name component before composition*, which is what the favourites and chapter menus already did correctly, and what the rest now do too.

Where the column is genuinely ours, `allowColumn` keeps the first tab, sanitises each half separately and drops any further tab, so the text cannot manufacture a column of its own. That matters for `CRenderedTextSubtitle::GetStreamInfo`, which deliberately returns `name\tlanguage`.

Where the name comes from `IAMStreamSelect` it is treated as untrusted throughout: the old `name.Find(L'\t') < 0` guard was assuming that a tab in a splitter-supplied name meant "this already has a language column", so a track name containing a tab could suppress the real language and claim to be any language it liked. Those names now have their tabs neutralised and always get our own language column. This is the case @clsid2 raised on the issue — a title or description can contain a tab that is not a column separator. MPC-HC's own `IAMStreamSelect` implementation, `CStreamSwitcherFilter`, builds its name from a file name or URL and never emits a tab, so nothing legitimate is lost.

### Length

Nothing capped a splitter-supplied track name, so a multi-kilobyte track title produced a menu wider than the screen. `MENU_NAME_MAX` is 256 — deliberately generous, so that no real name is shortened and only the pathological case is bounded. The two sites that already had a limit keep theirs: filters at 43, and recent files keep their existing 150-character composition, including the `~~~` middle-ellipsis that keeps the file extension visible.

### Screenshots

Favorites is a good probe: it is driven entirely by settings and it composes its own right-aligned column, so it has the same shape as the track menus. With three deliberately hostile favourite names — `Dan & Mary's TV`, `Spoof<TAB>English`, and `Bell<BEL>Ring`:

![menu labels in all three themes](https://raw.githubusercontent.com/adipose/mpc-hc/pr-menu-sanitize-assets/fav-themes.png)

The ampersand survives as one literal `&` without underlining the `M`; the position column still lines up; `Spoof<TAB>English` renders on one line with no second column claiming to be a language; and the control character is gone. A 300-character name (not shown — it makes the capture ~2800px wide) is cut at 256 with a single-character ellipsis.

### Notes

* `OnPlayFiltersCopyToClipboard` reads the filter labels back out of the menu to build the "Filters currently loaded" clipboard dump. Filter names were previously unescaped, so that text was clean; it now unescapes on the way out to keep it that way.
* Truncation of filter names moved from `>= 43` to `> 43`, so a name of exactly 43 characters now survives whole.
* `SetupSubtitleStreams` also uses tab presence to mean "language known", but for track *selection* rather than display, so it inherits the same assumption on the `IAMStreamSelect` side. Left alone here deliberately — changing it would change which subtitle gets picked, which does not belong in a rendering fix.
* The static mnemonic collisions mentioned in the issue are not part of this; per the discussion there they are not worth churning the resources over.
