### PR TITLE
Fix focus rectangles accumulating on themed checkboxes and radio buttons

### DIFF
--- a/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
+++ b/src/mpc-hc/CMPCThemeRadioOrCheck.cpp
@@ -153,7 +153,8 @@ void CMPCThemeRadioOrCheck::OnPaint()
 
                 CRect focusRect = rectItem;
                 focusRect.InflateRect(0, 0);
-                if (buttonStyle & BS_MULTILINE) { //needed to clear old select for multi-line
+                { //clears the previous focus rect: the text is drawn transparently, and focus changes
+                  //repaint us without an erase, so nothing else wipes it
                     HBRUSH hb = CMPCThemeUtil::getParentDialogBGClr(this, &dc);
                     CBrush cb;
                     cb.Attach(hb);


### PR DESCRIPTION
In the modern dark theme, focus rectangles on themed checkboxes and radio buttons are never erased. Every TAB press and every click leaves the previous control's rectangle behind, so after navigating a few controls the Options dialog shows several "focused" controls at once.

![before and after](https://raw.githubusercontent.com/adipose/mpc-hc/patch685-assets/pr-focusrect.png)

### Cause

A regression from #4116. That change draws the focus rect before the label and switches the text to `TRANSPARENT` so the text does not paint over it:

```cpp
int nMode = dc.SetBkMode(TRANSPARENT); //keep the text from filling over the focus rect
```

The previously opaque text draw was also the only thing erasing the *previous* focus rect. comctl32 repaints the button on focus change with `bErase = FALSE`, so `OnEraseBkgnd` does not run and nothing wipes the old frame.

The explicit clear added in #2509 was only applied for `BS_MULTILINE`, which is why the multi-line radio buttons on the same page are unaffected and every stale rectangle is on a single-line checkbox.

### Fix

Make that clear unconditional, so the previous focus rect is erased on every paint now that the transparent text no longer does it incidentally.

### Testing

Options -> Player -> General, dark theme, four TAB presses: five focus rectangles before, one after. Light theme is unaffected (native button painting) and verified unchanged. Multi-line radio buttons behave as before.

Reported at https://github.com/adipose/mpc-hc/issues/93 (items 2, 3 and 4). Items 1 and 5 of that report are not addressed here.