### PR TITLE
Fix web interface returning 404 during startup

### DIFF
--- a/src/mpc-hc/WebServer.cpp
+++ b/src/mpc-hc/WebServer.cpp
@@ -40,6 +40,11 @@ CWebServer::CWebServer(CMainFrame* pMainFrame, int nPort)
     : m_pMainFrame(pMainFrame)
     , m_nPort(nPort)
 {
+    // Populate the route tables before the server thread below starts accepting requests,
+    // otherwise every request is answered with 404. Init() used to run at the end of
+    // InitInstance, long after CMainFrame::OnCreate had already started the server.
+    Init();
+
     m_webroot = CPath(PathUtils::GetProgramPath());
     const CAppSettings& s = AfxGetAppSettings();
 

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -2321,8 +2321,6 @@ BOOL CMPlayerCApp::InitInstance()
 
     m_mutexOneInstance.Release();
 
-    CWebServer::Init();
-
     if (m_s->fAssociatedWithIcons) {
         m_s->fileAssoc.CheckIconsAssoc();
     }


### PR DESCRIPTION
The web server starts listening in CMainFrame::OnCreate, but its static route tables (m_internalpages, m_downloads, m_mimes) were only populated by CWebServer::Init() at the very end of InitInstance. Any request arriving in that window was answered with 404.

Normally the window is short, but the first-run update prompt (raised from UpdateChecker::IsAutoUpdateEnabled before Init() runs) makes it unbounded: the modal pumps messages, so the player is fully alive and the server is accepting connections, yet every route 404s until someone answers the dialog. On an unattended launch that is forever. This is a second consequence of the same modal that caused #3989, and the old placement was also a data race (the main thread wrote the CAtlStringMaps while the server thread could already be reading them).

Fix: call Init() at the top of the CWebServer constructor, before its worker thread is created, so the tables are always populated before the socket can accept anything, and remove the late call in InitInstance. Init() has no dependencies and is idempotent, so being invoked again on a server restart from the options page is harmless.

Verified with a fresh portable ini (EnableWebServer=1, no UpdaterAutoCheck): with the first-run prompt on screen, curl 127.0.0.1:13579/status.json now returns the full status JSON; before this change it returned 404 until the prompt was answered. The prompt itself is unchanged and still persists its answer.