### PR TITLE
Fix ATSC channel scanning: RF channel plan, virtual channel numbers, VCT flags, E-AC-3

### DIFF
--- a/src/DSUtil/Mpeg2Def.h
+++ b/src/DSUtil/Mpeg2Def.h
@@ -67,6 +67,7 @@ enum PES_STREAM_TYPE {
     AUDIO_STREAM_AC3_PLUS               = 0x84,
     AUDIO_STREAM_DTS_HD                 = 0x85,
     AUDIO_STREAM_DTS_HD_MASTER_AUDIO    = 0x86,
+    AUDIO_STREAM_EAC3_ATSC              = 0x87, // ATSC A/53 E-AC-3. The values above are Blu-ray registrations; ATSC signals E-AC-3 with its own stream type, not with 0x84
     PRESENTATION_GRAPHICS_STREAM        = 0x90,
     INTERACTIVE_GRAPHICS_STREAM         = 0x91,
     SUBTITLE_STREAM                     = 0x92,

--- a/src/mpc-hc/DVBChannel.cpp
+++ b/src/mpc-hc/DVBChannel.cpp
@@ -96,6 +96,10 @@ void CBDAChannel::FromString(CString strValue)
         m_nVideoHeight = _tstol(strValue.Tokenize(_T("|"), i));
         m_nVideoAR     = (BDA_AspectRatio_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
     }
+    if (nVersion > FORMAT_VERSION_6) {
+        m_nATSCMajor = _tstol(strValue.Tokenize(_T("|"), i));
+        m_nATSCMinor = _tstol(strValue.Tokenize(_T("|"), i));
+    }
 }
 
 CString CBDAChannel::ToString() const
@@ -145,6 +149,10 @@ CString CBDAChannel::ToString() const
                           m_nVideoWidth,
                           m_nVideoHeight,
                           m_nVideoAR);
+
+    strValue.AppendFormat(_T("|%d|%d"),
+                          m_nATSCMajor,
+                          m_nATSCMinor);
 
     return strValue;
 }

--- a/src/mpc-hc/DVBChannel.h
+++ b/src/mpc-hc/DVBChannel.h
@@ -29,7 +29,8 @@
 #define FORMAT_VERSION_3       3
 #define FORMAT_VERSION_4       4
 #define FORMAT_VERSION_5       5
-#define FORMAT_VERSION_CURRENT 6
+#define FORMAT_VERSION_6       6
+#define FORMAT_VERSION_CURRENT 7
 
 #define BDA_MAX_AUDIO    10
 #define BDA_MAX_SUBTITLE 10
@@ -123,6 +124,13 @@ public:
     ULONG GetSymbolRate() const { return m_ulSymbolRate; }
     int GetPrefNumber() const { return m_nPrefNumber; };
     int GetOriginNumber() const { return m_nOriginNumber; };
+    // ATSC identifies a service by a two-part virtual channel number carried in
+    // the VCT, which is independent of the RF channel it arrives on. Both parts
+    // are zero for DVB, where the logical channel number in m_nOriginNumber is
+    // the equivalent concept.
+    int GetATSCMajor() const { return m_nATSCMajor; };
+    int GetATSCMinor() const { return m_nATSCMinor; };
+    bool HasATSCNumber() const { return m_nATSCMajor != 0; };
     ULONG GetONID() const { return m_ulONID; };
     ULONG GetTSID() const { return m_ulTSID; };
     ULONG GetSID() const { return m_ulSID; };
@@ -160,6 +168,15 @@ public:
     void SetSymbolRate(ULONG ulSymbolRate) { m_ulSymbolRate = ulSymbolRate; }
     void SetPrefNumber(int Value) { m_nPrefNumber = Value; };
     void SetOriginNumber(int Value) { m_nOriginNumber = Value; };
+    // Also derives m_nOriginNumber, so that everything already keying off the
+    // logical channel number - sorting in the scan dialog, the channel list -
+    // orders ATSC services correctly without needing to know about ATSC.
+    // 9.1 < 9.2 < 9.91 < 10.1 < 50.1 holds under this encoding.
+    void SetATSCNumber(int nMajor, int nMinor) {
+        m_nATSCMajor = nMajor;
+        m_nATSCMinor = nMinor;
+        m_nOriginNumber = nMajor * 1000 + nMinor;
+    };
     void SetEncrypted(bool Value) { m_bEncrypted = Value; };
     void SetNowNextFlag(bool Value) { m_bNowNextFlag = Value; };
     void SetONID(ULONG Value) { m_ulONID = Value; };
@@ -196,6 +213,8 @@ private:
     ULONG m_ulSymbolRate            = 0;
     int m_nPrefNumber               = 0;
     int m_nOriginNumber             = 0;
+    int m_nATSCMajor                = 0;
+    int m_nATSCMinor                = 0;
     bool m_bEncrypted               = false;
     bool m_bNowNextFlag             = false;
     ULONG m_ulONID                  = 0;

--- a/src/mpc-hc/FGManagerBDA.cpp
+++ b/src/mpc-hc/FGManagerBDA.cpp
@@ -701,6 +701,12 @@ STDMETHODIMP CFGManagerBDA::SetAudio(int nAudioIndex)
     return E_NOTIMPL;
 }
 
+STDMETHODIMP CFGManagerBDA::IsATSC(bool& bIsATSC)
+{
+    bIsATSC = tunerIsATSC;
+    return S_OK;
+}
+
 STDMETHODIMP CFGManagerBDA::SetFrequency(ULONG ulFrequency, ULONG ulBandwidth, ULONG ulSymbolRate)
 {
     HRESULT hr;

--- a/src/mpc-hc/FGManagerBDA.h
+++ b/src/mpc-hc/FGManagerBDA.h
@@ -124,6 +124,7 @@ public:
     STDMETHODIMP SetFrequency(ULONG ulFrequency, ULONG ulBandwidth, ULONG ulSymbolRate);
     STDMETHODIMP Scan(ULONG ulFrequency, ULONG ulBandwidth, ULONG ulSymbolRate, HWND hWnd);
     STDMETHODIMP GetStats(BOOLEAN& bPresent, BOOLEAN& bLocked, LONG& lDbStrength, LONG& lPercentQuality);
+    STDMETHODIMP IsATSC(bool& bIsATSC);
 
     // IAMStreamSelect
     STDMETHODIMP Count(DWORD* pcStreams);

--- a/src/mpc-hc/IGraphBuilder2.h
+++ b/src/mpc-hc/IGraphBuilder2.h
@@ -58,4 +58,7 @@ interface __declspec(uuid("546E72B3-66A1-4A58-A99B-56530B3E2FFF"))
     STDMETHOD(Scan)(ULONG ulFrequency, ULONG ulBandwidth, ULONG ulSymbolRate, HWND hWnd) PURE;
     STDMETHOD(GetStats)(BOOLEAN& bPresent, BOOLEAN& bLocked, LONG& lDbStrength, LONG& lPercentQuality) PURE;
     STDMETHOD(UpdatePSI)(const class CBDAChannel* pChannel, struct EventDescriptor& NowNext) PURE;
+    // ATSC and DVB differ in how their RF channels are laid out, so a scan has
+    // to know which it is dealing with rather than assuming a uniform raster.
+    STDMETHOD(IsATSC)(bool& bIsATSC) PURE;
 };

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -17247,6 +17247,51 @@ bool CMainFrame::SearchInDir(bool bDirForward, bool bLoop /*= false*/)
     return true;
 }
 
+static const int ATSC_FIRST_CHANNEL            = 2;
+static const int ATSC_FIRST_UHF_CHANNEL        = 14;
+static const int ATSC_LAST_UHF_CHANNEL         = 51;
+static const int ATSC_RADIO_ASTRONOMY_CHANNEL  = 37;
+
+// Centre frequency in kHz of a US ATSC terrestrial RF channel, or false if the
+// channel number is not one that carries a broadcast.
+//
+// The plan is deliberately a lookup rather than arithmetic, because it is not a
+// uniform raster. Stepping by bandwidth - which is what a DVB scan does, and
+// what this scan used to do for every standard - is correct only within a band:
+// there is a 10 MHz step between channels 4 and 5, the FM broadcast band sits
+// between 6 and 7, and 260 MHz separate 13 from 14. A 6 MHz sweep therefore
+// lands off-channel from channel 5 onwards and wastes some forty tuning
+// attempts crossing the gap below UHF.
+static bool GetATSCChannelFrequency(int nChannel, ULONG& ulFrequency)
+{
+    // VHF low (2-6) and VHF high (7-13) are irregular and are listed out.
+    static const struct { int nChannel; ULONG ulFrequency; } VHFChannels[] = {
+        {  2,  57000 }, {  3,  63000 }, {  4,  69000 },
+        {  5,  79000 }, {  6,  85000 },
+        {  7, 177000 }, {  8, 183000 }, {  9, 189000 }, { 10, 195000 },
+        { 11, 201000 }, { 12, 207000 }, { 13, 213000 },
+    };
+
+    for (const auto& channel : VHFChannels) {
+        if (channel.nChannel == nChannel) {
+            ulFrequency = channel.ulFrequency;
+            return true;
+        }
+    }
+
+    // UHF is a regular 6 MHz raster starting at channel 14 on 473 MHz.
+    // Channel 37 is reserved worldwide for radio astronomy and never carries a
+    // broadcast, so receivers skip it. Above channel 36 the band was reassigned
+    // to mobile use by the 2017 repack, but older recordings may still sit
+    // there, so the plan runs to channel 51.
+    if (nChannel >= ATSC_FIRST_UHF_CHANNEL && nChannel <= ATSC_LAST_UHF_CHANNEL && nChannel != ATSC_RADIO_ASTRONOMY_CHANNEL) {
+        ulFrequency = 473000 + (nChannel - ATSC_FIRST_UHF_CHANNEL) * 6000;
+        return true;
+    }
+
+    return false;
+}
+
 void CMainFrame::DoTunerScan(TunerScanData* pTSD)
 {
     if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
@@ -17268,7 +17313,32 @@ void CMainFrame::DoTunerScan(TunerScanData* pTSD)
             m_bStopTunerScan = false;
             pTun->Scan(0, 0, 0, NULL);  // Clear maps
 
-            for (ULONG ulFrequency = pTSD->FrequencyStart; ulFrequency <= pTSD->FrequencyStop; ulFrequency += pTSD->Bandwidth) {
+            // Work out which frequencies to visit before tuning any of them.
+            // For ATSC these come from the RF channel plan, because its
+            // channels are not evenly spaced; for DVB the historical fixed step
+            // by bandwidth is correct. The start and stop frequencies bound the
+            // scan either way, so the dialog keeps working unchanged.
+            bool bIsATSC = false;
+            pTun->IsATSC(bIsATSC);
+
+            std::vector<ULONG> frequencies;
+            if (bIsATSC) {
+                for (int nChannel = ATSC_FIRST_CHANNEL; nChannel <= ATSC_LAST_UHF_CHANNEL; nChannel++) {
+                    ULONG ulChannelFrequency;
+                    if (GetATSCChannelFrequency(nChannel, ulChannelFrequency)
+                            && ulChannelFrequency >= pTSD->FrequencyStart
+                            && ulChannelFrequency <= pTSD->FrequencyStop) {
+                        frequencies.push_back(ulChannelFrequency);
+                    }
+                }
+            } else {
+                for (ULONG ulFrequency = pTSD->FrequencyStart; ulFrequency <= pTSD->FrequencyStop; ulFrequency += pTSD->Bandwidth) {
+                    frequencies.push_back(ulFrequency);
+                }
+            }
+
+            for (size_t nIndex = 0; nIndex < frequencies.size(); nIndex++) {
+                const ULONG ulFrequency = frequencies[nIndex];
                 bool bSucceeded = false;
                 for (int nOffsetPos = 0; nOffsetPos < nOffset && !bSucceeded; nOffsetPos++) {
                     if (SUCCEEDED(pTun->SetFrequency(ulFrequency + lOffsets[nOffsetPos], pTSD->Bandwidth, pTSD->SymbolRate))) {
@@ -17281,7 +17351,9 @@ void CMainFrame::DoTunerScan(TunerScanData* pTSD)
                     }
                 }
 
-                int nProgress = MulDiv(ulFrequency - pTSD->FrequencyStart, 100, pTSD->FrequencyStop - pTSD->FrequencyStart);
+                // Steps are uneven under a channel plan, so progress counts
+                // frequencies visited rather than distance travelled up the band.
+                int nProgress = MulDiv((int)nIndex + 1, 100, (int)frequencies.size());
                 ::SendMessage(pTSD->Hwnd, WM_TUNER_SCAN_PROGRESS, nProgress, 0);
                 ::SendMessage(pTSD->Hwnd, WM_TUNER_STATS, lDbStrength, lPercentQuality);
 

--- a/src/mpc-hc/Mpeg2SectionData.cpp
+++ b/src/mpc-hc/Mpeg2SectionData.cpp
@@ -237,6 +237,7 @@ BDA_STREAM_TYPE CMpeg2DataParser::ConvertToDVBType(PES_STREAM_TYPE nType)
         case AUDIO_STREAM_AC3:
             return BDA_AC3;
         case AUDIO_STREAM_AC3_PLUS:
+        case AUDIO_STREAM_EAC3_ATSC:
             return BDA_EAC3;
         case AUDIO_STREAM_AAC:
             return BDA_ADTS;

--- a/src/mpc-hc/Mpeg2SectionData.cpp
+++ b/src/mpc-hc/Mpeg2SectionData.cpp
@@ -434,8 +434,8 @@ HRESULT CMpeg2DataParser::ParseVCT(ULONG ulFrequency, ULONG ulBandwidth, ULONG u
         uint16_t channel_TSID=gb.BitRead(16); //channel_TSID
         uint16_t program_number=gb.BitRead(16); //program_number
         gb.BitRead(2); //ETM_location
-        gb.BitRead(1); //access_controlled
-        gb.BitRead(1); //hidden
+        uint8_t access_controlled = (uint8_t)gb.BitRead(1); //access_controlled
+        uint8_t hidden = (uint8_t)gb.BitRead(1); //hidden
         gb.BitRead(2); //TVCT: reserved(1), CVCT: path_select(1) / out_of_band(1)
         gb.BitRead(1); //hide_guide
         gb.BitRead(3); //reserved
@@ -457,15 +457,30 @@ HRESULT CMpeg2DataParser::ParseVCT(ULONG ulFrequency, ULONG ulBandwidth, ULONG u
         Channel.SetTSID(channel_TSID);
         Channel.SetONID(0); //ATSC doesn't apply
         Channel.SetSID(program_number);
+        // The virtual channel number is the identity a viewer knows a station
+        // by, and is what the scan list and channel ordering should key on.
+        // Without this every ATSC channel carries number 0 and the scan list is
+        // left in discovery order.
+        Channel.SetATSCNumber(major_channel_number, minor_channel_number);
+        // access_controlled is the ATSC equivalent of the DVB free_CA_mode
+        // flag; without it every ATSC service reports as unencrypted.
+        Channel.SetEncrypted(!!access_controlled);
 
         if (!Channels.Lookup(Channel.GetSID())) {
-            switch (serviceType) {
-            case ATSC_DIGITAL_TV:
-                Channels[Channel.GetSID()] = Channel;
-                break;
-            default:
-                BDA_LOG(_T("ATSC: Skipping not supported service: %-20s %lu"), Channel.GetName(), Channel.GetSID());
-                break;
+            if (hidden) {
+                // Not intended for viewers - typically test or data services.
+                // Receivers omit these, and so does the DVB path via the
+                // service descriptor.
+                BDA_LOG(_T("ATSC: Skipping hidden service: %-20s %lu"), Channel.GetName(), Channel.GetSID());
+            } else {
+                switch (serviceType) {
+                case ATSC_DIGITAL_TV:
+                    Channels[Channel.GetSID()] = Channel;
+                    break;
+                default:
+                    BDA_LOG(_T("ATSC: Skipping not supported service: %-20s %lu"), Channel.GetName(), Channel.GetSID());
+                    break;
+                }
             }
         }
     }

--- a/src/mpc-hc/TunerScanDlg.cpp
+++ b/src/mpc-hc/TunerScanDlg.cpp
@@ -244,7 +244,13 @@ LRESULT CTunerScanDlg::OnNewChannel(WPARAM wParam, LPARAM lParam)
                 nItem = m_ChannelList.GetItemCount();
             }
 
-            strTemp.Format(_T("%d"), nChannelNumber);
+            if (channel.HasATSCNumber()) {
+                // ATSC numbers are two-part and are what a viewer recognises,
+                // so show 9.1 rather than the 9001 used internally to order them.
+                strTemp.Format(_T("%d.%d"), channel.GetATSCMajor(), channel.GetATSCMinor());
+            } else {
+                strTemp.Format(_T("%d"), nChannelNumber);
+            }
             nItem = m_ChannelList.InsertItem(nItem, strTemp);
 
             m_ChannelList.SetItemData(nItem, channel.GetOriginNumber());


### PR DESCRIPTION
Four problems, all specific to ATSC.

**The scan assumed the band is a uniform raster.** `DoTunerScan` stepped from the
start frequency by the bandwidth, which is correct for DVB-T and coincidentally
correct for ATSC above channel 14. The US plan is not uniform below that: 10 MHz
separates channels 4 and 5, the FM broadcast band sits between 6 and 7, and
260 MHz between 13 and 14.

The effect was worse than being off-channel in VHF. Because 473000 is not on the
6 MHz grid measured from a VHF start (473000 - 57000 = 416000, which is not a
multiple of 6000), the misalignment propagated upwards: a scan begun below
channel 14 found **no channels at all**, not merely no VHF ones. A UHF-only scan
worked, which is why this was easy to miss.

`DoTunerScan` now derives the frequencies to visit from a channel plan when the
tuner is ATSC, keeping the fixed step for DVB. The start and stop frequencies
still bound the scan, so the dialog is unchanged. `IBDATuner` gains `IsATSC` so
the scan can tell the two apart rather than inferring it. Progress counts
frequencies visited rather than distance travelled up the band, because the
steps are no longer even.

**ATSC channels had no channel number.** `ParseVCT` formatted the major and minor
channel numbers into the channel *name* and never set a channel number, so every
ATSC channel carried number 0, the `N` column read `0`, and
`CTunerScanDlg::OnNewChannel` took its `else` branch and appended in discovery
order instead of sorting.

It now records both parts and derives the existing origin number from them, so
sorting and display work without anything downstream needing to know about ATSC:
9.1 < 9.2 < 9.91 < 10.1 < 50.1 holds under this encoding. The scan dialog shows
`9.1` rather than the `9001` used internally to order it. Channel numbers are
persisted behind a format version bump (6 to 7), so existing saved channel lists
continue to load.

**Two VCT flags were parsed and discarded.** `access_controlled` and `hidden`
were read off the bitstream and dropped, so every ATSC service reported as
unencrypted regardless of its CA state, and services flagged as not intended for
viewers were listed as if they were. Both are now honoured. Note that
`access_controlled` feeds the existing "Ignore encrypted channels" option, so
with that option enabled an ATSC service carrying the CA bit is now excluded
from a scan rather than merely labelled.

**ATSC E-AC-3 was silently dropped.** `PES_STREAM_TYPE` ran 0x80 to 0x86 and
stopped; those are Blu-ray registrations. ATSC signals E-AC-3 with stream type
0x87, which had no enum entry and no case in `ConvertToDVBType`, so an ATSC
service carrying E-AC-3 fell through to the default, returned `BDA_UNKNOWN`, and
`AddStreamInfo` was never called: the audio track vanished with nothing reported
anywhere. US broadcasters do use E-AC-3, so this affects real signals.

## Testing

Exercised against a software BDA tuner replaying real ATSC and DVB-T captures,
which runs the whole path without hardware: enumeration, graph construction,
tuning, lock, PSI/SI parsing, the channel list and persistence. Both this branch
and its parent commit were built and run against the same setup, and the scan
dialog was read through window messages so the comparisons are on
`CBDAChannel::ToString()` records rather than on screenshots.

Confirmed before and after, on the same three multiplexes:

| | before | after |
|---|---|---|
| virtual channel number | `N` reads `0` for every service | `9.1 … 9.91, 10.1 … 10.4, 50.1` |
| ordering | discovery order (10.x, 50.1, 9.x) | sorted; 9.91 between 9.4 and 10.1 |
| `access_controlled` set | reported unencrypted | reported encrypted |
| `hidden` set | listed | omitted |

Neither flag is set anywhere in the capture library, so those two rows were
covered by authoring a stream with TSDuck that sets `access_controlled` on one
service and `hidden` on another, scanned alongside the unmodified original at a
second frequency as a control in the same scan.

Also checked, on an earlier revision of this branch rather than its current tip:
a DVB-T scan over 474000-858000 returned the same 39 channels before and after,
with every persisted record byte-identical once the format version field and the
two newly appended fields are set aside; a full 57000-695000 sweep found all ten
ATSC services after the change and none before; and a version 6 channel list
saved by the pre-change build loaded and round-tripped intact.

The E-AC-3 fix was found against a generated ATSC sample, which ffmpeg emits with
stream type 0x87 by default.
