### PR TITLE
Emit the whole DVB channel record from the web interface, and add a headless scan

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -2715,6 +2715,11 @@ void CAppSettings::ParseCommandLine(CAtlList<CString>& cmdln)
     fixedWindowPosition = NO_FIXED_POSITION;
     iMonitor = 0;
     strPnSPreset.Empty();
+    cmdlnDVBScan.ulFrequencyStart = 0;
+    cmdlnDVBScan.ulFrequencyStop = 0;
+    cmdlnDVBScan.ulBandwidth = 0;
+    cmdlnDVBScan.ulSymbolRate = 0;
+    cmdlnDVBScan.strOutputPath.Empty();
 
     POSITION pos = cmdln.GetHeadPosition();
     while (pos) {
@@ -2861,6 +2866,28 @@ void CAppSettings::ParseCommandLine(CAtlList<CString>& cmdln)
                 if (tmpport >= 0 && tmpport <= 65535) {
                     nCmdlnWebServerPort = tmpport;
                 }
+            } else if (sw == _T("dvbscan") && pos) {
+                // /dvbscan <start>-<stop>, in kHz. Run a tuner scan without the
+                // scan dialog, write the result and quit. The range is required
+                // because there is no sensible default: the persisted one
+                // belongs to whoever last used the dialog.
+                CString strRange = cmdln.GetNext(pos);
+                int nDash = strRange.Find(_T('-'));
+                if (nDash > 0) {
+                    ULONG ulStart = _tcstoul(strRange.Left(nDash), nullptr, 10);
+                    ULONG ulStop = _tcstoul(strRange.Mid(nDash + 1), nullptr, 10);
+                    if (ulStart > 0 && ulStop >= ulStart) {
+                        cmdlnDVBScan.ulFrequencyStart = ulStart;
+                        cmdlnDVBScan.ulFrequencyStop = ulStop;
+                        nCLSwitches |= CLSW_DVBSCAN;
+                    }
+                }
+            } else if (sw == _T("dvbscanout") && pos) {
+                cmdlnDVBScan.strOutputPath = cmdln.GetNext(pos);
+            } else if (sw == _T("dvbbandwidth") && pos) {
+                cmdlnDVBScan.ulBandwidth = _tcstoul(cmdln.GetNext(pos), nullptr, 10);
+            } else if (sw == _T("dvbsymbolrate") && pos) {
+                cmdlnDVBScan.ulSymbolRate = _tcstoul(cmdln.GetNext(pos), nullptr, 10);
             } else if (sw == _T("debug")) {
                 fShowDebugInfo = true;
             } else if (sw == _T("nocrashreporter")) {

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -97,7 +97,8 @@ enum : UINT64 {
     CLSW_MUTE = CLSW_CONFIGLAVVIDEO << 1,
     CLSW_VOLUME = CLSW_MUTE << 1,
     CLSW_THUMBNAILS = CLSW_VOLUME << 1,
-    CLSW_UNRECOGNIZEDSWITCH = CLSW_THUMBNAILS << 1, // 47
+    CLSW_DVBSCAN = CLSW_THUMBNAILS << 1,
+    CLSW_UNRECOGNIZEDSWITCH = CLSW_DVBSCAN << 1, // 48
 };
 
 enum MpcCaptionState {
@@ -794,6 +795,17 @@ public:
     std::vector<CBDAChannel> m_DVBChannels;
     DVB_RebuildFilterGraph nDVBRebuildFilterGraph;
     DVB_StopFilterGraph nDVBStopFilterGraph;
+
+    // Headless tuner scan, driven by /dvbscan. Command line only and never
+    // persisted: this describes one run rather than a preference, and writing
+    // it to the profile would leave the next launch trying to scan.
+    struct {
+        ULONG   ulFrequencyStart;   // kHz
+        ULONG   ulFrequencyStop;    // kHz
+        ULONG   ulBandwidth;        // kHz; 0 means use iBDABandwidth
+        ULONG   ulSymbolRate;       // 0 means use iBDASymbolRate
+        CString strOutputPath;      // where the JSON is written
+    } cmdlnDVBScan;
 
     // Internal Filters
     bool            SrcFilters[SRC_LAST + !SRC_LAST];

--- a/src/mpc-hc/DVBChannel.cpp
+++ b/src/mpc-hc/DVBChannel.cpp
@@ -162,7 +162,10 @@ CString CBDAChannel::ToString() const
 static LPCSTR StreamTypeName(BDA_STREAM_TYPE type)
 {
     switch (type) {
-        case BDA_MPV:      return "MPEG2";
+        // Not "MPEG2": ConvertToDVBType folds both VIDEO_STREAM_MPEG1 and
+        // VIDEO_STREAM_MPEG2 into BDA_MPV, and AddStreamInfo does not keep the
+        // PES type for video, so the distinction is not available here.
+        case BDA_MPV:      return "MPEG-Video";
         case BDA_H264:     return "H264";
         case BDA_HEVC:     return "HEVC";
         case BDA_MPA:      return "MPEG-Audio";
@@ -201,12 +204,26 @@ static LPCSTR AspectRatioName(BDA_AspectRatio_TYPE ar)
     }
 }
 
+static LPCSTR ChromaName(BDA_CHROMA_TYPE chroma)
+{
+    switch (chroma) {
+        case BDA_Chroma_4_2_0: return "4:2:0";
+        case BDA_Chroma_4_2_2: return "4:2:2";
+        case BDA_Chroma_4_4_4: return "4:4:4";
+        default:               return "";
+    }
+}
+
 static CStringA StreamToJSON(const BDAStreamInfo& stream, bool bDefault)
 {
+    // "pes" is the PMT stream_type the stream was classified from, after any
+    // descriptor that overrides it. It distinguishes branches that share a
+    // BDA type, such as AAC with ADTS (0x0F) against LATM (0x11).
     CStringA json;
-    json.Format("{ \"pid\" : %lu, \"type\" : \"%s\", \"language\" : \"%s\", \"default\" : %s }",
+    json.Format("{ \"pid\" : %lu, \"type\" : \"%s\", \"pes\" : %d, \"language\" : \"%s\", \"default\" : %s }",
                 stream.ulPID,
                 StreamTypeName(stream.nType),
+                stream.nPesType,
                 EscapeJSONString(UTF16To8(stream.sLanguage)).GetString(),
                 bDefault ? "true" : "false");
     return json;
@@ -238,15 +255,19 @@ CStringA CBDAChannel::ToJSON() const
                              ", \"pmtPid\" : %lu, \"pcrPid\" : %lu",
                              m_ulONID, m_ulTSID, m_ulSID, m_ulPMT, m_ulPCR);
 
+    // No "pes" here: AddStreamInfo keeps the PES type for audio and subtitle
+    // streams but not for video, so it is not available to report.
     jsonChannel.AppendFormat(", \"video\" : { \"pid\" : %lu, \"type\" : \"%s\""
                              ", \"width\" : %lu, \"height\" : %lu"
-                             ", \"fps\" : \"%s\", \"aspectRatio\" : \"%s\" }",
+                             ", \"fps\" : \"%s\", \"aspectRatio\" : \"%s\""
+                             ", \"chroma\" : \"%s\" }",
                              m_ulVideoPID,
                              StreamTypeName(m_nVideoType),
                              m_nVideoWidth,
                              m_nVideoHeight,
                              FpsName(m_nVideoFps),
-                             AspectRatioName(m_nVideoAR));
+                             AspectRatioName(m_nVideoAR),
+                             ChromaName(m_nVideoChroma));
 
     jsonChannel += ", \"audio\" : [";
     for (int i = 0; i < m_nAudioCount; i++) {

--- a/src/mpc-hc/DVBChannel.cpp
+++ b/src/mpc-hc/DVBChannel.cpp
@@ -157,12 +157,112 @@ CString CBDAChannel::ToString() const
     return strValue;
 }
 
+// Names rather than raw enum values, so that a consumer of the web interface
+// does not need its own copy of these enums to make sense of the output.
+static LPCSTR StreamTypeName(BDA_STREAM_TYPE type)
+{
+    switch (type) {
+        case BDA_MPV:      return "MPEG2";
+        case BDA_H264:     return "H264";
+        case BDA_HEVC:     return "HEVC";
+        case BDA_MPA:      return "MPEG-Audio";
+        case BDA_AC3:      return "AC3";
+        case BDA_EAC3:     return "EAC3";
+        case BDA_ADTS:     return "AAC-ADTS";
+        case BDA_LATM:     return "AAC-LATM";
+        case BDA_SUBTITLE: return "DVB-Subtitle";
+        default:           return "unknown";
+    }
+}
+
+static LPCSTR FpsName(BDA_FPS_TYPE fps)
+{
+    switch (fps) {
+        case BDA_FPS_23_976: return "23.976";
+        case BDA_FPS_24_0:   return "24";
+        case BDA_FPS_25_0:   return "25";
+        case BDA_FPS_29_97:  return "29.97";
+        case BDA_FPS_30_0:   return "30";
+        case BDA_FPS_50_0:   return "50";
+        case BDA_FPS_59_94:  return "59.94";
+        case BDA_FPS_60_0:   return "60";
+        default:             return "";
+    }
+}
+
+static LPCSTR AspectRatioName(BDA_AspectRatio_TYPE ar)
+{
+    switch (ar) {
+        case BDA_AR_1:      return "1:1";
+        case BDA_AR_3_4:    return "4:3";
+        case BDA_AR_9_16:   return "16:9";
+        case BDA_AR_1_2_21: return "2.21:1";
+        default:            return "";
+    }
+}
+
+static CStringA StreamToJSON(const BDAStreamInfo& stream, bool bDefault)
+{
+    CStringA json;
+    json.Format("{ \"pid\" : %lu, \"type\" : \"%s\", \"language\" : \"%s\", \"default\" : %s }",
+                stream.ulPID,
+                StreamTypeName(stream.nType),
+                EscapeJSONString(UTF16To8(stream.sLanguage)).GetString(),
+                bDefault ? "true" : "false");
+    return json;
+}
+
 CStringA CBDAChannel::ToJSON() const
 {
+    // index and name keep their names and stay first: /dvb/channels has
+    // shipped with them, so anything already reading it keeps working.
     CStringA jsonChannel;
-    jsonChannel.Format("{ \"index\" : %d, \"name\" : \"%s\" }",
+    jsonChannel.Format("{ \"index\" : %d, \"name\" : \"%s\"",
                        m_nPrefNumber,
                        EscapeJSONString(UTF16To8(m_strName)).GetString());
+
+    jsonChannel.AppendFormat(", \"originNumber\" : %d"
+                             ", \"frequency\" : %lu"
+                             ", \"bandwidth\" : %lu"
+                             ", \"symbolRate\" : %lu"
+                             ", \"encrypted\" : %s",
+                             m_nOriginNumber,
+                             m_ulFrequency,
+                             m_ulBandwidth,
+                             m_ulSymbolRate,
+                             m_bEncrypted ? "true" : "false");
+
+    // The identifiers needed to correlate a channel against the transport
+    // stream it was scanned from.
+    jsonChannel.AppendFormat(", \"onid\" : %lu, \"tsid\" : %lu, \"sid\" : %lu"
+                             ", \"pmtPid\" : %lu, \"pcrPid\" : %lu",
+                             m_ulONID, m_ulTSID, m_ulSID, m_ulPMT, m_ulPCR);
+
+    jsonChannel.AppendFormat(", \"video\" : { \"pid\" : %lu, \"type\" : \"%s\""
+                             ", \"width\" : %lu, \"height\" : %lu"
+                             ", \"fps\" : \"%s\", \"aspectRatio\" : \"%s\" }",
+                             m_ulVideoPID,
+                             StreamTypeName(m_nVideoType),
+                             m_nVideoWidth,
+                             m_nVideoHeight,
+                             FpsName(m_nVideoFps),
+                             AspectRatioName(m_nVideoAR));
+
+    jsonChannel += ", \"audio\" : [";
+    for (int i = 0; i < m_nAudioCount; i++) {
+        jsonChannel += i ? ", " : " ";
+        jsonChannel += StreamToJSON(m_Audios[i], i == m_nDefaultAudio);
+    }
+    jsonChannel += m_nAudioCount ? " ]" : "]";
+
+    jsonChannel += ", \"subtitles\" : [";
+    for (int i = 0; i < m_nSubtitleCount; i++) {
+        jsonChannel += i ? ", " : " ";
+        jsonChannel += StreamToJSON(m_Subtitles[i], i == m_nDefaultSubtitle);
+    }
+    jsonChannel += m_nSubtitleCount ? " ]" : "]";
+
+    jsonChannel += " }";
     return jsonChannel;
 }
 

--- a/src/mpc-hc/DVBChannel.cpp
+++ b/src/mpc-hc/DVBChannel.cpp
@@ -238,12 +238,19 @@ CStringA CBDAChannel::ToJSON() const
                        m_nPrefNumber,
                        EscapeJSONString(UTF16To8(m_strName)).GetString());
 
+    // atscMajor/atscMinor are the two halves of the ATSC virtual channel
+    // number from the VCT; both are zero for DVB, where originNumber carries
+    // the logical channel number instead (and, for ATSC, its
+    // major * 1000 + minor encoding - see SetATSCNumber).
     jsonChannel.AppendFormat(", \"originNumber\" : %d"
+                             ", \"atscMajor\" : %d, \"atscMinor\" : %d"
                              ", \"frequency\" : %lu"
                              ", \"bandwidth\" : %lu"
                              ", \"symbolRate\" : %lu"
                              ", \"encrypted\" : %s",
                              m_nOriginNumber,
+                             m_nATSCMajor,
+                             m_nATSCMinor,
                              m_ulFrequency,
                              m_ulBandwidth,
                              m_ulSymbolRate,

--- a/src/mpc-hc/DVBChannel.cpp
+++ b/src/mpc-hc/DVBChannel.cpp
@@ -437,3 +437,22 @@ DWORD CBDAChannel::GetVideoARy()
     }
     return Value;
 }
+
+CStringA DVBChannelsToJSON(const std::vector<CBDAChannel>& channels)
+{
+    // begin the JSON object with the "channels" array inside
+    CStringA jsonChannels = "{ \"channels\" : [";
+
+    for (auto it = channels.begin(); it != channels.end();) {
+        // fill the array with individual channel objects
+        jsonChannels += it->ToJSON();
+        if (++it == channels.end()) {
+            break;
+        }
+        jsonChannels += ",";
+    }
+
+    // terminate the array and the object, and return.
+    jsonChannels += "] }";
+    return jsonChannels;
+}

--- a/src/mpc-hc/DVBChannel.h
+++ b/src/mpc-hc/DVBChannel.h
@@ -245,3 +245,13 @@ private:
 
     void FromString(CString strValue);
 };
+
+/**
+ * @brief Serialize a list of channels as the JSON object the web interface
+ *        serves from /dvb/channels.json.
+ * @note Shared so that the endpoint and any other consumer emit the same
+ * document. A second copy of this loop would be free to drift from the first.
+ * @returns @c { "channels" : [ ... ] } with one @c CBDAChannel::ToJSON() per
+ * entry.
+ */
+CStringA DVBChannelsToJSON(const std::vector<CBDAChannel>& channels);

--- a/src/mpc-hc/DVBChannel.h
+++ b/src/mpc-hc/DVBChannel.h
@@ -111,8 +111,15 @@ public:
     CString ToString() const;
     /**
      * @brief Output a JSON representation of a BDA channel.
-     * @note The object contains two elements : "index", which corresponds to
-     * @c m_nPrefNumber, and "name", which contains @c m_strName.
+     * @note "index" corresponds to @c m_nPrefNumber and "name" to
+     * @c m_strName. These come first and keep their names, because the web
+     * interface has shipped with them. The rest of the record follows: the
+     * tuning parameters, the identifiers needed to correlate a channel with
+     * the transport stream it was scanned from, a "video" object, and "audio"
+     * and "subtitles" arrays of @c BDAStreamInfo entries.
+     * @note Stream types, frame rates and aspect ratios are emitted as names
+     * rather than raw enum values, so a consumer does not need its own copy of
+     * the enums in this header to read the output.
      * @returns A string representing a JSON object containing the
      * aforementioned elements.
      */

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -4519,6 +4519,14 @@ LRESULT CMainFrame::OnOpenMediaFailed(WPARAM wParam, LPARAM lParam)
         FLUSH_LOGGER();
     }
 
+    // The other way a headless scan can be left with nothing to wait for: the
+    // device was configured but would not open. Quit rather than sit idle.
+    if (AfxGetAppSettings().nCLSwitches & CLSW_DVBSCAN) {
+        TRACE(_T("/dvbscan: the capture device failed to open, abandoning the scan\n"));
+        AfxGetAppSettings().nCLSwitches &= ~CLSW_DVBSCAN;
+        PostMessage(WM_CLOSE);
+    }
+
     m_lastOMD.Free();
     m_lastOMD.Attach((OpenMediaData*)lParam);
     if (!m_lastOMD->title) {
@@ -5286,11 +5294,23 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
         s.nCLSwitches &= ~CLSW_CD;
         PostMessage(WM_MPC_OPENCURPLAYLIST, 0, 0);
     } else if (s.nCLSwitches & (CLSW_DEVICE | CLSW_DVBSCAN)) {
-        // /dvbscan implies opening the capture device, because DoTunerScan only
-        // runs in PM_DIGITAL_CAPTURE. CLSW_DVBSCAN is deliberately left set:
-        // OnFilePostOpenmedia consumes it once the device is actually up.
-        PostMessage(WM_COMMAND, ID_FILE_OPENDEVICE);
-        s.nCLSwitches &= ~CLSW_DEVICE;
+        // OnFileOpendevice shows the capture options page and returns when no
+        // device is configured. Interactively that is a prompt; for a headless
+        // run it is a modal nobody can answer, and the process would sit there
+        // with no device, no scan and nothing to time out. Check the same
+        // condition first and fail the run instead.
+        if ((s.nCLSwitches & CLSW_DVBSCAN) && s.iDefaultCaptureDevice == 0 &&
+                s.strAnalogVideo == L"dummy" && s.strAnalogAudio == L"dummy") {
+            TRACE(_T("/dvbscan: no capture device configured, nothing to scan\n"));
+            s.nCLSwitches &= ~CLSW_DVBSCAN;
+            PostMessage(WM_CLOSE);
+        } else {
+            // /dvbscan implies opening the capture device, because DoTunerScan
+            // only runs in PM_DIGITAL_CAPTURE. CLSW_DVBSCAN is deliberately
+            // left set: OnFilePostOpenmedia consumes it once the device is up.
+            PostMessage(WM_COMMAND, ID_FILE_OPENDEVICE);
+            s.nCLSwitches &= ~CLSW_DEVICE;
+        }
     } else if (!s.slFiles.IsEmpty()) {
         CAtlList<CString> sl;
         sl.AddTailList(&s.slFiles);

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -328,6 +328,8 @@ BEGIN_MESSAGE_MAP(CMainFrame, CFrameWnd)
 
     ON_MESSAGE(WM_POSTOPEN, OnFilePostOpenmedia)
     ON_MESSAGE(WM_OPENFAILED, OnOpenMediaFailed)
+    ON_MESSAGE(WM_TUNER_NEW_CHANNEL, OnHeadlessScanNewChannel)
+    ON_MESSAGE(WM_TUNER_SCAN_END, OnHeadlessScanEnd)
     ON_MESSAGE(WM_DVB_EIT_DATA_READY, OnCurrentChannelInfoUpdated)
 
     ON_COMMAND(ID_BOSS, OnBossKey)
@@ -4493,6 +4495,14 @@ LRESULT CMainFrame::OnFilePostOpenmedia(WPARAM wParam, LPARAM lParam)
 
     m_bSettingUpMenus = false;
 
+    // The device is open now, which is the one precondition DoTunerScan has.
+    // Consume the switch so a later open cannot start a second scan.
+    if ((s.nCLSwitches & CLSW_DVBSCAN) && GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
+        s.nCLSwitches &= ~CLSW_DVBSCAN;
+        m_bHeadlessDVBScan = true;
+        StartHeadlessDVBScan();
+    }
+
     return 0;
 }
 
@@ -5275,7 +5285,10 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
         applyRandomizeSwitch();
         s.nCLSwitches &= ~CLSW_CD;
         PostMessage(WM_MPC_OPENCURPLAYLIST, 0, 0);
-    } else if (s.nCLSwitches & CLSW_DEVICE) {
+    } else if (s.nCLSwitches & (CLSW_DEVICE | CLSW_DVBSCAN)) {
+        // /dvbscan implies opening the capture device, because DoTunerScan only
+        // runs in PM_DIGITAL_CAPTURE. CLSW_DVBSCAN is deliberately left set:
+        // OnFilePostOpenmedia consumes it once the device is actually up.
         PostMessage(WM_COMMAND, ID_FILE_OPENDEVICE);
         s.nCLSwitches &= ~CLSW_DEVICE;
     } else if (!s.slFiles.IsEmpty()) {
@@ -21206,6 +21219,101 @@ void CMainFrame::StartTunerScan(CAutoPtr<TunerScanData> pTSD)
 void CMainFrame::StopTunerScan()
 {
     m_bStopTunerScan = true;
+}
+
+void CMainFrame::StartHeadlessDVBScan()
+{
+    const CAppSettings& s = AfxGetAppSettings();
+
+    m_headlessDVBScanChannels.clear();
+
+    CAutoPtr<TunerScanData> pTSD(DEBUG_NEW TunerScanData);
+    pTSD->Hwnd = m_hWnd;
+    pTSD->FrequencyStart = s.cmdlnDVBScan.ulFrequencyStart;
+    pTSD->FrequencyStop = s.cmdlnDVBScan.ulFrequencyStop;
+    // Bandwidth is kHz in TunerScanData and MHz in the profile. This is the
+    // same conversion CTunerScanDlg makes when it loads its fields, so a
+    // headless run and a dialog run scan identically for identical settings.
+    pTSD->Bandwidth = s.cmdlnDVBScan.ulBandwidth ? s.cmdlnDVBScan.ulBandwidth
+                      : (ULONG)s.iBDABandwidth * 1000;
+    pTSD->SymbolRate = s.cmdlnDVBScan.ulSymbolRate ? s.cmdlnDVBScan.ulSymbolRate
+                       : (ULONG)s.iBDASymbolRate;
+    pTSD->Offset = s.fBDAUseOffset ? s.iBDAOffset : 0;
+
+    StartTunerScan(pTSD);
+}
+
+LRESULT CMainFrame::OnHeadlessScanNewChannel(WPARAM wParam, LPARAM lParam)
+{
+    if (!m_bHeadlessDVBScan) {
+        return FALSE;
+    }
+
+    const CAppSettings& s = AfxGetAppSettings();
+    const size_t maxChannelsNum = ID_NAVIGATE_JUMPTO_SUBITEM_END - ID_NAVIGATE_JUMPTO_SUBITEM_START + 1;
+
+    try {
+        CBDAChannel channel((LPCTSTR)lParam);
+        // The dialog applies this filter as it fills its list rather than at
+        // save time, so apply it here too.
+        if (!s.fBDAIgnoreEncryptedChannels || !channel.IsEncrypted()) {
+            if (m_headlessDVBScanChannels.size() < maxChannelsNum) {
+                channel.SetPrefNumber((int)m_headlessDVBScanChannels.size());
+                m_headlessDVBScanChannels.push_back(channel);
+            }
+        }
+    } catch (CException* e) {
+        // A record that will not tokenise is dropped and the scan continues,
+        // which is what CTunerScanDlg::OnNewChannel does with the same failure.
+        TRACE(_T("/dvbscan: failed to parse a scanned channel record\n"));
+        e->Delete();
+    }
+
+    return TRUE;
+}
+
+LRESULT CMainFrame::OnHeadlessScanEnd(WPARAM wParam, LPARAM lParam)
+{
+    if (!m_bHeadlessDVBScan) {
+        return FALSE;
+    }
+    FinishHeadlessDVBScan();
+    return TRUE;
+}
+
+void CMainFrame::FinishHeadlessDVBScan()
+{
+    const CAppSettings& s = AfxGetAppSettings();
+
+    // The serializer the web interface uses, not a second copy of it: whatever
+    // /dvb/channels.json would say about these channels, this file says too.
+    const CStringA json = DVBChannelsToJSON(m_headlessDVBScanChannels);
+
+    bool bWritten = false;
+    if (!s.cmdlnDVBScan.strOutputPath.IsEmpty()) {
+        CFile file;
+        CFileException fe;
+        if (file.Open(s.cmdlnDVBScan.strOutputPath,
+                      CFile::modeCreate | CFile::modeWrite | CFile::typeBinary, &fe)) {
+            try {
+                file.Write((LPCSTR)json, json.GetLength());
+                bWritten = true;
+            } catch (CFileException* pfe) {
+                pfe->Delete();
+            }
+            file.Close();
+        }
+    }
+
+    if (!bWritten) {
+        // Losing the result silently would leave a caller unable to tell an
+        // empty scan from an unwritable path.
+        TRACE(_T("/dvbscan: could not write the result to '%s'\n"),
+              s.cmdlnDVBScan.strOutputPath.GetString());
+    }
+
+    m_bHeadlessDVBScan = false;
+    PostMessage(WM_CLOSE);
 }
 
 HRESULT CMainFrame::SetChannel(int nChannel)

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -705,6 +705,15 @@ public:
     void StopTunerScan();
     HRESULT SetChannel(int nChannel);
 
+    // Headless tuner scan, driven by /dvbscan rather than CTunerScanDlg.
+    // DoTunerScan reports through window messages, so this listens for them
+    // instead of the dialog and writes the result out. The scan engine itself
+    // is unchanged and unaware of which listener it is talking to.
+    bool m_bHeadlessDVBScan = false;
+    std::vector<CBDAChannel> m_headlessDVBScanChannels;
+    void StartHeadlessDVBScan();
+    void FinishHeadlessDVBScan();
+
     void AddCurDevToPlaylist();
 
     bool m_bTrayIcon;
@@ -964,6 +973,11 @@ public:
 
     afx_msg LRESULT OnFilePostOpenmedia(WPARAM wParam, LPARAM lparam);
     afx_msg LRESULT OnOpenMediaFailed(WPARAM wParam, LPARAM lParam);
+
+    // Only reached in headless scan mode: with the dialog running these go to
+    // it instead, because DoTunerScan sends to the HWND it was handed.
+    afx_msg LRESULT OnHeadlessScanNewChannel(WPARAM wParam, LPARAM lParam);
+    afx_msg LRESULT OnHeadlessScanEnd(WPARAM wParam, LPARAM lParam);
     void OnFilePostClosemedia(bool bNextIsQueued = false);
 
     afx_msg void OnBossKey();

--- a/src/mpc-hc/WebClientSocket.cpp
+++ b/src/mpc-hc/WebClientSocket.cpp
@@ -1022,30 +1022,13 @@ bool CWebClientSocket::OnViewRes(CStringA& hdr, CStringA& body, CStringA& mime)
     return true;
 }
 
-static CStringA GetChannelsJSON(const std::vector<CBDAChannel>& channels)
-{
-    // begin the JSON object with the "channels" array inside
-    CStringA jsonChannels = "{ \"channels\" : [";
-
-    for (auto it = channels.begin(); it != channels.end();) {
-        // fill the array with individual channel objects
-        jsonChannels += it->ToJSON();
-        if (++it == channels.end()) {
-            break;
-        }
-        jsonChannels += ",";
-    }
-
-    // terminate the array and the object, and return.
-    jsonChannels += "] }";
-    return jsonChannels;
-}
-
 bool CWebClientSocket::OnDVBChannels(CStringA& hdr, CStringA& body, CStringA& mime)
 {
     if (m_pMainFrame->GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
         mime = "application/json";
-        body = GetChannelsJSON(AfxGetAppSettings().m_DVBChannels);
+        // DVBChannelsToJSON (DVBChannel.cpp) rather than a copy of the loop
+        // here, so this and the headless scan's output cannot diverge.
+        body = DVBChannelsToJSON(AfxGetAppSettings().m_DVBChannels);
     } else {
         // if we're not currently running the capture, report the service as
         // unavailable and return.


### PR DESCRIPTION
`/dvb/channels.json` reported only a channel's index and name:

```cpp
jsonChannel.Format("{ \"index\" : %d, \"name\" : \"%s\" }", ...);
```

A name proves the SDT parsed. It says nothing about the PMT, the codecs, the
resolution, the language tags or the subtitle tracks — all of which
`CBDAChannel` already holds, having parsed, stored and persisted them. They
were simply never exposed.

This emits the full record: the tuning parameters, the identifiers needed to
correlate a channel with the transport stream it was scanned from, a `video`
object, and `audio` and `subtitles` arrays. Real output, captured from a tuned
player:

```json
{ "index": 0, "name": "VT VSD", "originNumber": 0,
  "frequency": 498000, "bandwidth": 8000, "symbolRate": 0, "encrypted": false,
  "onid": 65281, "tsid": 16, "sid": 269, "pmtPid": 4096, "pcrPid": 256,
  "video": { "pid": 256, "type": "MPEG-Video", "width": 720, "height": 576,
             "fps": "50", "aspectRatio": "", "chroma": "4:2:0" },
  "audio": [ { "pid": 257, "type": "MPEG-Audio", "pes": 3,
               "language": "eng", "default": true } ],
  "subtitles": [] }
```

Stream types, frame rates, aspect ratios and chroma formats are emitted as
names via small file-static lookup tables, so a consumer of the web interface
does not need its own copy of the enums in `DVBChannel.h`. `pes` is the PMT
`stream_type` after any overriding descriptor — the numeric wire value, which
is the only thing that separates branches sharing a BDA type (AAC-ADTS 0x0F
against AAC-LATM 0x11, for instance). `BDA_MPV` is labelled `MPEG-Video`
rather than `MPEG2`, because `ConvertToDVBType` folds `VIDEO_STREAM_MPEG1`
and `VIDEO_STREAM_MPEG2` into it and the distinction is not stored.

**Backward compatible by construction.** `index` and `name` keep their names
and stay first; everything else is additive, so anything already parsing
`/dvb/channels.json` keeps working. This is the web interface only —
`ToString`/`FromString` and `FORMAT_VERSION_CURRENT` are untouched, so the
persisted channel list format does not change.

### /dvbscan

The scan engine (`CMainFrame::DoTunerScan`) was already independent of
`CTunerScanDlg` — the dialog only fills a `TunerScanData` and listens for the
`WM_TUNER_*` messages. This adds a second listener:

```
mpc-hc64.exe /dvbscan 474000-506000 /dvbbandwidth 8000 /dvbsymbolrate 0
             /dvbscanout C:\path\scan.json
```

opens the configured capture device, runs the scan, writes the channel JSON
and exits. The serializer is shared (`DVBChannelsToJSON`, also used by the
endpoint), so the file and `/dvb/channels.json` cannot drift. It honours the
ignore-encrypted setting and the channel cap exactly as the dialog's save
path does, and fails fast — with no dialog raised — if no capture device is
configured or the device open fails, so an unattended caller gets a prompt
exit rather than a hang. Bandwidth and symbol rate default to the persisted
scan settings when the switches are omitted.

### Testing

Built x64 Release. Verified against live DVB-T scans of generated and real
off-air transport streams, on two binaries across multiple runs:

- Every field cross-checked against the same scan's `CBDAChannel::ToString()`
  records and in agreement.
- `chroma` verified against four generated streams carrying
  `video_stream_descriptor` with `chroma_format` 1, 2 and 3 plus an
  `MPEG_1_only` control: decoded and rendered as `4:2:0`, `4:2:2`, `4:4:4`
  and `""` respectively, with `fps "50"` proving the descriptor was read
  (25 is the fallback `ParsePMT` invents when it is absent).
- `pes` verified on the wire against known PMT stream types.
- `/dvbscan` run end to end: device open, 4-frequency sweep, JSON written,
  clean exit, output identical in shape to the endpoint's.
- `width`/`height` of `0` and empty `aspectRatio`/`chroma`/`fps` mean the
  stream carried no descriptor for them (except `fps` and MPEG-2 rasters,
  which `ParsePMT` back-fills to 25 and 720x576 — pre-existing behaviour,
  unchanged here).

One pre-existing issue this makes visible: DVB `tsid` values arrive
byte-swapped (`0x1000` reads as `16`). That is not introduced here — the BDA
`SECTION` struct's `TableIdExtension` is a host-order field and
`ParseSIHeader` re-reads it as big-endian wire data, while `onid` and `sid`
sit in the untouched payload and decode correctly. The JSON reports the value
the parser produces; a fix at that seam is being prepared separately.

Note the endpoint answers only while the player is in `PM_DIGITAL_CAPTURE`
and returns 503 otherwise; that behaviour is unchanged. `/dvbscan` exists
partly so the JSON can be obtained without a live tuned player. (Builds
predating #4135 additionally 404 every web route while the first-run update
prompt is unanswered — fixed upstream, mentioned here only because anyone
testing this endpoint against an older build will hit it.)

The ATSC virtual channel number added by #4136 (format version 7) is emitted
as `atscMajor`/`atscMinor` (both zero for DVB; `originNumber` carries the
`major*1000+minor` encoding either way). Verified against an ATSC scan of
authored VCT streams: 9.1/9.2/9.4/9.91 decoded with a two-digit minor intact,
a service whose VCT sets `access_controlled` reported `"encrypted": true`,
and a `hidden` service was correctly absent from the scan while its
unflagged twin on another frequency appeared.
