### PR TITLE
Fix transport_stream_id decoded byte-swapped from BDA section headers

### DIFF
--- a/src/mpc-hc/Mpeg2SectionData.cpp
+++ b/src/mpc-hc/Mpeg2SectionData.cpp
@@ -677,7 +677,6 @@ HRESULT CMpeg2DataParser::ParseEIT(ULONG ulSID, EventDescriptor& NowNext)
     HRESULT hr = S_OK;
     DWORD dwLength;
     PSECTION data;
-    ULONG ulGetSID;
     EventInformationSection InfoEvent;
     NowNext = EventDescriptor();
 
@@ -689,12 +688,14 @@ HRESULT CMpeg2DataParser::ParseEIT(ULONG ulSID, EventDescriptor& NowNext)
         CGolombBuffer gb((BYTE*)data, dwLength);
 
         InfoEvent.TableID = (UINT8)gb.BitRead(8);
-        InfoEvent.SectionSyntaxIndicator = (WORD)gb.BitRead(1);
-        gb.BitRead(3);
-        InfoEvent.SectionLength = (WORD)gb.BitRead(12);
-        ulGetSID  = (ULONG)gb.BitRead(8);
-        ulGetSID += 0x100 * (ULONG)gb.BitRead(8);
-        InfoEvent.ServiceId = ulGetSID; // This is really strange, ServiceID should be uimsbf ???
+        // Same host-order header as ParseSIHeader: the BDA demux has already
+        // byte-swapped Header.W and TableIdExtension, so read them as
+        // little-endian WORDs. The hand-rolled little-endian service id this
+        // replaces was correct, and was why it looked "strange" here.
+        WORD wEitHeader = (WORD)gb.ReadShortLE();
+        InfoEvent.SectionSyntaxIndicator = (WORD)(wEitHeader >> 15);
+        InfoEvent.SectionLength = (WORD)(wEitHeader & 0x0FFF);
+        InfoEvent.ServiceId = (ULONG)(WORD)gb.ReadShortLE();
         if (InfoEvent.ServiceId == ulSID) {
             gb.BitRead(2);
             InfoEvent.VersionNumber = (UINT8)gb.BitRead(5);

--- a/src/mpc-hc/Mpeg2SectionData.cpp
+++ b/src/mpc-hc/Mpeg2SectionData.cpp
@@ -254,11 +254,14 @@ HRESULT CMpeg2DataParser::ParseSIHeader(CGolombBuffer& gb, DVB_SI SIType, WORD& 
     if (gb.BitRead(8) != SIType) {
         return ERROR_INVALID_DATA;              // table_id
     }
-    gb.BitRead(1);                              // section_syntax_indicator
-    gb.BitRead(1);                              // reserved_future_use
-    gb.BitRead(2);                              // reserved
-    wSectionLength = (WORD)gb.BitRead(12);      // section_length
-    wTSID = (WORD)gb.BitRead(16);               // transport_stream_id
+    // The BDA demux hands us a SECTION/LONG_SECTION struct (mpeg2structs.h), not
+    // raw wire bytes: Header.W and TableIdExtension have already been swapped to
+    // host order for us, which is what the SDK's SWAP_MPEG_SECTION_HEADER_BYTES
+    // macro does. Read those two as little-endian WORDs; everything from
+    // RemainingData onwards is untouched wire payload and stays big-endian.
+    WORD wHeader = (WORD)gb.ReadShortLE();      // section_syntax_indicator, reserved, section_length
+    wSectionLength = wHeader & 0x0FFF;          // section_length
+    wTSID = (WORD)gb.ReadShortLE();             // transport_stream_id
     gb.BitRead(2);                              // reserved
     gb.BitRead(5);                              // version_number
     gb.BitRead(1);                              // current_next_indicator


### PR DESCRIPTION
# Fix transport_stream_id decoded byte-swapped from BDA section headers

## The defect

`CMpeg2DataParser::ParseSIHeader` wraps the buffer handed back by
`ISectionList::GetSectionData` in a `CGolombBuffer` and reads the section header
big-endian, as it would off the wire. But that buffer is not wire data: it is a
`SECTION` / `LONG_SECTION` struct from the Windows SDK (`mpeg2structs.h`), and
the BDA MPEG-2 section filter has already byte-swapped two of its fields into
host order before we see them:

| offset | field | order |
|--------|-------|-------|
| 0 | `TableId` | byte, unaffected |
| 1-2 | `Header.W` | **host WORD** |
| 3-4 | `TableIdExtension` | **host WORD** |
| 5-7 | `Version`, `SectionNumber`, `LastSectionNumber` | bytes, unaffected |
| 8+ | `RemainingData` | raw wire payload, big-endian |

That is what the SDK's own `SWAP_MPEG_SECTION_HEADER_BYTES` macro exists to do,
and why there is a matching `UNSWAP_` for handing a section back.

So `section_length` was garbled and `transport_stream_id` came out
byte-reversed. `original_network_id` and `service_id` live in `RemainingData`
and always decoded correctly, which is why only the TSID was ever noticed.

The file already contained evidence of this. `ParseEIT` parses its own copy of
the same header and reads the service id little-endian by hand:

```cpp
ulGetSID  = (ULONG)gb.BitRead(8);
ulGetSID += 0x100 * (ULONG)gb.BitRead(8);
InfoEvent.ServiceId = ulGetSID; // This is really strange, ServiceID should be uimsbf ???
```

Someone hit this years ago, worked around it locally, and recorded that they
did not understand why it was necessary. This PR fixes the cause and removes
the workaround.

## Scope of the behaviour change: DVB SDT only

`ParseSIHeader` has six callers, so the misread happened in all six — but the
observable change is one field in one table:

| caller | uses `wTSID`? |
|--------|---------------|
| `ParseSDT` | **yes** — `Channel.SetTSID(wTSID)`, the only consumer |
| `ParseVCT` | no — sets TSID from the per-channel `channel_TSID` in the section body, which is ordinary wire payload and was always correct |
| `ParseMGT`, `ParsePAT`, `ParsePMT`, `ParseNIT` | no — each declares it, passes it by reference, never reads it back |

`wSectionLength` is written by all six and read by none; the parse loops bound
on buffer size instead.

**This is not an ATSC fix.** ATSC channels take their TSID from the VCT body,
so they were correct before and are unchanged after — verified, see below.

## Verification

Virtual BDA tuner, DVB-T, one frequency, channel list cleared before each run,
same guest, two builds differing only by this change. The stream is a
real-world capture whose authored values were read independently with TSDuck:

```
PAT: TS id: 2 (0x0002)
SDT: Transport Stream Id: 0x0002 (2)   Original Network Id: 0x20FA (8442)
```

Resulting `CBDAChannel` records:

| | before | after | authored |
|---|--------|-------|----------|
| **TSID** | **512** (0x0200) | **2** (0x0002) | **0x0002** |
| ONID | 8442 | 8442 | 0x20FA (8442) |
| service ids | 513/515/516/517/518 | unchanged | unchanged |

ONID is the control: it lives in `RemainingData`, so it must decode correctly
either way, and it does. A byte-swapped TSID sitting beside a correct ONID in
the same record is the signature of this defect and nothing else.

Across all five channel records, exactly one field changed — the TSID — five
times. Every other field, including the PMT PID, PCR PID and the video and
audio elementary PIDs, is byte-identical between the two runs. Those come from
`ParsePAT` and `ParsePMT`, both of which go through the changed function, so
they demonstrate that the header still consumes exactly eight bytes and no
downstream parse has shifted.

ATSC regression, same method on an ATSC mux:

```
before  6|50.1 - KEJT-HD|515000|6000|0|0|0|0|0|0|9099|3|48|...
after   6|50.1 - KEJT-HD|515000|6000|0|0|0|0|0|0|9099|3|48|...
```

Byte-identical, TSID 9099 both times, as expected for a value read from the
VCT body rather than the header.

## Note for anyone comparing against a saved channel list

TSID is persisted (`CBDAChannel::ToString` / `FromString`), so every channel
list saved by an earlier build holds a byte-swapped TSID, and a fresh scan will
now disagree with it. This is harmless: `CBDAChannel::operator==` compares only
`GetPMT()` and `GetFrequency()`, so saved channels still match after the fix
and nothing needs re-scanning. Flagging it so the difference is not mistaken
for a regression.

## Second commit: the same header in ParseEIT

`ParseEIT` parses its own inline copy of the header. Its hand-rolled
little-endian service id was already correct, so this is not a behaviour fix
there — the second commit makes it use the same idiom, for one reason: with
`ParseSIHeader` corrected, that lone workaround and its puzzled comment are an
invitation for someone to later "fix" it into a bug.

`ServiceId` is bit-identical before and after — the old `b0 + 0x100*b1` and
`_byteswap_ushort(BitRead(16))` compute the same value from the same two bytes,
checked exhaustively over all 65 536 inputs. Byte consumption is 40 bits either
way. `SectionSyntaxIndicator` and `SectionLength` go from wrong to correct;
neither has any reader in the codebase. The now-unused `ulGetSID` declaration
is removed.
