### PR TITLE
Allow editing keyboard shortcuts on the Keys page without a mouse

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -12695,7 +12695,9 @@ void CMainFrame::ToggleFullscreen(bool fToNearest, bool fSwitchScreenResWhenHasT
             }
 
             if (m_wndPlaylistBar.IsHiddenDueToFullscreen() && !m_controls.ControlChecked(CMainFrameControls::Panel::PLAYLIST)) {
-                if (s.bHideWindowedControls) {
+                // A floating playlist can not be revealed by the autohide logic, which only knows about dock zones,
+                // so it has to be restored right away even when windowed controls are set to autohide.
+                if (s.bHideWindowedControls && !m_wndPlaylistBar.IsFloating()) {
                     m_wndPlaylistBar.SetHiddenDueToFullscreen(false, true);
                 } else {
                     m_wndPlaylistBar.SetHiddenDueToFullscreen(false);

--- a/src/mpc-hc/PPageAccelTbl.cpp
+++ b/src/mpc-hc/PPageAccelTbl.cpp
@@ -115,6 +115,15 @@ BOOL CPPageAccelTbl::PreTranslateMessage(MSG* pMsg)
         return TRUE;
     }
 
+    if (pMsg->message == WM_KEYDOWN && (pMsg->wParam == VK_SPACE || pMsg->wParam == VK_RETURN) && pMsg->hwnd == m_list.m_hWnd
+            && GetKeyState(VK_CONTROL) >= 0 && GetKeyState(VK_MENU) >= 0 && GetKeyState(VK_SHIFT) >= 0) {
+        int nItem = m_list.GetNextItem(-1, LVNI_FOCUSED);
+        if (nItem >= 0) {
+            m_list.BeginInPlaceEdit(nItem, COL_KEY);
+            return TRUE;
+        }
+    }
+
     return __super::PreTranslateMessage(pMsg);
 }
 

--- a/src/mpc-hc/PlayerListCtrl.cpp
+++ b/src/mpc-hc/PlayerListCtrl.cpp
@@ -50,6 +50,11 @@ END_MESSAGE_MAP()
 // CInPlaceHotKey message handlers
 BOOL CInPlaceWinHotkey::PreTranslateMessage(MSG* pMsg)
 {
+    if (pMsg->message == WM_KEYDOWN && pMsg->wParam == VK_TAB) {
+        GetParent()->SetFocus();
+        return TRUE;
+    }
+
     if (pMsg->message == WM_KEYDOWN) {
         if (pMsg->wParam == VK_RETURN
                 || pMsg->wParam == VK_DELETE
@@ -922,6 +927,17 @@ void CPlayerListCtrl::OnLButtonDown(UINT nFlags, CPoint point)
 }
 
 
+void CPlayerListCtrl::BeginInPlaceEdit(int nItem, int nSubItem)
+{
+    LV_DISPINFO dispinfo = {};
+    dispinfo.hdr.hwndFrom = m_hWnd;
+    dispinfo.hdr.idFrom = GetDlgCtrlID();
+    dispinfo.hdr.code = LVN_DOLABELEDIT;
+    dispinfo.item.iItem = nItem;
+    dispinfo.item.iSubItem = nSubItem;
+    GetParent()->SendMessage(WM_NOTIFY, GetDlgCtrlID(), (LPARAM)&dispinfo);
+}
+
 void CPlayerListCtrl::OnTimer(UINT_PTR nIDEvent)
 {
     if (nIDEvent == m_nTimerID) {
@@ -930,13 +946,7 @@ void CPlayerListCtrl::OnTimer(UINT_PTR nIDEvent)
 
         UINT flag = LVIS_FOCUSED;
         if ((GetItemState(m_nItemClicked, flag) & flag) == flag && m_nSubItemClicked >= 0) {
-            LV_DISPINFO dispinfo = {};
-            dispinfo.hdr.hwndFrom = m_hWnd;
-            dispinfo.hdr.idFrom = GetDlgCtrlID();
-            dispinfo.hdr.code = LVN_DOLABELEDIT;
-            dispinfo.item.iItem = m_nItemClicked;
-            dispinfo.item.iSubItem = m_nSubItemClicked;
-            GetParent()->SendMessage(WM_NOTIFY, GetDlgCtrlID(), (LPARAM)&dispinfo);
+            BeginInPlaceEdit(m_nItemClicked, m_nSubItemClicked);
         }
     } else if (nIDEvent == 43) {
         // CListCtrl does really strange things on this timer.

--- a/src/mpc-hc/PlayerListCtrl.h
+++ b/src/mpc-hc/PlayerListCtrl.h
@@ -166,6 +166,7 @@ public:
 
     static LRESULT SendLabelEditNotify(CWnd* pList, UINT code, int nItem, int nSubItem, LPCTSTR pszText = nullptr);
 
+    void BeginInPlaceEdit(int nItem, int nSubItem);
     CWinHotkeyCtrl* ShowInPlaceWinHotkey(int nItem, int nCol);
     CInPlaceEdit* ShowInPlaceEdit(int nItem, int nCol);
     CEdit* ShowInPlaceFloatEdit(int nItem, int nCol);

--- a/src/mpc-hc/WinHotkeyCtrl.cpp
+++ b/src/mpc-hc/WinHotkeyCtrl.cpp
@@ -32,6 +32,7 @@
 
 HHOOK CWinHotkeyCtrl::sm_hhookKb = nullptr;
 CWinHotkeyCtrl* CWinHotkeyCtrl::sm_pwhcFocus = nullptr;
+DWORD CWinHotkeyCtrl::sm_fModsDown = 0;
 
 
 IMPLEMENT_DYNAMIC(CWinHotkeyCtrl, CEdit)
@@ -73,9 +74,49 @@ LRESULT CALLBACK CWinHotkeyCtrl::LowLevelKeyboardProc(int nCode, WPARAM wParam, 
 {
     LRESULT lResult = 1;
 
+    if (nCode < 0) {
+        return ::CallNextHookEx(sm_hhookKb, nCode, wParam, lParam);
+    }
+
     if (nCode == HC_ACTION && (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN ||
                                wParam == WM_KEYUP || wParam == WM_SYSKEYUP) && sm_pwhcFocus) {
-        sm_pwhcFocus->PostMessage(WM_KEY, ((PKBDLLHOOKSTRUCT)lParam)->vkCode, (wParam & 1));
+        DWORD vkCode = ((PKBDLLHOOKSTRUCT)lParam)->vkCode;
+        BOOL fUp = (wParam & 1);
+        DWORD fMod = 0;
+
+        switch (vkCode) {
+            case VK_CONTROL:
+            case VK_LCONTROL:
+            case VK_RCONTROL:
+                fMod = MOD_CONTROL;
+                break;
+            case VK_MENU:
+            case VK_LMENU:
+            case VK_RMENU:
+                fMod = MOD_ALT;
+                break;
+            case VK_SHIFT:
+            case VK_LSHIFT:
+            case VK_RSHIFT:
+                fMod = MOD_SHIFT;
+                break;
+        }
+        if (fMod) {
+            if (fUp) {
+                sm_fModsDown &= ~fMod;
+            } else {
+                sm_fModsDown |= fMod;
+            }
+        }
+
+        // Tab and Enter without modifiers leave the field through the normal message flow,
+        // so keyboard-only users are not trapped in it. Ctrl+Enter, Shift+Tab etc. stay assignable
+        // (a modifier press has already replaced the recorded key by the time Tab arrives).
+        if ((vkCode == VK_RETURN || vkCode == VK_TAB) && sm_fModsDown == 0) {
+            return ::CallNextHookEx(sm_hhookKb, nCode, wParam, lParam);
+        }
+
+        sm_pwhcFocus->PostMessage(WM_KEY, vkCode, fUp);
     }
     return lResult;
 }
@@ -86,6 +127,17 @@ BOOL CWinHotkeyCtrl::InstallKbHook()
         sm_pwhcFocus->UninstallKbHook();
     }
     sm_pwhcFocus = this;
+    // seed with the modifiers already held, so a combo started before the field got focus is still recorded
+    sm_fModsDown = 0;
+    if (GetAsyncKeyState(VK_CONTROL) < 0) {
+        sm_fModsDown |= MOD_CONTROL;
+    }
+    if (GetAsyncKeyState(VK_MENU) < 0) {
+        sm_fModsDown |= MOD_ALT;
+    }
+    if (GetAsyncKeyState(VK_SHIFT) < 0) {
+        sm_fModsDown |= MOD_SHIFT;
+    }
 
     sm_hhookKb = ::SetWindowsHookEx(WH_KEYBOARD_LL, (HOOKPROC)LowLevelKeyboardProc, GetModuleHandle(nullptr), 0);
 

--- a/src/mpc-hc/WinHotkeyCtrl.h
+++ b/src/mpc-hc/WinHotkeyCtrl.h
@@ -43,6 +43,7 @@ public:
 private:
     static HHOOK sm_hhookKb;
     static CWinHotkeyCtrl* sm_pwhcFocus;
+    static DWORD sm_fModsDown;
     bool isMouseModifier;
 
     UINT m_vkCode, m_vkCode_def;


### PR DESCRIPTION
Fixes #4137

Shortcuts on the Keys page could only be edited by clicking a cell, and once the hotkey field had focus its low-level keyboard hook swallowed every key event system-wide, so there was no keyboard way out.

### Behaviour

| Key | State | Result |
|---|---|---|
| Space or Enter (no modifier) | list focused | Starts editing the Key column of the focused row |
| Any key or combination | editing | Shown as the candidate shortcut (unchanged) |
| Space, Esc, Apps, with or without modifiers | editing | Recorded as the candidate; no special handling, since these are default hotkeys and must stay assignable |
| Enter, no modifier held | editing | Commits and ends the edit; focus returns to the list on the same row |
| Enter with Ctrl/Alt/Shift held | editing | Recorded as the candidate (Ctrl+Enter etc. stay assignable) |
| Tab, no modifier held | editing | Commits and ends the edit; focus returns to the list |
| Shift+Tab, Ctrl+Tab, Alt+Tab | editing | Unchanged (Shift+Tab is recorded; Alt+Tab was already rejected) |

Plain Tab is the one combination that becomes unassignable, as discussed in the issue. Escape deliberately does not cancel, because it is a default hotkey.

### Implementation

- **`WinHotkeyCtrl.cpp`**: the `WH_KEYBOARD_LL` hook now tracks the physically held Ctrl/Alt/Shift state (seeded from `GetAsyncKeyState` when the hook installs, so a modifier already held when the field takes focus is still counted). Tab and Enter with no modifier held are passed to `CallNextHookEx` instead of being swallowed, so they reach the field through the normal message flow. Everything else is still captured for recording. `nCode < 0` is now forwarded as the hook contract requires.
- **`PlayerListCtrl.cpp`**: the `LVN_DOLABELEDIT` notification that the click timer sends is extracted into a public `CPlayerListCtrl::BeginInPlaceEdit(nItem, nSubItem)`; the mouse path calls it unchanged. `CInPlaceWinHotkey::PreTranslateMessage` handles Tab the same way the existing (previously unreachable) Enter path does: focus goes back to the list, which fires `LVN_ENDLABELEDIT` and applies the value.
- **`PPageAccelTbl.cpp`**: `PreTranslateMessage` intercepts Space/Enter on the list before the dialog manager, so Enter starts an edit instead of pressing the sheet's OK button, and calls `BeginInPlaceEdit` on the focused row's Key column.

Only the Key column is keyboard-editable; the App Command, RemoteCmd and RepCnt columns are unchanged. The Apply/Clear/Cancel popup on the field is still mouse-only.

### Testing

Keyboard-only run with injected input (which does pass through the low-level hook, unlike posted messages), Release x64, dark theme: Tab to the list, Down to a row, Space, Ctrl+Shift+F7, Tab; Down, Enter, Esc, Ctrl+Enter, F8, Enter; Down, Space, Shift+Tab, F9, Tab; Tab to OK, Enter. Esc and Ctrl+Enter were displayed in the field without ending the edit, Enter on the list did not close Options, and the three rows were saved as Ctrl+Shift+F7, F8 and F9 in `[Commands2]`. The mouse path is unchanged in code but was not re-exercised in that run.

### Screenshot

Editor opened on the Open Directory row with Space, Ctrl+Shift+F7 pressed, before Tab commits it (no mouse used):

![Keys page hotkey editor opened from the keyboard](https://raw.githubusercontent.com/adipose/mpc-hc/pr4150-assets/keys-editor-opened-by-keyboard.png)
