### PR TITLE
Build IntelQuickSyncDecoder with Visual Studio 2026

### DIFF
--- a/src/thirdparty/LAVFilters/Directory.Build.props
+++ b/src/thirdparty/LAVFilters/Directory.Build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Applies to every project under this directory, the LAV submodule's included.
+     IntelQuickSyncDecoder.vcxproj maps toolsets itself and stops at VS 17.0; this adds 18.0. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Configuration" Condition="'$(MSBuildProjectName)'=='IntelQuickSyncDecoder' And '$(VisualStudioVersion)'=='18.0'">
+    <PlatformToolset>v143</PlatformToolset>
+    <SpectreMitigation>false</SpectreMitigation>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
`IntelQuickSyncDecoder.vcxproj` (the qsdecoder submodule inside LAV Filters) selects its toolset with one `PropertyGroup` per `VisualStudioVersion`, ending at 17.0. `src\platform.props` already maps 18.0 to v143 for every other project, but qsdecoder does not import it, so under Visual Studio 2026 the project falls through to its `v100` default and the LAV build stops with:

```
Microsoft.CppBuild.targets(473,5): error MSB8020: The build tools for Visual Studio 2010 (Platform Toolset = 'v100') cannot be found.
```

This adds `src\thirdparty\LAVFilters\Directory.Build.props`, which MSBuild picks up automatically for every project below that directory, submodules included. It applies the same three properties the project's own 17.0 block sets (v143, no Spectre mitigation, Windows SDK 10.0), only for `IntelQuickSyncDecoder` and only when `VisualStudioVersion` is 18.0. Nothing changes for VS 2022 and earlier, and the submodule itself is untouched, so no fork or pin change is needed.

Verified with the VS 2026 MSBuild (v180, 14.51): `IntelQuickSyncDecoder` Release x64 fails with MSB8020 without the file and builds and links with it.
