### PR TITLE
Fix volume percentage vertical alignment in the modern theme

### DIFF
--- a/src/mpc-hc/VolumeCtrl.cpp
+++ b/src/mpc-hc/VolumeCtrl.cpp
@@ -130,6 +130,43 @@ void CVolumeCtrl::getCustomChannelRect(LPRECT rc)
     }
 }
 
+void CVolumeCtrl::drawPercentage(CDC& dc, const CStringW& str, const CRect& rc)
+{
+    const UINT format = DT_CENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX;
+
+    // DT_VCENTER centres the line box, which is ascent + descent. The readout is only
+    // digits and '%', none of which descend, so the descent below the baseline is dead
+    // space while the font's internal leading pads the top, and the glyphs sit low in
+    // the channel by (ascent - capHeight - descent) / 2. Centre the glyph ink instead,
+    // measured from the font itself so it holds at every DPI and toolbar size.
+    static const MAT2 identity = { { 0, 1 }, { 0, 0 }, { 0, 0 }, { 0, 1 } };
+    TEXTMETRIC tm;
+    int aboveBaseline = 0, belowBaseline = 0;
+    if (dc.GetTextMetrics(&tm)) {
+        for (int i = 0; i < str.GetLength(); i++) {
+            GLYPHMETRICS gm;
+            if (GDI_ERROR != ::GetGlyphOutlineW(dc.GetSafeHdc(), str[i], GGO_METRICS, &gm, 0, nullptr, &identity)) {
+                aboveBaseline = std::max<int>(aboveBaseline, gm.gmptGlyphOrigin.y);
+                belowBaseline = std::max<int>(belowBaseline, (int)gm.gmBlackBoxY - gm.gmptGlyphOrigin.y);
+            }
+        }
+    }
+
+    CRect textRect(rc);
+    const int inkHeight = aboveBaseline + belowBaseline;
+    if (inkHeight <= 0 || inkHeight > rc.Height()) {
+        // bitmap font, or the glyphs do not fit anyway: nothing better than DT_VCENTER
+        dc.DrawTextW(str, textRect, format | DT_VCENTER);
+        return;
+    }
+
+    // equal space above and below the ink; any odd leftover pixel goes below, which
+    // reads better than the other way round
+    textRect.top = rc.top + (rc.Height() - inkHeight) / 2 + aboveBaseline - tm.tmAscent;
+    textRect.bottom = textRect.top + tm.tmHeight;
+    dc.DrawTextW(str, textRect, format | DT_TOP);
+}
+
 void CVolumeCtrl::OnNMCustomdraw(NMHDR* pNMHDR, LRESULT* pResult)
 {
     LPNMCUSTOMDRAW pNMCD = reinterpret_cast<LPNMCUSTOMDRAW>(pNMHDR);
@@ -488,7 +525,7 @@ void CVolumeCtrl::OnPaint() {
             int oldMode = dcMem.SetBkMode(TRANSPARENT);
             CStringW str;
             str.Format(IDS_VOLUME, GetPos());
-            dcMem.DrawTextW(str, r, DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
+            drawPercentage(dcMem, str, r);
             dcMem.SelectObject(oldFont);
             dcMem.SetBkMode(oldMode);
         }

--- a/src/mpc-hc/VolumeCtrl.h
+++ b/src/mpc-hc/VolumeCtrl.h
@@ -42,6 +42,7 @@ public:
 protected:
     afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
     void getCustomChannelRect(LPRECT rc);
+    void drawPercentage(CDC& dc, const CStringW& str, const CRect& rc);
     void updateModernVolCtrl(CPoint point);
     bool m_bDrag, m_bHover;
     bool modernStyle;


### PR DESCRIPTION
## Summary

Fixes a follow-up report on #4076: the "100%" readout on the volume slider (modern theme, self-drawn) sits visibly low in its box, more noticeably at higher DPI scaling.

`CVolumeCtrl::OnPaint` drew the text with `DT_VCENTER`, which centres the font's ascent+descent line box. The readout is only digits and `%`, none of which have descenders, so the line box's descent-side dead space plus the font's internal leading push the visible ink down inside the box. The effect grows with font size, so it is worse at high DPI/toolbar-size settings and easy to miss at 100%.

The fix measures the actual glyph ink (via `GetGlyphOutlineW`) instead of relying on the font's line metrics, and centres that ink in the box. It falls back to the old `DT_VCENTER` behavior if ink metrics can't be obtained (e.g. a bitmap font).

Measured against font heights 12–44px and toolbar sizes 26/28/30/32/36 in the modern theme: current code drifts the ink up to ~1.5px low (worse at larger sizes), consistently returning to a symmetric ~0px offset with this change.

## Test plan
- [x] Built `mpc-hc.vcxproj` (Release x64) and confirmed it compiles clean
- [x] Captured the volume control at multiple `DefaultToolbarSize` values (26/28/30/32/36) in the dark modern theme, before and after, and confirmed the ink is vertically centred after the change at every size tested
- [x] Confirmed no visible change to the box border, fill, or sizes that were already centred
