### PR TITLE
Fix mpc-hc.rc checking out with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.sh text eol=lf
 *.po text eol=crlf
-src/mpc-hc/mpc-hc.rc text working-tree-encoding=UTF-16LE-BOM eol=CRLF
+src/mpc-hc/mpc-hc.rc text working-tree-encoding=UTF-16LE-BOM eol=crlf


### PR DESCRIPTION
git matches eol values case-sensitively, so eol=CRLF was ignored and the file fell back to core.autocrlf. With autocrlf=input it checked out as LF, which the translation scripts cannot parse.