### PR TITLE
keep the playing file first when sorting a redirected multi-file open

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -5426,7 +5426,10 @@ void CMainFrame::ProcessCommandLine(CAtlList<CString>& cmdln, ULONGLONG tArrived
                 }
             } else {
                 fSetForegroundWindow = true;
-                m_nLastAppendSelectionIndex = 0; // the playlist gets replaced below
+                // The playlist gets replaced below and its first item starts playing. The rest of
+                // the selection is sorted in under it, so the playing item stays on top: sorting
+                // from 0 moved it into the middle and everything sorted before it never played.
+                m_nLastAppendSelectionIndex = 1;
 
                 if (GetMediaState() == State_Running) {
                     MediaControlPause(true);


### PR DESCRIPTION
From #4168.  The sort added in #3995 started at index 0 on the open path, so the file that Explorer launched first, which is already playing, got sorted into the middle of the selection and everything sorted in front of it never played.  The sort now starts at index 1 there, leaving the playing item on top and the rest of the selection in path order under it.  The append path is unchanged since nothing in that batch is playing.

Tested with a release x64 build by launching five files the way Explorer does, one process each with c first: c plays, then a, b, d, e follow in order, and the playlist reads c, a, b, d, e.
