### PR TITLE
add a droptarget verb served by the player exe

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -2749,6 +2749,8 @@ void CAppSettings::ParseCommandLine(CAtlList<CString>& cmdln)
                 nCLSwitches |= CLSW_MINIMIZED;
             } else if (sw == _T("new")) {
                 nCLSwitches |= CLSW_NEW;
+            } else if (sw == _T("embedding")) { // COM appends -Embedding when it starts a local server
+                nCLSwitches |= CLSW_EMBEDDING;
             } else if (sw == _T("help") || sw == _T("h") || sw == _T("?")) {
                 nCLSwitches |= CLSW_HELP;
             } else if (sw == _T("dub") && pos) {

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -99,6 +99,7 @@ enum : UINT64 {
     CLSW_THUMBNAILS = CLSW_VOLUME << 1,
     CLSW_DVBSCAN = CLSW_THUMBNAILS << 1,
     CLSW_UNRECOGNIZEDSWITCH = CLSW_DVBSCAN << 1, // 48
+    CLSW_EMBEDDING = CLSW_UNRECOGNIZEDSWITCH << 1, // started by COM to serve an Explorer verb, see ShellDropTarget.h
 };
 
 enum MpcCaptionState {

--- a/src/mpc-hc/FileAssoc.cpp
+++ b/src/mpc-hc/FileAssoc.cpp
@@ -25,6 +25,7 @@
 #include "FileAssoc.h"
 #include "resource.h"
 #include "PathUtils.h"
+#include "ShellDropTarget.h"
 
 
 // TODO: change this along with the root key for settings and the mutex name to
@@ -63,6 +64,13 @@ void CFileAssoc::IconLib::SaveVersion() const
     AfxGetApp()->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_ICON_LIB_VERSION, m_fnGetIconLibVersion());
 }
 
+static CString ClsidToString(const CLSID& clsid)
+{
+    OLECHAR buff[40] = {};
+    VERIFY(StringFromGUID2(clsid, buff, _countof(buff)));
+    return buff;
+}
+
 CFileAssoc::CFileAssoc()
     : m_iconLibPath(PathUtils::CombinePaths(PathUtils::GetProgramPath(), _T("mpciconlib.dll")))
     , m_strRegisteredAppName(_T("Media Player Classic"))
@@ -71,6 +79,8 @@ CFileAssoc::CFileAssoc()
     , m_strRegAppFileAssocKey(_T("Software\\Clients\\Media\\Media Player Classic\\Capabilities\\FileAssociations"))
     , m_strOpenCommand(_T("\"") + PathUtils::GetProgramPath(true) + _T("\" \"%1\""))
     , m_strEnqueueCommand(_T("\"") + PathUtils::GetProgramPath(true) + _T("\" /add \"%1\""))
+    , m_strPlayClsid(ClsidToString(CLSID_MPCHCDropTargetPlay))
+    , m_strEnqueueClsid(ClsidToString(CLSID_MPCHCDropTargetEnqueue))
     , m_bNoRecentDocs(false)
     , m_checkIconsAssocInactiveEvent(TRUE, TRUE) // initially set, manual reset
 {
@@ -165,6 +175,42 @@ bool CFileAssoc::RegisterApp()
     return success;
 }
 
+// A verb with a DropTarget entry makes Explorer hand a whole selection to one COM call
+// instead of running the command line once per file. The command line stays as it is: it is
+// what other launchers use and what Explorer falls back to if the activation fails.
+bool CFileAssoc::RegisterDropTargetServer()
+{
+    const CString strServer = _T("\"") + PathUtils::GetProgramPath(true) + _T("\"");
+    const struct {
+        const CString& strClsid;
+        LPCTSTR strName;
+    } classes[] = {
+        { m_strPlayClsid, _T("MPC-HC Play") },
+        { m_strEnqueueClsid, _T("MPC-HC Add to playlist") },
+    };
+
+    for (const auto& cls : classes) {
+        CRegKey key;
+        if (ERROR_SUCCESS != key.Create(HKEY_CLASSES_ROOT, _T("CLSID\\") + cls.strClsid)
+                || ERROR_SUCCESS != key.SetStringValue(nullptr, cls.strName)
+                || ERROR_SUCCESS != key.Create(HKEY_CLASSES_ROOT, _T("CLSID\\") + cls.strClsid + _T("\\LocalServer32"))
+                || ERROR_SUCCESS != key.SetStringValue(nullptr, strServer)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CFileAssoc::UnregisterDropTargetServer()
+{
+    CRegKey key;
+    key.Attach(HKEY_CLASSES_ROOT);
+    bool success = (ERROR_SUCCESS == key.RecurseDeleteKey(_T("CLSID\\") + m_strPlayClsid));
+    success &= (ERROR_SUCCESS == key.RecurseDeleteKey(_T("CLSID\\") + m_strEnqueueClsid));
+    key.Detach();
+    return success;
+}
+
 bool CFileAssoc::Register(CString ext, CString strLabel, bool bRegister, bool bAddEnqueueContextMenu, bool bAssociatedWithIcon)
 {
     CRegKey key;
@@ -206,7 +252,9 @@ bool CFileAssoc::Register(CString ext, CString strLabel, bool bRegister, bool bA
                     || ERROR_SUCCESS != key.SetStringValue(_T("Icon"), appIcon)
                     || ERROR_SUCCESS != key.SetStringValue(_T("MultiSelectModel"), _T("Player"))
                     || ERROR_SUCCESS != key.Create(HKEY_CLASSES_ROOT, strProgID + _T("\\shell\\enqueue\\command"))
-                    || ERROR_SUCCESS != key.SetStringValue(nullptr, m_strEnqueueCommand)) {
+                    || ERROR_SUCCESS != key.SetStringValue(nullptr, m_strEnqueueCommand)
+                    || ERROR_SUCCESS != key.Create(HKEY_CLASSES_ROOT, strProgID + _T("\\shell\\enqueue\\DropTarget"))
+                    || ERROR_SUCCESS != key.SetStringValue(_T("Clsid"), m_strEnqueueClsid)) {
                 return false;
             }
         } else {
@@ -225,7 +273,10 @@ bool CFileAssoc::Register(CString ext, CString strLabel, bool bRegister, bool bA
             return false;
         }
         if (ERROR_SUCCESS != key.Create(HKEY_CLASSES_ROOT, strProgID + _T("\\shell\\open\\command"))
-                || ERROR_SUCCESS != key.SetStringValue(nullptr, m_strOpenCommand)) {
+                || ERROR_SUCCESS != key.SetStringValue(nullptr, m_strOpenCommand)
+                || ERROR_SUCCESS != key.Create(HKEY_CLASSES_ROOT, strProgID + _T("\\shell\\open\\DropTarget"))
+                || ERROR_SUCCESS != key.SetStringValue(_T("Clsid"), m_strPlayClsid)
+                || !RegisterDropTargetServer()) {
             return false;
         }
 
@@ -434,6 +485,9 @@ bool CFileAssoc::RegisterFolderContextMenuEntries(bool bRegister)
                 key.SetStringValue(nullptr, m_strEnqueueCommand);
                 success = true;
             }
+            if (ERROR_SUCCESS == key.Create(HKEY_CLASSES_ROOT, _T("Directory\\shell\\") PROGID _T(".enqueue\\DropTarget"))) {
+                key.SetStringValue(_T("Clsid"), m_strEnqueueClsid);
+            }
         }
 
         if (success && ERROR_SUCCESS == key.Create(HKEY_CLASSES_ROOT, _T("Directory\\shell\\") PROGID _T(".play"))) {
@@ -446,6 +500,10 @@ bool CFileAssoc::RegisterFolderContextMenuEntries(bool bRegister)
                 key.SetStringValue(nullptr, m_strOpenCommand);
                 success = true;
             }
+            if (ERROR_SUCCESS == key.Create(HKEY_CLASSES_ROOT, _T("Directory\\shell\\") PROGID _T(".play\\DropTarget"))) {
+                key.SetStringValue(_T("Clsid"), m_strPlayClsid);
+            }
+            RegisterDropTargetServer();
         }
 
     } else {

--- a/src/mpc-hc/FileAssoc.h
+++ b/src/mpc-hc/FileAssoc.h
@@ -79,6 +79,10 @@ public:
 
     bool RegisterApp();
 
+    // The COM classes behind the verbs' DropTarget entries, served by this executable.
+    bool RegisterDropTargetServer();
+    bool UnregisterDropTargetServer();
+
     bool Register(CString ext, CString strLabel, bool bRegister, bool bRegisterContextMenuEntries, bool bAssociatedWithIcon);
     bool IsRegistered(CString ext) const;
     bool HasEnqueueContextMenuEntry(CString strExt) const;
@@ -126,6 +130,8 @@ protected:
 
     const CString m_strOpenCommand;
     const CString m_strEnqueueCommand;
+    const CString m_strPlayClsid;
+    const CString m_strEnqueueClsid;
 
     bool m_bNoRecentDocs;
 

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -5182,19 +5182,25 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCDS)
         cmdln.AddTail(str);
     }
 
-    // Queue the command line and return at once. Everything past this point probes the
-    // filesystem, and a path on an unreachable share blocks it for half a minute. While that
-    // ran inside this handler the window was not pumping messages, so Windows marked it as
-    // not responding and the other instances redirecting to us gave up and each opened a
-    // window of their own (#4149). The arrival time travels with the command line, so a slow
-    // open cannot make the next file of the same Explorer selection look like a new one.
+    QueueCommandLine(cmdln);
+
+    return TRUE;
+}
+
+// Queue a command line and return at once. Everything that acts on it probes the filesystem,
+// and a path on an unreachable share blocks that for half a minute. While it ran inside the
+// WM_COPYDATA handler the window was not pumping messages, so Windows marked it as not
+// responding and the other instances redirecting to us gave up and each opened a window of
+// their own (#4149). The arrival time travels with the command line, so a slow open cannot
+// make the next file of the same Explorer selection look like a new one. The Explorer drop
+// target (ShellDropTarget.cpp) comes in here too, with Explorer itself waiting on the return.
+void CMainFrame::QueueCommandLine(const CAtlList<CString>& cmdln)
+{
     m_pendingCommandLines.emplace_back();
     PendingCommandLine& pending = m_pendingCommandLines.back();
     pending.tArrived = GetTickCount64();
     pending.cmdln.AddTailList(&cmdln);
     VERIFY(PostMessage(WM_MPC_CMDLINE));
-
-    return TRUE;
 }
 
 LRESULT CMainFrame::OnCommandLineReceived(WPARAM wParam, LPARAM lParam)

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1334,6 +1334,7 @@ public:
 
     void        SetLoadState(MLS eState);
     MLS         GetLoadState() const;
+    void        QueueCommandLine(const CAtlList<CString>& cmdln);
     bool        IsStateLoaded();
     bool        IsStateLoadedOrLoading();
     bool        IsStateClosed();

--- a/src/mpc-hc/ShellDropTarget.cpp
+++ b/src/mpc-hc/ShellDropTarget.cpp
@@ -1,0 +1,325 @@
+/*
+ * (C) 2026 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "ShellDropTarget.h"
+#include "mplayerc.h"
+#include "MainFrm.h"
+#include "PathUtils.h"
+#include <shellapi.h>
+#include <shlwapi.h>
+#include <algorithm>
+#include <vector>
+
+#ifdef _WIN64
+const CLSID CLSID_MPCHCDropTargetPlay    = { 0x97A8DFA8, 0x4C28, 0x4F94, { 0xB4, 0xB0, 0x5E, 0x2E, 0xE0, 0x26, 0x53, 0xFF } };
+const CLSID CLSID_MPCHCDropTargetEnqueue = { 0x7FDF201D, 0xC5E2, 0x4A23, { 0x9A, 0x0C, 0xD7, 0x4E, 0x89, 0x52, 0x86, 0xCB } };
+#else
+const CLSID CLSID_MPCHCDropTargetPlay    = { 0x350FCB02, 0x242B, 0x4716, { 0x8E, 0x0F, 0xD7, 0xB7, 0xDC, 0xF2, 0x8E, 0xA8 } };
+const CLSID CLSID_MPCHCDropTargetEnqueue = { 0xA1A14499, 0x02C8, 0x4A17, { 0x88, 0x95, 0x92, 0x72, 0x51, 0xC8, 0x21, 0xB2 } };
+#endif
+
+static bool GetDroppedFiles(IDataObject* pDataObj, CAtlList<CString>& files)
+{
+    if (!pDataObj) {
+        return false;
+    }
+
+    FORMATETC fmt = { CF_HDROP, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+    STGMEDIUM stg = {};
+    if (FAILED(pDataObj->GetData(&fmt, &stg))) {
+        return false;
+    }
+
+    if (HDROP hDrop = static_cast<HDROP>(GlobalLock(stg.hGlobal))) {
+        UINT nFiles = ::DragQueryFile(hDrop, UINT_MAX, nullptr, 0);
+        for (UINT iFile = 0; iFile < nFiles; iFile++) {
+            CString fn;
+            UINT res = ::DragQueryFile(hDrop, iFile, fn.GetBuffer(2048), 2048);
+            if (res) {
+                fn.ReleaseBuffer(res);
+                files.AddTail(fn);
+            }
+        }
+        GlobalUnlock(stg.hGlobal);
+    }
+    ReleaseStgMedium(&stg);
+
+    return !files.IsEmpty();
+}
+
+// Explorer enumerates a selection with the focused item first and the rest in no order
+// worth keeping, so the batch is put in path order here, once, before the player sees it.
+// Same comparison as the playlist's own sort by path.
+static void SortByPath(CAtlList<CString>& files)
+{
+    std::vector<CString> v;
+    v.reserve(files.GetCount());
+    POSITION pos = files.GetHeadPosition();
+    while (pos) {
+        v.emplace_back(files.GetNext(pos));
+    }
+    std::sort(v.begin(), v.end(), [](const CString& a, const CString& b) {
+        return StrCmpLogicalW(a, b) < 0;
+    });
+    files.RemoveAll();
+    for (const CString& fn : v) {
+        files.AddTail(fn);
+    }
+}
+
+// With multiple instances allowed, a selection opened while this instance is busy gets a
+// window of its own, which is what the command line path gave it before the drop target
+// existed. It is one process for the whole selection, not one per file.
+static bool LaunchNewInstance(const CAtlList<CString>& files)
+{
+    CString args;
+    POSITION pos = files.GetHeadPosition();
+    while (pos) {
+        if (!args.IsEmpty()) {
+            args += _T(' ');
+        }
+        args += _T('"') + files.GetNext(pos) + _T('"');
+    }
+    if (args.GetLength() > 30000) { // longer than a command line can carry
+        return false;
+    }
+
+    SHELLEXECUTEINFO sei = { sizeof(sei) };
+    sei.fMask = SEE_MASK_NOASYNC;
+    sei.lpFile = PathUtils::GetProgramPath(true);
+    sei.lpParameters = args;
+    sei.nShow = SW_SHOWNORMAL;
+    return !!ShellExecuteEx(&sei);
+}
+
+// CShellDropTarget
+
+CShellDropTarget::CShellDropTarget(CMainFrame* pMainFrame, bool bAppend)
+    : m_cRef(1)
+    , m_pMainFrame(pMainFrame)
+    , m_bAppend(bAppend)
+{
+}
+
+STDMETHODIMP CShellDropTarget::QueryInterface(REFIID riid, void** ppv)
+{
+    if (!ppv) {
+        return E_POINTER;
+    }
+    if (riid == IID_IUnknown || riid == IID_IDropTarget) {
+        *ppv = static_cast<IDropTarget*>(this);
+        AddRef();
+        return S_OK;
+    }
+    *ppv = nullptr;
+    return E_NOINTERFACE;
+}
+
+STDMETHODIMP_(ULONG) CShellDropTarget::AddRef()
+{
+    return InterlockedIncrement(&m_cRef);
+}
+
+STDMETHODIMP_(ULONG) CShellDropTarget::Release()
+{
+    ULONG cRef = InterlockedDecrement(&m_cRef);
+    if (cRef == 0) {
+        delete this;
+    }
+    return cRef;
+}
+
+STDMETHODIMP CShellDropTarget::DragEnter(IDataObject* pDataObj, DWORD, POINTL, DWORD* pdwEffect)
+{
+    if (!pdwEffect) {
+        return E_POINTER;
+    }
+    FORMATETC fmt = { CF_HDROP, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+    *pdwEffect = (pDataObj && pDataObj->QueryGetData(&fmt) == S_OK) ? DROPEFFECT_COPY : DROPEFFECT_NONE;
+    return S_OK;
+}
+
+STDMETHODIMP CShellDropTarget::DragOver(DWORD, POINTL, DWORD* pdwEffect)
+{
+    if (!pdwEffect) {
+        return E_POINTER;
+    }
+    *pdwEffect = DROPEFFECT_COPY;
+    return S_OK;
+}
+
+STDMETHODIMP CShellDropTarget::DragLeave()
+{
+    return S_OK;
+}
+
+// Runs on the main thread, called from Explorer through COM. Explorer waits for it to
+// return, so nothing here may touch the filesystem or the graph: the command line is
+// queued the same way a redirected one is and acted on after this call has returned.
+STDMETHODIMP CShellDropTarget::Drop(IDataObject* pDataObj, DWORD, POINTL, DWORD* pdwEffect)
+{
+    if (!pdwEffect) {
+        return E_POINTER;
+    }
+    *pdwEffect = DROPEFFECT_NONE;
+
+    CAtlList<CString> files;
+    if (!GetDroppedFiles(pDataObj, files)) {
+        return E_INVALIDARG;
+    }
+    SortByPath(files);
+
+    if (!m_pMainFrame || !::IsWindow(m_pMainFrame->m_hWnd)) {
+        return E_UNEXPECTED;
+    }
+
+    const CAppSettings& s = AfxGetAppSettings();
+    if (!m_bAppend && s.GetAllowMultiInst() && m_pMainFrame->GetLoadState() != MLS::CLOSED
+            && LaunchNewInstance(files)) {
+        *pdwEffect = DROPEFFECT_COPY;
+        return S_OK;
+    }
+
+    if (!m_bAppend) {
+        // The shell hands its foreground rights to a drop target for the duration of this
+        // call, so this is the moment to use them. Not when adding to the playlist: same rule
+        // as the command line redirect, which leaves a minimized player alone for /add.
+        if (m_pMainFrame->IsIconic()) {
+            m_pMainFrame->ShowWindow(SW_RESTORE);
+        }
+        m_pMainFrame->SetForegroundWindow();
+    }
+
+    CAtlList<CString> cmdln;
+    if (m_bAppend) {
+        cmdln.AddTail(_T("/add"));
+    }
+    cmdln.AddTailList(&files);
+    m_pMainFrame->QueueCommandLine(cmdln);
+
+    *pdwEffect = DROPEFFECT_COPY;
+    return S_OK;
+}
+
+// CShellDropTargetFactory
+
+CShellDropTargetFactory::CShellDropTargetFactory(CMainFrame* pMainFrame, bool bAppend)
+    : m_cRef(1)
+    , m_pMainFrame(pMainFrame)
+    , m_bAppend(bAppend)
+{
+}
+
+STDMETHODIMP CShellDropTargetFactory::QueryInterface(REFIID riid, void** ppv)
+{
+    if (!ppv) {
+        return E_POINTER;
+    }
+    if (riid == IID_IUnknown || riid == IID_IClassFactory) {
+        *ppv = static_cast<IClassFactory*>(this);
+        AddRef();
+        return S_OK;
+    }
+    *ppv = nullptr;
+    return E_NOINTERFACE;
+}
+
+STDMETHODIMP_(ULONG) CShellDropTargetFactory::AddRef()
+{
+    return InterlockedIncrement(&m_cRef);
+}
+
+STDMETHODIMP_(ULONG) CShellDropTargetFactory::Release()
+{
+    ULONG cRef = InterlockedDecrement(&m_cRef);
+    if (cRef == 0) {
+        delete this;
+    }
+    return cRef;
+}
+
+STDMETHODIMP CShellDropTargetFactory::CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppv)
+{
+    if (!ppv) {
+        return E_POINTER;
+    }
+    *ppv = nullptr;
+    if (pUnkOuter) {
+        return CLASS_E_NOAGGREGATION;
+    }
+    CShellDropTarget* pTarget = DEBUG_NEW CShellDropTarget(m_pMainFrame, m_bAppend);
+    HRESULT hr = pTarget->QueryInterface(riid, ppv);
+    pTarget->Release();
+    return hr;
+}
+
+STDMETHODIMP CShellDropTargetFactory::LockServer(BOOL)
+{
+    // The player's lifetime is its window, not COM's reference count.
+    return S_OK;
+}
+
+// CShellDropTargetServer
+
+CShellDropTargetServer::CShellDropTargetServer()
+    : m_dwPlayCookie(0)
+    , m_dwEnqueueCookie(0)
+{
+}
+
+CShellDropTargetServer::~CShellDropTargetServer()
+{
+    Revoke();
+}
+
+void CShellDropTargetServer::Register(CMainFrame* pMainFrame)
+{
+    ASSERT(!m_dwPlayCookie && !m_dwEnqueueCookie);
+
+    struct {
+        const CLSID& clsid;
+        bool bAppend;
+        DWORD& dwCookie;
+    } entries[] = {
+        { CLSID_MPCHCDropTargetPlay, false, m_dwPlayCookie },
+        { CLSID_MPCHCDropTargetEnqueue, true, m_dwEnqueueCookie },
+    };
+
+    for (auto& entry : entries) {
+        CComPtr<IClassFactory> pFactory;
+        pFactory.Attach(DEBUG_NEW CShellDropTargetFactory(pMainFrame, entry.bAppend));
+        HRESULT hr = CoRegisterClassObject(entry.clsid, pFactory, CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, &entry.dwCookie);
+        if (FAILED(hr)) {
+            TRACE(_T("CoRegisterClassObject failed: 0x%08x\n"), hr);
+            entry.dwCookie = 0;
+        }
+    }
+}
+
+void CShellDropTargetServer::Revoke()
+{
+    for (DWORD* pCookie : { &m_dwPlayCookie, &m_dwEnqueueCookie }) {
+        if (*pCookie) {
+            CoRevokeClassObject(*pCookie);
+            *pCookie = 0;
+        }
+    }
+}

--- a/src/mpc-hc/ShellDropTarget.h
+++ b/src/mpc-hc/ShellDropTarget.h
@@ -1,0 +1,101 @@
+/*
+ * (C) 2026 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <oleidl.h>
+
+class CMainFrame;
+
+// A file type verb that carries a DropTarget CLSID makes Explorer hand the whole selection
+// to one IDropTarget::Drop call, instead of running the verb's command line once per file
+// and leaving the player to guess which of the resulting processes belong together. This
+// executable is the server for those CLSIDs (LocalServer32), so COM connects Explorer to
+// the player that is already running, or starts one with -Embedding when none is.
+//
+// One CLSID per verb, because a drop target is not told which verb invoked it. The values
+// differ between the 32-bit and 64-bit builds, like the ProgIDs do, so both can be
+// installed side by side.
+extern const CLSID CLSID_MPCHCDropTargetPlay;
+extern const CLSID CLSID_MPCHCDropTargetEnqueue;
+
+class CShellDropTarget : public IDropTarget
+{
+public:
+    CShellDropTarget(CMainFrame* pMainFrame, bool bAppend);
+
+    // IUnknown
+    STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override;
+    STDMETHODIMP_(ULONG) AddRef() override;
+    STDMETHODIMP_(ULONG) Release() override;
+
+    // IDropTarget
+    STDMETHODIMP DragEnter(IDataObject* pDataObj, DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
+    STDMETHODIMP DragOver(DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
+    STDMETHODIMP DragLeave() override;
+    STDMETHODIMP Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
+
+private:
+    ~CShellDropTarget() = default;
+
+    LONG m_cRef;
+    CMainFrame* const m_pMainFrame;
+    const bool m_bAppend;
+};
+
+class CShellDropTargetFactory : public IClassFactory
+{
+public:
+    CShellDropTargetFactory(CMainFrame* pMainFrame, bool bAppend);
+
+    // IUnknown
+    STDMETHODIMP QueryInterface(REFIID riid, void** ppv) override;
+    STDMETHODIMP_(ULONG) AddRef() override;
+    STDMETHODIMP_(ULONG) Release() override;
+
+    // IClassFactory
+    STDMETHODIMP CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppv) override;
+    STDMETHODIMP LockServer(BOOL fLock) override;
+
+private:
+    ~CShellDropTargetFactory() = default;
+
+    LONG m_cRef;
+    CMainFrame* const m_pMainFrame;
+    const bool m_bAppend;
+};
+
+// Registers the class objects with COM for the life of the process. Every instance
+// registers, whether or not COM started it: REGCLS_MULTIPLEUSE lets one registration
+// serve any number of Explorer invocations, and COM routes them to whichever registered
+// instance is still alive.
+class CShellDropTargetServer
+{
+public:
+    CShellDropTargetServer();
+    ~CShellDropTargetServer();
+
+    void Register(CMainFrame* pMainFrame);
+    void Revoke();
+
+private:
+    DWORD m_dwPlayCookie;
+    DWORD m_dwEnqueueCookie;
+};

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -222,6 +222,7 @@ if not exist "$(OutDir)LAVFilters" if exist "$(SolutionDir)bin\mpc-hc_x86\LAVFil
     <ClCompile Include="FGManagerBDA.cpp" />
     <ClCompile Include="FileAssoc.cpp" />
     <ClCompile Include="DropTarget.cpp" />
+    <ClCompile Include="ShellDropTarget.cpp" />
     <ClCompile Include="FreeviewEPGDecode.cpp" />
     <ClCompile Include="GPUInfo.cpp" />
     <ClCompile Include="ImageGrayer.cpp" />
@@ -424,6 +425,7 @@ if not exist "$(OutDir)LAVFilters" if exist "$(SolutionDir)bin\mpc-hc_x86\LAVFil
     <ClInclude Include="FGManagerBDA.h" />
     <ClInclude Include="FileAssoc.h" />
     <ClInclude Include="DropTarget.h" />
+    <ClInclude Include="ShellDropTarget.h" />
     <ClInclude Include="FilterEnum.h" />
     <ClInclude Include="FloatEdit.h" />
     <ClInclude Include="FreeviewEPGDecode.h" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -439,6 +439,9 @@
     <ClCompile Include="DropTarget.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
+    <ClCompile Include="ShellDropTarget.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
     <ClCompile Include="CrashReporter.cpp">
       <Filter>Crash Reporter</Filter>
     </ClCompile>
@@ -1020,6 +1023,9 @@
       <Filter>Panels</Filter>
     </ClInclude>
     <ClInclude Include="DropTarget.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="ShellDropTarget.h">
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="Logger.h">

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -2190,6 +2190,7 @@ BOOL CMPlayerCApp::InitInstance()
         for (size_t i = 0, cnt = mf.GetCount(); i < cnt; i++) {
             m_s->fileAssoc.Register(mf[i], false, false, false);
         }
+        m_s->fileAssoc.UnregisterDropTargetServer();
 
         SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
 
@@ -2245,7 +2246,11 @@ BOOL CMPlayerCApp::InitInstance()
     m_mutexOneInstance.Create(nullptr, TRUE, MPC_WND_CLASS_NAME);
 
     if (GetLastError() == ERROR_ALREADY_EXISTS) {
-        if ((m_s->nCLSwitches & CLSW_ADD) || !(m_s->GetAllowMultiInst() || m_s->nCLSwitches & CLSW_NEW || m_cmdln.IsEmpty())) {
+        // Started by COM to serve an Explorer verb (see ShellDropTarget.h): there is nothing
+        // to redirect, the selection arrives through IDropTarget once this instance has
+        // registered its class objects, and exiting here would fail Explorer's activation.
+        const bool bEmbedding = !!(m_s->nCLSwitches & CLSW_EMBEDDING);
+        if (!bEmbedding && ((m_s->nCLSwitches & CLSW_ADD) || !(m_s->GetAllowMultiInst() || m_s->nCLSwitches & CLSW_NEW || m_cmdln.IsEmpty()))) {
             // The first instance owns this mutex until it has created its window, so waiting
             // for it means waiting for startup to finish. Release it again straight away:
             // holding it across the send serialized every redirecting process, so one slow
@@ -2367,6 +2372,11 @@ BOOL CMPlayerCApp::InitInstance()
     }
 
     pFrame->ActivateFrame(m_nCmdShow);
+
+    // From here on Explorer can hand this instance a selection through COM. Registered
+    // before anything below pumps messages, so an instance COM started for that purpose
+    // is reachable before the first-run prompt can hold it up.
+    m_shellDropTargetServer.Register(pFrame);
 
     if (AfxGetAppSettings().HasFixedWindowSize() && IsWindows8OrGreater()) {//make adjustments for drop shadow frame
         CRect rect, frame;
@@ -2643,6 +2653,7 @@ int CMPlayerCApp::ExitInstance()
 
     MH_Uninitialize();
 
+    m_shellDropTargetServer.Revoke();
     OleUninitialize();
 
     return CWinAppEx::ExitInstance();

--- a/src/mpc-hc/mplayerc.h
+++ b/src/mpc-hc/mplayerc.h
@@ -30,6 +30,7 @@
 #include "AppSettings.h"
 #include "MpcApi.h"
 #include "Profile.h"
+#include "ShellDropTarget.h"
 #include "../filters/renderer/VideoRenderers/RenderersSettings.h"
 #include "resource.h"
 
@@ -137,6 +138,7 @@ class CMPlayerCApp : public CWinAppEx
     enum class RedirectResult { Redirected, OpenNormally, ExitSilently };
 
     CAtlList<CString> m_cmdln;
+    CShellDropTargetServer m_shellDropTargetServer;
     void PreProcessCommandLine();
     bool SendCommandLine(HWND hWnd);
     HWND FindOtherInstance();


### PR DESCRIPTION
For #4168.  The open and enqueue verbs now carry a DropTarget CLSID next to their command line, so Explorer hands a whole selection to one IDropTarget::Drop call instead of starting a process per file.  The server for the two CLSIDs is the player itself (LocalServer32), so COM connects Explorer to the running instance, or starts one with -Embedding when nothing is running.  Nothing gets loaded into explorer.exe and nothing new needs installing, CFileAssoc writes the keys along with the verbs it already registers.

The drop target sorts the selection by path (Explorer only guarantees the focused item first), queues it through the same path as a redirected command line and returns, so Explorer never waits on a file open.  With multiple instances allowed a busy player starts a second process with the whole selection on its command line.  The command line verbs stay as they were for other launchers.

Tested with a release x64 build through a per-user test association and Explorer's own verb invocation: five files open in one process started with -Embedding and play in name order, a second open connects to that instance and replaces the playlist, enqueue appends without touching the current file, the player comes to the foreground, and a single double-click goes the same way.  Not done here: an App Paths DropTarget entry for drops on the exe or taskbar icon.
