### PR TITLE
fix gdi handle leaks in themed controls and icon transforms

### DIFF
--- a/src/mpc-hc/CMPCThemeUtil.cpp
+++ b/src/mpc-hc/CMPCThemeUtil.cpp
@@ -1358,8 +1358,8 @@ bool CMPCThemeUtil::IsWindowVisibleAndRendered(CWnd* window) {
         return false;
     } else {
         CRect r;
-        HDC hdc = GetWindowDC(window->m_hWnd);
-        GetClipBox(hdc, &r);
+        CWindowDC dc(window); // released on scope exit, a raw GetWindowDC here was never released
+        GetClipBox(dc, &r);
         if (r.IsRectEmpty()) {
             return false;
         }

--- a/src/mpc-hc/DpiHelper.cpp
+++ b/src/mpc-hc/DpiHelper.cpp
@@ -189,13 +189,14 @@ int DpiHelper::CalculateListCtrlItemHeight(CListCtrl* wnd) {
         nItemHeight = v;
     } else {
         TEXTMETRICW tm;
-        CDC* cdc = wnd->GetDC();
-        if (!cdc) {
+        CClientDC dc(wnd); // released on scope exit, a raw GetDC here was never released
+        if (!dc.m_hDC) {
             ASSERT(false);
             return 1;
         }
-        cdc->SelectObject(wnd->GetFont());
-        cdc->GetTextMetricsW(&tm);
+        CFont* pOldFont = dc.SelectObject(wnd->GetFont());
+        dc.GetTextMetricsW(&tm);
+        dc.SelectObject(pOldFont);
 
         nItemHeight = tm.tmHeight + 4;
         CImageList* ilist;

--- a/src/mpc-hc/ImageGrayer.cpp
+++ b/src/mpc-hc/ImageGrayer.cpp
@@ -277,10 +277,22 @@ bool ImageGrayer::Colorize(const CImage& imgSrc, CImage& imgDest, COLORREF fg, C
     }
 
     if (rot90) {
-        Gdiplus::Bitmap* gdiPlusBitmap = Gdiplus::Bitmap::FromHBITMAP(imgDest.Detach(), 0);
+        // FromHBITMAP copies the pixels and does not take ownership, so the
+        // detached source bitmap and the Gdiplus object both have to be freed here
+        HBITMAP hSource = imgDest.Detach();
+        Gdiplus::Bitmap* gdiPlusBitmap = Gdiplus::Bitmap::FromHBITMAP(hSource, 0);
+        if (!gdiPlusBitmap) {
+            imgDest.Attach(hSource);
+            return false;
+        }
         gdiPlusBitmap->RotateFlip(Gdiplus::Rotate90FlipNone);
-        HBITMAP hbmp;
+        HBITMAP hbmp = nullptr;
         gdiPlusBitmap->GetHBITMAP(Gdiplus::Color::White, &hbmp);
+        delete gdiPlusBitmap;
+        DeleteObject(hSource);
+        if (!hbmp) {
+            return false;
+        }
         imgDest.Attach(hbmp);
     }
 

--- a/src/mpc-hc/SVGImage.cpp
+++ b/src/mpc-hc/SVGImage.cpp
@@ -90,10 +90,13 @@ void GdiTransform(CImage& image, Gdiplus::RotateFlipType transform) {
     int bpp = image.GetBPP();
 
     HBITMAP hbmp = image.Detach();
-    Gdiplus::Bitmap* bmpTemp = Gdiplus::Bitmap::FromHBITMAP(hbmp, 0);
-    Gdiplus::PixelFormat pixel_format = bmpTemp->GetPixelFormat();
-    if (bpp == 32) {
-        pixel_format = PixelFormat32bppARGB;
+    Gdiplus::PixelFormat pixel_format = PixelFormat32bppARGB;
+    if (bpp != 32) {
+        // only needed to learn the pixel format, and was never deleted
+        std::unique_ptr<Gdiplus::Bitmap> bmpTemp(Gdiplus::Bitmap::FromHBITMAP(hbmp, 0));
+        if (bmpTemp) {
+            pixel_format = bmpTemp->GetPixelFormat();
+        }
     }
     image.Attach(hbmp);
 


### PR DESCRIPTION
Three places take a GDI handle they never give back, and one leaks a GDI+ object.  I measured the first three in a standalone test, each one is a handle per call, so they add up over a long session.

1. CMPCThemeUtil::IsWindowVisibleAndRendered called GetWindowDC and never released it.  It runs from hideNativeScrollBars on every scroll and resize of a themed control.  Now uses CWindowDC.
2. DpiHelper::CalculateListCtrlItemHeight did the same with CWnd::GetDC, and left the list font selected.  Now uses CClientDC and restores the font.
3. ImageGrayer::Colorize with rot90 detached the source bitmap into Gdiplus::Bitmap::FromHBITMAP, which copies it, and neither the bitmap nor the Gdiplus object was deleted.  That is every NC paint of a horizontally docked bar.
4. GdiTransform in SVGImage.cpp allocated a Gdiplus::Bitmap only to read its pixel format and never deleted it.

The numbers came from GetGuiResources before and after 2000 calls of each pattern.
